### PR TITLE
object/integer: satisfy iterable interface

### DIFF
--- a/docs/content/docs/control_expressions/foreach.md
+++ b/docs/content/docs/control_expressions/foreach.md
@@ -28,7 +28,7 @@ input = a
 Count form zero to a given number (excluding):
 
 ```js
-> foreach i in 5 { puts(i) }
+🚀 > foreach i in 5 { puts(i) }
 0
 1
 2
@@ -40,7 +40,7 @@ Count form zero to a given number (excluding):
 Iterate over a string:
 
 ```js
->foreach i in "test" { puts(i) }
+🚀 > foreach i in "test" { puts(i) }
 "t"
 "e"
 "s"

--- a/docs/content/docs/control_expressions/foreach.md
+++ b/docs/content/docs/control_expressions/foreach.md
@@ -23,3 +23,27 @@ foreach i, number in input {
 // assign temporary array to input array
 input = a
 ```
+
+
+Count form zero to a given number (excluding):
+
+```js
+> foreach i in 5 { puts(i) }
+0
+1
+2
+3
+4
+=> 5
+```
+
+Iterate over a string:
+
+```js
+>foreach i in "test" { puts(i) }
+"t"
+"e"
+"s"
+"t" 
+=> "test"
+```

--- a/object/integer.go
+++ b/object/integer.go
@@ -7,6 +7,7 @@ import (
 
 type Integer struct {
 	Value int64
+	index int64
 }
 
 func NewInteger(i int64) *Integer {
@@ -87,4 +88,17 @@ func (i *Integer) InvokeMethod(method string, env Environment, args ...Object) O
 
 func (i *Integer) ToFloat() Object {
 	return NewFloat(float64(i.Value))
+}
+
+func (i *Integer) Reset() {
+	i.index = 0
+}
+
+func (i *Integer) Next() (Object, Object, bool) {
+	if i.index < i.Value {
+		index := NewInteger(i.index)
+		i.index++
+		return index, index, true
+	}
+	return nil, NewInteger(0), false
 }

--- a/object/integer_test.go
+++ b/object/integer_test.go
@@ -55,3 +55,31 @@ func TestIntegerInspect(t *testing.T) {
 		t.Errorf("integer inspect does not match value")
 	}
 }
+
+func TestIntegerIteratable(t *testing.T) {
+	int1 := object.NewInteger(3)
+
+	for expected := int64(0); expected < 3; expected++ {
+		_, value, ok := int1.Next()
+		actual := value.(*object.Integer)
+
+		if !ok {
+			t.Errorf("integer iteration finished too early")
+		}
+
+		if actual.Value != expected {
+			t.Errorf("integer next %d does not match value %d", actual.Value, expected)
+		}
+	}
+
+	_, _, ok := int1.Next()
+	if ok {
+		t.Errorf("integer iteration didn't finish")
+	}
+
+	int1.Reset()
+	_, _, ok = int1.Next()
+	if !ok {
+		t.Errorf("integer iteration shouldn't finish after reset")
+	}
+}

--- a/object/integer_test.go
+++ b/object/integer_test.go
@@ -68,7 +68,11 @@ func TestIntegerIteratable(t *testing.T) {
 		}
 
 		if actual.Value != expected {
-			t.Errorf("integer next %d does not match value %d", actual.Value, expected)
+			t.Errorf(
+				"integer next %d does not match value %d",
+				actual.Value,
+				expected,
+			)
 		}
 	}
 

--- a/parser/foreach.go
+++ b/parser/foreach.go
@@ -42,6 +42,16 @@ func (p *Parser) parseForEach() ast.Expression {
 		return nil
 	}
 
+	// don't allow negative iterable integer
+	if prefix, ok := expression.Value.(*ast.Prefix); ok && prefix.Operator == "-" {
+		p.errors = append(p.errors, fmt.Sprintf(
+			"%d:%d: expected positive value got %v",
+			p.peekToken.LineNumber,
+			p.peekToken.LinePosition,
+			prefix))
+		return nil
+	}
+
 	p.nextToken()
 	expression.Body = p.parseBlock()
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/flipez/rocket-lang/ast"
@@ -789,5 +790,15 @@ func TestParsingImportExpressions(t *testing.T) {
 		if actual != tt.expected {
 			t.Errorf("expected=%q, got=%q", tt.expected, actual)
 		}
+	}
+}
+
+func TestParsingForEachExpressionsFailsWithNegativeNumber(t *testing.T) {
+	l := lexer.New(`foreach i in -5 { puts(i)}`)
+	p := New(l, nil)
+	p.ParseProgram()
+
+	if !strings.Contains(p.Errors()[0], "expected positive value got (-5)") {
+		t.Errorf("expected error that iterating over a negative number fails")
 	}
 }


### PR DESCRIPTION
Make integer iterable to provide an easy way of iterating from 0 to an arbitrary number.