### PR TITLE
fix(string): correct base inference in to_i()

### DIFF
--- a/docs/docs/literals/array.md
+++ b/docs/docs/literals/array.md
@@ -223,23 +223,27 @@ nil.to_f()
 ### to_i()
 > Returns `INTEGER`
 
-If possible converts an object to its integer representation. If not 0 is returned.
+Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
 
 
 <CodeBlockSimple input='true.to_i()
 false.to_i()
 1234.to_i()
 "4".to_i()
-"10011010010"to_i(2)
-"2322".to_i(8)
+"0".to_i()
+"0125".to_i()
 "0x2322".to_i()
+"0b1010".to_i()
+"test".to_i()
 ' output='1
 0
 1234
 4
-1234
-1234
-1234
+0
+0o125
+0x2322
+0b1010
+0
 ' />
 
 

--- a/docs/docs/literals/boolean.md
+++ b/docs/docs/literals/boolean.md
@@ -53,23 +53,27 @@ nil.to_f()
 ### to_i()
 > Returns `INTEGER`
 
-If possible converts an object to its integer representation. If not 0 is returned.
+Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
 
 
 <CodeBlockSimple input='true.to_i()
 false.to_i()
 1234.to_i()
 "4".to_i()
-"10011010010"to_i(2)
-"2322".to_i(8)
+"0".to_i()
+"0125".to_i()
 "0x2322".to_i()
+"0b1010".to_i()
+"test".to_i()
 ' output='1
 0
 1234
 4
-1234
-1234
-1234
+0
+0o125
+0x2322
+0b1010
+0
 ' />
 
 

--- a/docs/docs/literals/error.md
+++ b/docs/docs/literals/error.md
@@ -88,23 +88,27 @@ nil.to_f()
 ### to_i()
 > Returns `INTEGER`
 
-If possible converts an object to its integer representation. If not 0 is returned.
+Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
 
 
 <CodeBlockSimple input='true.to_i()
 false.to_i()
 1234.to_i()
 "4".to_i()
-"10011010010"to_i(2)
-"2322".to_i(8)
+"0".to_i()
+"0125".to_i()
 "0x2322".to_i()
+"0b1010".to_i()
+"test".to_i()
 ' output='1
 0
 1234
 4
-1234
-1234
-1234
+0
+0o125
+0x2322
+0b1010
+0
 ' />
 
 

--- a/docs/docs/literals/file.md
+++ b/docs/docs/literals/file.md
@@ -107,23 +107,27 @@ nil.to_f()
 ### to_i()
 > Returns `INTEGER`
 
-If possible converts an object to its integer representation. If not 0 is returned.
+Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
 
 
 <CodeBlockSimple input='true.to_i()
 false.to_i()
 1234.to_i()
 "4".to_i()
-"10011010010"to_i(2)
-"2322".to_i(8)
+"0".to_i()
+"0125".to_i()
 "0x2322".to_i()
+"0b1010".to_i()
+"test".to_i()
 ' output='1
 0
 1234
 4
-1234
-1234
-1234
+0
+0o125
+0x2322
+0b1010
+0
 ' />
 
 

--- a/docs/docs/literals/float.md
+++ b/docs/docs/literals/float.md
@@ -39,23 +39,27 @@ nil.to_f()
 ### to_i()
 > Returns `INTEGER`
 
-If possible converts an object to its integer representation. If not 0 is returned.
+Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
 
 
 <CodeBlockSimple input='true.to_i()
 false.to_i()
 1234.to_i()
 "4".to_i()
-"10011010010"to_i(2)
-"2322".to_i(8)
+"0".to_i()
+"0125".to_i()
 "0x2322".to_i()
+"0b1010".to_i()
+"test".to_i()
 ' output='1
 0
 1234
 4
-1234
-1234
-1234
+0
+0o125
+0x2322
+0b1010
+0
 ' />
 
 

--- a/docs/docs/literals/hash.md
+++ b/docs/docs/literals/hash.md
@@ -111,23 +111,27 @@ nil.to_f()
 ### to_i()
 > Returns `INTEGER`
 
-If possible converts an object to its integer representation. If not 0 is returned.
+Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
 
 
 <CodeBlockSimple input='true.to_i()
 false.to_i()
 1234.to_i()
 "4".to_i()
-"10011010010"to_i(2)
-"2322".to_i(8)
+"0".to_i()
+"0125".to_i()
 "0x2322".to_i()
+"0b1010".to_i()
+"test".to_i()
 ' output='1
 0
 1234
 4
-1234
-1234
-1234
+0
+0o125
+0x2322
+0b1010
+0
 ' />
 
 

--- a/docs/docs/literals/http.md
+++ b/docs/docs/literals/http.md
@@ -84,26 +84,30 @@ nil.to_f()
 ' />
 
 
-### to_i(INTEGER)
+### to_i()
 > Returns `INTEGER`
 
-If possible converts an object to its integer representation. If not 0 is returned.
+Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
 
 
 <CodeBlockSimple input='true.to_i()
 false.to_i()
 1234.to_i()
 "4".to_i()
-"10011010010"to_i(2)
-"2322".to_i(8)
+"0".to_i()
+"0125".to_i()
 "0x2322".to_i()
+"0b1010".to_i()
+"test".to_i()
 ' output='1
 0
 1234
 4
-1234
-1234
-1234
+0
+0o125
+0x2322
+0b1010
+0
 ' />
 
 
@@ -120,7 +124,7 @@ a.to_json()
 ' />
 
 
-### to_s(INTEGER)
+### to_s()
 > Returns `STRING`
 
 If possible converts an object to its string representation. If not empty string is returned.

--- a/docs/docs/literals/integer.md
+++ b/docs/docs/literals/integer.md
@@ -26,7 +26,7 @@ is_false = 1 == 2;
 Returns the base of the integer.
 
 
-<CodeBlockSimple input='0b1010".to_i().base()
+<CodeBlockSimple input='"0b1010".to_i().base()
 ' output='2' />
 
 
@@ -73,23 +73,27 @@ nil.to_f()
 ### to_i()
 > Returns `INTEGER`
 
-If possible converts an object to its integer representation. If not 0 is returned.
+Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
 
 
 <CodeBlockSimple input='true.to_i()
 false.to_i()
 1234.to_i()
 "4".to_i()
-"10011010010"to_i(2)
-"2322".to_i(8)
+"0".to_i()
+"0125".to_i()
 "0x2322".to_i()
+"0b1010".to_i()
+"test".to_i()
 ' output='1
 0
 1234
 4
-1234
-1234
-1234
+0
+0o125
+0x2322
+0b1010
+0
 ' />
 
 

--- a/docs/docs/literals/matrix.md
+++ b/docs/docs/literals/matrix.md
@@ -222,23 +222,27 @@ nil.to_f()
 ### to_i()
 > Returns `INTEGER`
 
-If possible converts an object to its integer representation. If not 0 is returned.
+Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
 
 
 <CodeBlockSimple input='true.to_i()
 false.to_i()
 1234.to_i()
 "4".to_i()
-"10011010010"to_i(2)
-"2322".to_i(8)
+"0".to_i()
+"0125".to_i()
 "0x2322".to_i()
+"0b1010".to_i()
+"test".to_i()
 ' output='1
 0
 1234
 4
-1234
-1234
-1234
+0
+0o125
+0x2322
+0b1010
+0
 ' />
 
 

--- a/docs/docs/literals/nil.md
+++ b/docs/docs/literals/nil.md
@@ -41,23 +41,27 @@ nil.to_f()
 ### to_i()
 > Returns `INTEGER`
 
-If possible converts an object to its integer representation. If not 0 is returned.
+Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
 
 
 <CodeBlockSimple input='true.to_i()
 false.to_i()
 1234.to_i()
 "4".to_i()
-"10011010010"to_i(2)
-"2322".to_i(8)
+"0".to_i()
+"0125".to_i()
 "0x2322".to_i()
+"0b1010".to_i()
+"test".to_i()
 ' output='1
 0
 1234
 4
-1234
-1234
-1234
+0
+0o125
+0x2322
+0b1010
+0
 ' />
 
 

--- a/docs/docs/literals/string.md
+++ b/docs/docs/literals/string.md
@@ -226,23 +226,27 @@ nil.to_f()
 ### to_i()
 > Returns `INTEGER`
 
-If possible converts an object to its integer representation. If not 0 is returned.
+Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
 
 
 <CodeBlockSimple input='true.to_i()
 false.to_i()
 1234.to_i()
 "4".to_i()
-"10011010010"to_i(2)
-"2322".to_i(8)
+"0".to_i()
+"0125".to_i()
 "0x2322".to_i()
+"0b1010".to_i()
+"test".to_i()
 ' output='1
 0
 1234
 4
-1234
-1234
-1234
+0
+0o125
+0x2322
+0b1010
+0
 ' />
 
 

--- a/docs/literals/http.yml
+++ b/docs/literals/http.yml
@@ -26,6 +26,6 @@ methods:
 
       - "status" needs to be an INTEGER (eg. 200, 400, 500). Default is 200.
       - "body" needs to be a STRING. Default ""
-      - "headers" needs to be a HASH(STRING:STRING) eg. headers["Content-Type"] = "text/plain". Default is {"Content-Type": "text/plain"}
+      - "headers" needs to be a HASH(STRING:STRING) eg. headers["Content-Type"] = "text/plain". Default is \{"Content-Type": "text/plain"\}
     input: |
       HTTP.handle("/", callback_func)

--- a/docs/literals/integer.yml
+++ b/docs/literals/integer.yml
@@ -14,7 +14,7 @@ methods:
   base:
     description: "Returns the base of the integer."
     input: |
-      0b1010".to_i().base()
+      "0b1010".to_i().base()
     output:
       2
   to_base:
@@ -24,7 +24,7 @@ methods:
     output: |
       0o12
   to_s:
-    description: "Returns a string representation of the integer. Also takes an argument which represents the integer base to convert between different number systems"
+    description: "Returns a string representation of the integer, rendered in the integer's own base."
     input: |
       1234.to_s()
     output: |

--- a/docs/literals/object.yml
+++ b/docs/literals/object.yml
@@ -18,23 +18,27 @@ methods:
       "test"
       "1.4"
   to_i:
-    description: "If possible converts an object to its integer representation. If not 0 is returned."
+    description: "Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly."
     input: |
       true.to_i()
       false.to_i()
       1234.to_i()
       "4".to_i()
-      "10011010010"to_i(2)
-      "2322".to_i(8)
+      "0".to_i()
+      "0125".to_i()
       "0x2322".to_i()
+      "0b1010".to_i()
+      "test".to_i()
     output: |
       1
       0
       1234
       4
-      1234
-      1234
-      1234
+      0
+      0o125
+      0x2322
+      0b1010
+      0
   to_f:
     description: "If possible converts an object to its float representation. If not 0.0 is returned."
     input: |

--- a/docs/literals/string.yml
+++ b/docs/literals/string.yml
@@ -73,19 +73,6 @@ methods:
     example: |
       🚀 » "test".size()
       » 4
-  to_i:
-    description: "Interprets the string as an integer with an optional given base. The default base is `10` and switched to `8` if the string starts with `0x`."
-    example: |
-      🚀 » "1234".to_i()
-      » 1234
-      🚀 » "1234".to_i(8)
-      » 668
-      🚀 » "0x1234".to_i(8)
-      » 668
-      🚀 » "0x1234".to_i()
-      » 668
-      🚀 » "0x1234".to_i(10)
-      » 0
   replace:
     description: "Replaces the first string with the second string in the given string."
     example: |

--- a/object/string.go
+++ b/object/string.go
@@ -323,23 +323,54 @@ func (s *String) ToStringObj() *String {
 
 func (s *String) ToIntegerObj() *Integer {
 	base := 10
+	digits := s.Value
+
+	sign := ""
+	if strings.HasPrefix(digits, "-") || strings.HasPrefix(digits, "+") {
+		sign, digits = digits[:1], digits[1:]
+	}
+
+	lower := strings.ToLower(digits)
 
 	switch {
-	case strings.HasPrefix(s.Value, "0b"):
-		base = 2
-	case strings.HasPrefix(s.Value, "0x"):
-		base = 16
-	case strings.HasPrefix(s.Value, "0"), strings.HasPrefix(s.Value, "0o"):
-		base = 8
+	case strings.HasPrefix(lower, "0b"):
+		base, digits = 2, digits[2:]
+	case strings.HasPrefix(lower, "0o"):
+		base, digits = 8, digits[2:]
+	case strings.HasPrefix(lower, "0x"):
+		base, digits = 16, digits[2:]
+	case isLegacyOctal(digits):
+		base, digits = 8, digits[1:]
 	}
 
-	i, err := strconv.ParseInt(s.Value, 0, 0)
+	i, err := strconv.ParseInt(sign+digits, base, 64)
 
 	if err != nil {
-		fmt.Println(err)
+		// Returning 0 on a failed conversion is the long-standing behaviour,
+		// tracked separately in #232. Do not print the Go error: it lands on
+		// stdout and corrupts the program's own output.
 		return NewInteger(0)
 	}
+
 	return NewIntegerWithBase(int(i), base)
+}
+
+// isLegacyOctal reports whether digits is a leading-zero octal literal such
+// as "0125". A bare "0" is decimal zero rather than an octal prefix with
+// nothing following it, and a leading zero followed by a non-octal digit
+// ("08") is a zero-padded decimal.
+func isLegacyOctal(digits string) bool {
+	if len(digits) < 2 || digits[0] != '0' {
+		return false
+	}
+
+	for _, c := range digits[1:] {
+		if c < '0' || c > '7' {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (s *String) ToFloatObj() *Float {

--- a/object/string_test.go
+++ b/object/string_test.go
@@ -42,6 +42,27 @@ func TestStringObjectMethods(t *testing.T) {
 		{`"1010".to_i()`, 1010},
 		{`"-1010".to_i()`, -1010},
 		{`"0x1022".to_i()`, 4130},
+		// A bare "0" is decimal zero, not a leading-zero octal prefix with
+		// nothing after it. Getting this wrong gave it base 8, so adding it to
+		// any ordinary integer failed with "unequal base".
+		{`"0".to_i()`, 0},
+		{`"0".to_i().base()`, 10},
+		{`"0".to_i() + 1`, 1},
+		{`"-0".to_i() + 1`, 1},
+		// A leading zero followed by a non-octal digit is a zero-padded
+		// decimal, not a malformed octal literal.
+		{`"08".to_i()`, 8},
+		{`"09".to_i().base()`, 10},
+		// Base prefixes are case insensitive; uppercase ones used to fall
+		// through to the legacy-octal branch and be tagged base 8.
+		{`"0X1022".to_i()`, 4130},
+		{`"0X1022".to_i().base()`, 16},
+		{`"0B101".to_i()`, 5},
+		{`"0B101".to_i().base()`, 2},
+		{`"0o17".to_i()`, 15},
+		{`"0O17".to_i().base()`, 8},
+		// Legacy leading-zero octal keeps working.
+		{`"0125".to_i().base()`, 8},
 		{`"1022".to_f()`, 1022.0},
 		{`"1022".to_s()`, "1022"},
 		{`"test".replace("e", "s")`, "tsst"},


### PR DESCRIPTION
Closes #277.

#277 was filed as "`day3.rl` fails with an integer base error". It is not a script problem — `day3.rl` just happens to trigger a real bug in `to_i()`.

## Bare `"0"` was inferred as octal

`String.ToIntegerObj` selected the base with a prefix switch whose last arm was `strings.HasPrefix(s.Value, "0")`. That matches the bare string `"0"`, so:

```js
"0".to_i().base()   // 8, should be 10
"0".to_i() + 1      // ERROR: infix operation with unequal base not allowed
```

`evalIntegerInfix` rejects operands of differing bases, so a parsed `0` could not be added to anything. `examples/aoc/2018/day3.txt` has six claims with a zero coordinate — the first is `#286 @ 0,295: 26x14` — which is exactly how the failure surfaced.

## Two more faults in the same switch

**Uppercase prefixes fell through to legacy octal.** The value came out right, because `ParseInt` with base 0 detects the prefix itself, but the recorded base did not:

```js
"0X1022".to_i()   // displayed as 0o10042 -- correct value, base 8
```

**A leading zero followed by a non-octal digit** was treated as malformed octal, printing a Go error onto **stdout** and returning 0:

```js
"08".to_i()
// prints: strconv.ParseInt: parsing "08": invalid syntax
// returns: 0
```

## Change

Infer the base explicitly and strip the prefix before parsing, instead of relying on `ParseInt`'s base-0 auto-detection:

- `0b` / `0o` / `0x` select the base, case insensitively
- a leading zero followed by one or more octal digits is legacy octal
- everything else, including bare `"0"` and zero-padded decimals, is base 10

Legacy octal is deliberately preserved — `"0125"` is still 85, which an existing test asserts.

Dropping the `fmt.Println` also stops a Go error string leaking into program output. Returning 0 on a genuine failure such as `"abc".to_i()` is unchanged, and remains tracked by #232.

## Verified

`examples/aoc/2018/day3.rl` now runs to completion, printing `105047` and `658`.

Mutation-checked the new tests by reverting the fix: 4 fail without it. Full suite green.