### PR TITLE
docs(module): document where an import may appear

### DIFF
--- a/docs/docs/language/modules.md
+++ b/docs/docs/language/modules.md
@@ -124,6 +124,39 @@ math.Sum(1, 2)          // 3
 math.Mean([1, 2])       // reaches Stats through the wrapper function
 ```
 
+### Where an import may appear
+
+An import is a statement, so it can go anywhere a statement can: at the top
+level, inside a function body, or inside a branch. Importing conditionally is
+the supported way to pick between implementations:
+
+```js
+if env == "prod"
+  import "./config_prod" as config
+else
+  import "./config_stage" as config
+end
+
+puts(config.Url)
+```
+
+Only one branch runs, so only one binding is made, and it is visible after the
+`if` ends.
+
+An import inside a **loop body** does not work. Loops reuse one scope across
+iterations, so the second iteration finds the name already bound:
+
+```js
+foreach name in ["a", "b"]
+  import "./plugin" as p     // Import Error on the second iteration:
+end                          // cannot bind module as 'p', name already in use
+```
+
+This is not a useful thing to write in any case. A path must be a string
+literal, so every iteration would import the same module, and a module is
+evaluated only once no matter how many times it is imported. Import what you
+need once, outside the loop.
+
 ## Finding modules
 
 A path starting with `./` or `../` resolves relative to the file doing the


### PR DESCRIPTION
Adds a `### Where an import may appear` section to the module docs, covering the conditional-import pattern and the loop limitation.

Context: #274.

## Conditional import works and was undocumented

Picking between implementations by branch is the realistic use case, and it works today — only one branch runs, so only one binding is made, and it is visible after the `if`:

```js
if env == "prod"
  import "./config_prod" as config
else
  import "./config_stage" as config
end

puts(config.Url)
```

Also verified: `elif` chains, and an import inside a function body called more than once (each call gets a fresh frame).

## Loops are not supported, and need not be

An import in a loop body fails on the second iteration, because loops reuse one scope across iterations:

```
Import Error: cannot bind module as 'p', name already in use
```

Rather than fix that, the docs now say plainly that it is not something worth writing. Since #278 restricted paths to string literals, a varying path in a loop is a *parse* error:

```
foreach n in [...]
  import n as c
  → expected next token to be STRING, got IDENT instead
```

So the only loop import that parses is the same literal module repeatedly — which the module cache collapses to a single evaluation anyway. #274 was filed when dynamic paths still existed and plugin-loading was plausible; that premise is gone.

Both documented examples were run against a build and reproduce exactly, including the error text.