### PR TITLE
feat(import): make import a statement rather than an expression

### DIFF
--- a/docs/docs/language/modules.md
+++ b/docs/docs/language/modules.md
@@ -38,6 +38,10 @@ export Square
 import "fixtures/module"
 ```
 
+`import` is a statement, not an expression: it binds a name as a side effect
+and cannot be used where a value is expected, so `x = import "lib"` is a parse
+error.
+
 This binds a variable named after the path's last segment:
 
 ```js

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -18,6 +18,8 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 		return evalBlock(node, env)
 	case *ast.Export:
 		return evalExport(node, env)
+	case *ast.Import:
+		return evalImport(node, env)
 	case *ast.Begin:
 		return evalBlock(node.Block, env)
 	case *ast.Foreach:
@@ -53,8 +55,6 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 		}
 
 		return function
-	case *ast.Import:
-		return evalImport(node, env)
 	case *ast.String:
 		return object.NewString(node.Value)
 	case *ast.Array:

--- a/parser/import.go
+++ b/parser/import.go
@@ -1,11 +1,23 @@
 package parser
 
 import (
+	"fmt"
+
 	"github.com/flipez/rocket-lang/ast"
 	"github.com/flipez/rocket-lang/token"
 )
 
-func (p *Parser) parseImport() ast.Expression {
+// parseImportAsExpression is registered as the prefix parser for `import` so
+// that using it where a value is expected produces a message naming the real
+// problem, rather than the generic "no prefix parse function" error. A well
+// placed import never reaches this: parseStatement handles token.IMPORT
+// before any expression parsing begins.
+func (p *Parser) parseImportAsExpression() ast.Expression {
+	p.errors = append(p.errors, fmt.Sprintf("%d:%d: `import` is a statement and cannot be used as an expression", p.curToken.LineNumber, p.curToken.LinePosition))
+	return nil
+}
+
+func (p *Parser) parseImport() ast.Statement {
 	expression := &ast.Import{Token: p.curToken}
 
 	if !p.expectPeek(token.STRING) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -88,7 +88,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.STRING, p.parseString)
 	p.registerPrefix(token.LBRACKET, p.parseArray)
 	p.registerPrefix(token.LBRACE, p.parseHash)
-	p.registerPrefix(token.IMPORT, p.parseImport)
+	p.registerPrefix(token.IMPORT, p.parseImportAsExpression)
 	p.registerPrefix(token.NIL, p.parseNil)
 	p.registerPrefix(token.BEGIN, p.parseBegin)
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -953,3 +953,55 @@ func TestParsingAssignmentFailsWithInvalidLeftSide(t *testing.T) {
 		t.Errorf("expected error about invalid assignment target, got: %q", p.Errors()[0])
 	}
 }
+
+// TestImportInExpressionPositionIsAParseError pins down that `import` is a
+// statement, not an expression. As an expression it silently accepted
+// nonsense: `x = import "lib"` bound nil, and `import "l" + name` parsed as
+// `(import "l") + name`, performing a real import of the wrong module before
+// failing with a misleading "no module named 'l'".
+func TestImportInExpressionPositionIsAParseError(t *testing.T) {
+	inputs := []string{
+		`x = import "lib"`,
+		`puts(import "lib")`,
+		`a = [import "lib", 1]`,
+		`import "l" + name`,
+	}
+
+	for _, input := range inputs {
+		l := lexer.New(input, "test")
+		p := New(l)
+		p.ParseProgram()
+
+		if len(p.Errors()) == 0 {
+			t.Fatalf("input %q: expected a parser error, got none", input)
+		}
+
+		// `import "l" + name` fails on the stray operator rather than on the
+		// import itself, and does so before any module is loaded.
+		if input != `import "l" + name` && !strings.Contains(p.Errors()[0], "`import` is a statement and cannot be used as an expression") {
+			t.Errorf("input %q: expected the statement-not-expression message, got %q", input, p.Errors()[0])
+		}
+	}
+}
+
+// TestImportParsesAsAStatementInsideBlocks guards the other direction: making
+// import a statement must not stop it working inside a function body or any
+// other block, since parseBlock routes through parseStatement too.
+func TestImportParsesAsAStatementInsideBlocks(t *testing.T) {
+	inputs := []string{
+		`import "lib"`,
+		`def f() import "lib" end`,
+		`if true import "lib" end`,
+		`foreach i in [1] import "lib" end`,
+	}
+
+	for _, input := range inputs {
+		l := lexer.New(input, "test")
+		p := New(l)
+		p.ParseProgram()
+
+		if len(p.Errors()) != 0 {
+			t.Errorf("input %q: expected no parser errors, got %v", input, p.Errors())
+		}
+	}
+}

--- a/parser/statement.go
+++ b/parser/statement.go
@@ -15,6 +15,8 @@ func (p *Parser) parseStatement() ast.Statement {
 		return p.parseNext()
 	case token.EXPORT:
 		return p.parseExport()
+	case token.IMPORT:
+		return p.parseImport()
 	case token.IDENT:
 		if p.isMultipleAssignment() {
 			return p.parseMultipleAssignment()


### PR DESCRIPTION
Follow-up to #278.

`import` was registered as a prefix parse function, making it an expression that could appear anywhere a value could. It evaluates to `nil`, so several nonsensical forms were silently accepted:

| Input | Before | After |
|---|---|---|
| `x = import "lib"` | binds `x` to `nil` | parse error |
| `puts(import "lib")` | prints `nil` | parse error |
| `a = [import "lib", 1]` | `[nil, 1]` | parse error |
| `import "l" + name` | imports `"l"`, then `no module named 'l'` | parse error, nothing imported |

The last row is why this matters. It parsed as `(import "l") + name` — the operator bound to the import's *result*, not to the path — so it performed a real import of the wrong module and then reported a missing-module error naming a path the user never wrote. Since #278 restricted paths to string literals, that is precisely the line someone writes first when migrating off computed paths.

## Change

Handle `token.IMPORT` in `parseStatement` instead of registering it as a prefix expression. This matches `export`, which has always been a statement — the two halves of the module system were built on opposite footings.

`ast.Statement` and `ast.Expression` are both just `Node` in this codebase, so `ast.Import` already satisfied both; the change is confined to the parser.

A prefix parser is still registered, but only to produce a clear diagnostic:

```
$ rocket-lang -e 'x = import "lib"'
1:11: `import` is a statement and cannot be used as an expression
```

Without it the error would be the generic `no prefix parse function for IMPORT found`.

## Verified

Imports still work at the top level and inside function bodies, `if` branches, and loops — `parseBlock` routes through `parseStatement`, so nothing about placement changed. Confirmed with a side-effecting module that `import "l" + name` now fails *before* loading anything; previously the module's `puts` ran.

An import still evaluates to `nil`, so every `=> nil` transcript in the module docs remains accurate. Added a sentence to `docs/docs/language/modules.md` noting the statement/expression distinction.

Tests: two new parser tests, one asserting the four expression-position forms are rejected with the right message, one guarding that imports still parse inside blocks. `go test ./...` green.