### PR TITLE
fix(import): anchor relative imports on cwd when there is no source file

### DIFF
--- a/docs/docs/language/modules.md
+++ b/docs/docs/language/modules.md
@@ -167,6 +167,10 @@ importing, so a module can import its neighbours:
 import "../util" as util
 ```
 
+In the REPL and under `rocket-lang -e` there is no importing file, so a
+relative path resolves against the working directory instead — the same place
+a bare module name is found.
+
 Any other path is looked up in the search paths: each entry of the
 `ROCKETLANGPATH` environment variable in order, followed by the working
 directory. Entries are separated by the platform's path list separator, `:` on

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -1175,3 +1175,24 @@ module.Sum(2, 3)
 
 	testIntegerObject(t, evaluated, 5)
 }
+
+// testEvalWithoutFile evaluates input with no source filename, which is what
+// the REPL and `rocket-lang -e` both do.
+func testEvalWithoutFile(input string) object.Object {
+	l := lexer.New(input, "")
+	p := parser.New(l)
+	program := p.ParseProgram()
+	env := object.NewEnvironment()
+
+	return Eval(program, env)
+}
+
+// TestRelativeImportWithoutSourceFile covers the REPL and `-e`, where there is
+// no importing file to resolve `./` and `../` against. Those anchor on the
+// working directory instead, so that the explicit spelling of an import
+// resolves wherever the bare name already does.
+func TestRelativeImportWithoutSourceFile(t *testing.T) {
+	evaluated := testEvalWithoutFile(`import "../fixtures/module"; module.A`)
+
+	testIntegerObject(t, evaluated, 5)
+}

--- a/evaluator/import.go
+++ b/evaluator/import.go
@@ -1,6 +1,7 @@
 package evaluator
 
 import (
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -14,9 +15,15 @@ import (
 func evalImport(ie *ast.Import, env *object.Environment) object.Object {
 	reg := env.Registry()
 
+	// A `./` or `../` path resolves against the directory of the file doing
+	// the importing. The REPL and `rocket-lang -e` have no such file, so they
+	// anchor on the working directory: that is where their source effectively
+	// lives, and it is already where a bare module name resolves from.
 	importerDir := ""
 	if ie.Token.File != "" {
 		importerDir = filepath.Dir(ie.Token.File)
+	} else if wd, err := os.Getwd(); err == nil {
+		importerDir = wd
 	}
 
 	filename := utilities.FindModuleFrom(ie.Path, importerDir)


### PR DESCRIPTION
Closes #275.

The REPL and `rocket-lang -e` both lex with an empty filename, so `./` and `../` paths had nothing to resolve against and always failed. The outcome was backwards — the *vaguer* spelling worked and the *explicit* one did not:

```
🚀 » import "local"     => nil          # resolves, cwd is a search path
🚀 » import "./local"   => ERROR: no module named './local' found
```

Same under `-e`. Since the docs teach `./` as the way to import a neighbour, it silently failed in both interactive entry points.

## Change

When `Token.File` is empty, use the working directory as the importing directory.

That is unambiguous: there are only three `lexer.New` call sites — `main.go` (the script path, or empty for `-e`), `evaluator/module.go` (always a resolved filename), and `repl/repl.go` (empty). An empty filename means exactly one thing, so there is no case where guessing the working directory is wrong.

The fallback lives in `evalImport`, not `FindModuleFrom`. The resolver keeps its contract — *resolve against this directory, and fail without one* — so the existing test that deliberately proves the guard short-circuits stays valid and meaningful. The caller is what knows the context.

## Verified

```
🚀 » import "./local"        => nil, and local.Here reads back "cwd"
$ rocket-lang -e 'import "./local"'      => ok
$ cd lib && rocket-lang -e 'import "../local"'  => ok
$ rocket-lang -e 'import "./nope"'       => still errors
```

File-based scripts are unchanged. Running `/tmp/rlp/lib/usesibling.rl` from `/tmp`, where no `shared.rl` exists, still resolves its `./shared` against the script's own directory — proving the script anchor was not replaced by the working directory.

Docs note the REPL/`-e` behaviour; `yarn build` succeeds.