### PR TITLE
fix(utilities): ROCKETLANGPATH adds search paths instead of replacing cwd

### DIFF
--- a/docs/docs/language/modules.md
+++ b/docs/docs/language/modules.md
@@ -167,9 +167,14 @@ importing, so a module can import its neighbours:
 import "../util" as util
 ```
 
-Any other path is looked up in the search paths, which come from the
-`ROCKETLANGPATH` environment variable, or the current working directory when
-that variable is not set.
+Any other path is looked up in the search paths: each entry of the
+`ROCKETLANGPATH` environment variable in order, followed by the working
+directory. Entries are separated by the platform's path list separator, `:` on
+Unix and `;` on Windows.
+
+The working directory is always searched, so setting `ROCKETLANGPATH` adds
+places to look rather than replacing the default. Configured entries are tried
+first, so they win when the same module name exists in both.
 
 The path must be a string literal; it cannot be a variable or a computed
 expression.

--- a/utilities/utilities.go
+++ b/utilities/utilities.go
@@ -11,6 +11,29 @@ import (
 var SearchPaths []string
 var once sync.Once
 
+// searchPathList builds the raw module search path from the ROCKETLANGPATH
+// value and the working directory. Entries are split on the platform's path
+// list separator, empty entries are dropped, and the working directory is
+// appended rather than substituted: setting ROCKETLANGPATH should add
+// somewhere to look, not silently stop imports resolving against the
+// directory the program was started in. Explicit entries come first, so
+// configuration still wins over the working directory.
+func searchPathList(env, cwd string) []string {
+	var paths []string
+
+	for _, entry := range filepath.SplitList(env) {
+		if entry != "" {
+			paths = append(paths, entry)
+		}
+	}
+
+	if cwd != "" {
+		paths = append(paths, cwd)
+	}
+
+	return paths
+}
+
 func AddPath(path string) error {
 	path = os.ExpandEnv(filepath.Clean(path))
 	absolutePath, err := filepath.Abs(path)

--- a/utilities/utilities_nowasm.go
+++ b/utilities/utilities_nowasm.go
@@ -5,7 +5,6 @@ package utilities
 import (
 	"log"
 	"os"
-	"strings"
 )
 
 func initSearchPaths() {
@@ -15,15 +14,10 @@ func initSearchPaths() {
 		log.Printf("error getting cwd: %s", err)
 	}
 
-	if e := os.Getenv("ROCKETLANGPATH"); e != "" {
-		tokens := strings.Split(e, ":")
-
-		for _, token := range tokens {
-			if err := AddPath(token); err != nil {
-				log.Fatalf("error adding token: %s", err)
-			}
+	for _, path := range searchPathList(os.Getenv("ROCKETLANGPATH"), cwd) {
+		if err := AddPath(path); err != nil {
+			// A bad entry costs us one search path, not the whole process.
+			log.Printf("error adding search path %q: %s", path, err)
 		}
-	} else {
-		SearchPaths = append(SearchPaths, cwd)
 	}
 }

--- a/utilities/utilities_test.go
+++ b/utilities/utilities_test.go
@@ -153,3 +153,75 @@ func TestFindModule_CanonicalizesSymlinks(t *testing.T) {
 		t.Fatalf("resolutions via symlinked and real routes differ: viaSymlink=%q viaReal=%q, want identical strings", viaSymlink, viaReal)
 	}
 }
+
+// TestSearchPathList covers the three defects the old initSearchPaths had:
+// it substituted the working directory instead of adding to it, it split on a
+// hardcoded ":", and it treated a bad entry as fatal.
+func TestSearchPathList(t *testing.T) {
+	sep := string(os.PathListSeparator)
+	cwd := "/work"
+
+	tests := []struct {
+		name     string
+		env      string
+		cwd      string
+		expected []string
+	}{
+		{
+			name:     "unset falls back to the working directory",
+			env:      "",
+			cwd:      cwd,
+			expected: []string{cwd},
+		},
+		{
+			// The old behaviour dropped cwd entirely here, so setting the
+			// variable silently broke every working-directory-relative import.
+			name:     "entries come first and the working directory is kept",
+			env:      "/opt/rl",
+			cwd:      cwd,
+			expected: []string{"/opt/rl", cwd},
+		},
+		{
+			name:     "multiple entries keep their order",
+			env:      "/a" + sep + "/b",
+			cwd:      cwd,
+			expected: []string{"/a", "/b", cwd},
+		},
+		{
+			// Split on a hardcoded ":" turned an empty leading entry into "",
+			// which AddPath then resolved to the working directory.
+			name:     "empty entries are dropped",
+			env:      sep + "/a" + sep + sep + "/b" + sep,
+			cwd:      cwd,
+			expected: []string{"/a", "/b", cwd},
+		},
+		{
+			name:     "no working directory yields only the configured entries",
+			env:      "/a",
+			cwd:      "",
+			expected: []string{"/a"},
+		},
+		{
+			name:     "nothing configured and no working directory yields nothing",
+			env:      "",
+			cwd:      "",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		got := searchPathList(tt.env, tt.cwd)
+
+		if len(got) != len(tt.expected) {
+			t.Errorf("%s: expected %v, got %v", tt.name, tt.expected, got)
+			continue
+		}
+
+		for i := range got {
+			if got[i] != tt.expected[i] {
+				t.Errorf("%s: expected %v, got %v", tt.name, tt.expected, got)
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #276.

`initSearchPaths` had three defects, all reachable by simply setting the variable.

## 1. It replaced the working directory rather than adding to it

The `else` meant that the moment `ROCKETLANGPATH` was set, every import resolving against the working directory stopped working:

```
$ rocket-lang usecwd.rl                              # import "local" -> works
$ ROCKETLANGPATH=/tmp/rlp/lib rocket-lang usecwd.rl  # same file
ERROR: Import Error: no module named 'local' found
```

Confirmed against a pre-fix binary; the post-fix binary resolves both the configured entry and the working directory.

## 2. It split on a hardcoded `:`

Wrong on Windows, where the separator is `;`. Now uses `filepath.SplitList`.

Empty entries were also a trap: `strings.Split` yields `""` for a leading, trailing or doubled separator, and `AddPath` runs that through `filepath.Clean("")` → `"."` → the working directory. So `ROCKETLANGPATH=":/opt"` quietly searched cwd as if it were configured. Empty entries are now dropped.

## 3. It called `log.Fatalf` on a bad entry

One unusable search path killed the interpreter. Now a warning; you lose that entry, not the process.

## Search order

Configured entries in order, then the working directory. Explicit configuration wins when the same module name exists in both, and the working directory is always searched.

## Testability

`initSearchPaths` runs under a `sync.Once` and cannot be re-entered, so the list building moved into a pure `searchPathList(env, cwd)`. That is what the new tests exercise — separator handling, empty entries, ordering, and the empty-cwd edge.

Mutation-checked: restoring the old replace semantics fails 3 of the new cases.

## Verified end to end

Single entry, two entries, and a value padded with leading, doubled and trailing separators all resolve correctly, with cwd imports still working in every case. Docs updated to describe the order and the separator; `yarn build` succeeds.