### PR TITLE
fix(parser): report unterminated blocks instead of swallowing the file

### DIFF
--- a/examples/misc/if.rl
+++ b/examples/misc/if.rl
@@ -8,9 +8,9 @@ end
 a = 2
 if (a == 1)
   puts("true2")
-else if (a == 3)
+elif (a == 3)
   puts("false2")
-else if (a == 2)
+elif (a == 2)
   puts(2)
 end
 

--- a/parser/block.go
+++ b/parser/block.go
@@ -1,6 +1,9 @@
 package parser
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/flipez/rocket-lang/ast"
 	"github.com/flipez/rocket-lang/token"
 )
@@ -23,6 +26,22 @@ func (p *Parser) parseBlock() *ast.Block {
 	}
 
 	p.blockDepth--
+
+	// Every caller of parseBlock expects an explicit terminator. Reaching EOF
+	// means the block was never closed, so report it instead of silently
+	// treating end-of-file as the end of the block -- which used to let an
+	// unterminated block swallow the rest of the source with no diagnostic.
+	if p.curTokenIs(token.EOF) {
+		// Don't pile a second diagnostic onto a position that already failed:
+		// an unterminated block is usually the knock-on effect of the earlier
+		// error, and reporting both just obscures the real cause.
+		position := fmt.Sprintf("%d:%d:", block.Token.LineNumber, block.Token.LinePosition)
+		if len(p.errors) == 0 || !strings.HasPrefix(p.errors[len(p.errors)-1], position) {
+			p.errors = append(p.errors, position+" unexpected end of file, expected `end` to close the block opened here")
+		}
+
+		return block
+	}
 
 	if p.curTokenIs(token.RESCUE) {
 		block.Rescue = &ast.Rescue{Token: p.curToken}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -508,9 +508,9 @@ func TestFunctionParameterParsing(t *testing.T) {
 		input          string
 		expectedParams []string
 	}{
-		{input: "def () {};", expectedParams: []string{}},
-		{input: "def (x) {};", expectedParams: []string{"x"}},
-		{input: "def (x, y, z) {};", expectedParams: []string{"x", "y", "z"}},
+		{input: "def () end", expectedParams: []string{}},
+		{input: "def (x) end", expectedParams: []string{"x"}},
+		{input: "def (x, y, z) end", expectedParams: []string{"x", "y", "z"}},
 	}
 
 	for _, tt := range tests {
@@ -1003,5 +1003,105 @@ func TestImportParsesAsAStatementInsideBlocks(t *testing.T) {
 		if len(p.Errors()) != 0 {
 			t.Errorf("input %q: expected no parser errors, got %v", input, p.Errors())
 		}
+	}
+}
+
+// TestUnterminatedBlockIsAParseError covers a parser bug where parseBlock
+// treated EOF as a valid block terminator. An unterminated block silently
+// swallowed the rest of the file -- including whole function definitions --
+// and produced no diagnostic at all.
+//
+// The `else if` case is the common way to hit this: RocketLang has no
+// two-keyword `else if` construct, only `elif`, so `else if` is an ordinary
+// nested if inside an else branch and needs its own `end`.
+func TestUnterminatedBlockIsAParseError(t *testing.T) {
+	inputs := []string{
+		`def h()
+  return 1
+puts("after")`,
+		`if true
+  puts(1)`,
+		`while false
+  puts(1)`,
+		`foreach i in [1]
+  puts(i)`,
+		// `else if` with a single `end`: the nested if consumes it, leaving
+		// the enclosing else unterminated.
+		`def g(a)
+  if a == 1
+    "one"
+  else if a == 2
+    "two"
+  end
+end`,
+	}
+
+	for _, input := range inputs {
+		l := lexer.New(input, "test")
+		p := New(l)
+		p.ParseProgram()
+
+		if len(p.Errors()) == 0 {
+			t.Errorf("input %q: expected an unterminated-block error, got none", input)
+			continue
+		}
+
+		if !strings.Contains(p.Errors()[0], "unexpected end of file, expected `end`") {
+			t.Errorf("input %q: expected an unterminated-block error, got %q", input, p.Errors()[0])
+		}
+	}
+}
+
+// TestElseWithNestedIfParses is the counterpart: `else` followed by a nested
+// `if` is well formed when each block closes itself, and must keep parsing.
+func TestElseWithNestedIfParses(t *testing.T) {
+	inputs := []string{
+		`if a == 1
+  "one"
+else
+  if a == 2
+    "two"
+  end
+end`,
+		// The same shape written on one line, which is still two blocks and
+		// so still needs two `end`s.
+		`if a == 1
+  "one"
+else if a == 2
+  "two"
+  end
+end`,
+		`if a == 1
+  "one"
+elif a == 2
+  "two"
+end`,
+	}
+
+	for _, input := range inputs {
+		l := lexer.New(input, "test")
+		p := New(l)
+		p.ParseProgram()
+
+		if len(p.Errors()) != 0 {
+			t.Errorf("input %q: expected no parser errors, got %v", input, p.Errors())
+		}
+	}
+}
+
+// TestUnterminatedBlockDoesNotCascade guards the suppression rule: a block
+// left unterminated by an earlier failure at the same position reports only
+// that first error, not a second one blaming the missing `end`.
+func TestUnterminatedBlockDoesNotCascade(t *testing.T) {
+	l := lexer.New(`def Test(`, "test")
+	p := New(l)
+	p.ParseProgram()
+
+	if len(p.Errors()) != 1 {
+		t.Fatalf("expected exactly 1 error, got %d: %v", len(p.Errors()), p.Errors())
+	}
+
+	if !strings.Contains(p.Errors()[0], "expected next token to be )") {
+		t.Errorf("expected the original paren error, got %q", p.Errors()[0])
 	}
 }


### PR DESCRIPTION
Closes #273.

## The actual bug

#273 was filed as "`else if` chain silently swallows following statements", but that framing was wrong, and the maintainer's reading is the correct one: there is no two-keyword `else if` construct in RocketLang. There is `elif`. So `else if` is an ordinary nested `if` inside an `else` branch, and it needs its own `end`.

Written with a single `end`, the nested `if` consumes it and the enclosing `else` is left unterminated. That is malformed input — a missing `end` — not an unsupported feature.

The real defect is that a missing `end` was never diagnosed. `parseBlock` listed `EOF` among its terminators, so an unclosed block simply ended at end-of-file and absorbed everything after it. It has nothing to do with `else`:

```js
def h()
  return 1
puts("after")
```

No error. `puts("after")` is swallowed into `h`'s body and never runs.

## Change

Report the unterminated block, naming where it opened:

```
1:7: unexpected end of file, expected `end` to close the block opened here
```

Suppressed when an error was already recorded at that same position, so a malformed header does not yield two diagnostics for one mistake — `def Test(` still reports only `expected next token to be )`.

The well-formed shapes are unaffected. `else` + nested `if` with two `end`s parses, on one line or several, as does `elif`.

## Fallout, both genuine

**`examples/misc/if.rl`** used the one-`end` form and is now a parse error. Rewritten with `elif`. Its output is byte-identical before and after — the swallowed statements happened to land in a branch that executed, which is precisely why nobody noticed.

**`TestFunctionParameterParsing`** used legacy brace syntax (`def () {};`), which parses `{}` as a *hash literal* body and then runs to EOF with no `end`. Updated to `def () end`. No assertion was weakened.

## Verified

Every tracked `.rl` file in the repo still parses, except `fixtures/parser_error.rl`, which is deliberately malformed. Mutation-checked the new tests by reverting the fix: 5 of the 6 unterminated cases pass silently without it.

Tests added for unterminated `def`/`if`/`while`/`foreach` and the one-`end` else-if; for the well-formed nested and `elif` shapes; and for the no-cascade rule.