### PR TITLE
feat(object): to_i and to_f return nil on a failed conversion

### DIFF
--- a/docs/docs/literals/array.md
+++ b/docs/docs/literals/array.md
@@ -206,24 +206,26 @@ Returns an array of all supported methods names.
 
 
 ### to_f()
-> Returns `FLOAT`
+> Returns `FLOAT|NIL`
 
-If possible converts an object to its float representation. If not 0.0 is returned.
+Converts an object to its float representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0.0`.
 
 
 <CodeBlockSimple input='1.to_f()
 "1.4".to_f()
+"abc".to_f()
 nil.to_f()
 ' output='1.0
 1.4
-0.0
+nil
+nil
 ' />
 
 
 ### to_i()
-> Returns `INTEGER`
+> Returns `INTEGER|NIL`
 
-Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
+Converts an object to its integer representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0`. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
 
 
 <CodeBlockSimple input='true.to_i()
@@ -243,7 +245,7 @@ false.to_i()
 0o125
 0x2322
 0b1010
-0
+nil
 ' />
 
 

--- a/docs/docs/literals/boolean.md
+++ b/docs/docs/literals/boolean.md
@@ -36,24 +36,26 @@ Returns an array of all supported methods names.
 
 
 ### to_f()
-> Returns `FLOAT`
+> Returns `FLOAT|NIL`
 
-If possible converts an object to its float representation. If not 0.0 is returned.
+Converts an object to its float representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0.0`.
 
 
 <CodeBlockSimple input='1.to_f()
 "1.4".to_f()
+"abc".to_f()
 nil.to_f()
 ' output='1.0
 1.4
-0.0
+nil
+nil
 ' />
 
 
 ### to_i()
-> Returns `INTEGER`
+> Returns `INTEGER|NIL`
 
-Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
+Converts an object to its integer representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0`. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
 
 
 <CodeBlockSimple input='true.to_i()
@@ -73,7 +75,7 @@ false.to_i()
 0o125
 0x2322
 0b1010
-0
+nil
 ' />
 
 

--- a/docs/docs/literals/error.md
+++ b/docs/docs/literals/error.md
@@ -71,24 +71,26 @@ Returns an array of all supported methods names.
 
 
 ### to_f()
-> Returns `FLOAT`
+> Returns `FLOAT|NIL`
 
-If possible converts an object to its float representation. If not 0.0 is returned.
+Converts an object to its float representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0.0`.
 
 
 <CodeBlockSimple input='1.to_f()
 "1.4".to_f()
+"abc".to_f()
 nil.to_f()
 ' output='1.0
 1.4
-0.0
+nil
+nil
 ' />
 
 
 ### to_i()
-> Returns `INTEGER`
+> Returns `INTEGER|NIL`
 
-Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
+Converts an object to its integer representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0`. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
 
 
 <CodeBlockSimple input='true.to_i()
@@ -108,7 +110,7 @@ false.to_i()
 0o125
 0x2322
 0b1010
-0
+nil
 ' />
 
 

--- a/docs/docs/literals/file.md
+++ b/docs/docs/literals/file.md
@@ -90,24 +90,26 @@ Returns an array of all supported methods names.
 
 
 ### to_f()
-> Returns `FLOAT`
+> Returns `FLOAT|NIL`
 
-If possible converts an object to its float representation. If not 0.0 is returned.
+Converts an object to its float representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0.0`.
 
 
 <CodeBlockSimple input='1.to_f()
 "1.4".to_f()
+"abc".to_f()
 nil.to_f()
 ' output='1.0
 1.4
-0.0
+nil
+nil
 ' />
 
 
 ### to_i()
-> Returns `INTEGER`
+> Returns `INTEGER|NIL`
 
-Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
+Converts an object to its integer representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0`. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
 
 
 <CodeBlockSimple input='true.to_i()
@@ -127,7 +129,7 @@ false.to_i()
 0o125
 0x2322
 0b1010
-0
+nil
 ' />
 
 

--- a/docs/docs/literals/float.md
+++ b/docs/docs/literals/float.md
@@ -22,24 +22,26 @@ Returns an array of all supported methods names.
 
 
 ### to_f()
-> Returns `FLOAT`
+> Returns `FLOAT|NIL`
 
-If possible converts an object to its float representation. If not 0.0 is returned.
+Converts an object to its float representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0.0`.
 
 
 <CodeBlockSimple input='1.to_f()
 "1.4".to_f()
+"abc".to_f()
 nil.to_f()
 ' output='1.0
 1.4
-0.0
+nil
+nil
 ' />
 
 
 ### to_i()
-> Returns `INTEGER`
+> Returns `INTEGER|NIL`
 
-Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
+Converts an object to its integer representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0`. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
 
 
 <CodeBlockSimple input='true.to_i()
@@ -59,7 +61,7 @@ false.to_i()
 0o125
 0x2322
 0b1010
-0
+nil
 ' />
 
 

--- a/docs/docs/literals/hash.md
+++ b/docs/docs/literals/hash.md
@@ -94,24 +94,26 @@ Returns an array of all supported methods names.
 
 
 ### to_f()
-> Returns `FLOAT`
+> Returns `FLOAT|NIL`
 
-If possible converts an object to its float representation. If not 0.0 is returned.
+Converts an object to its float representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0.0`.
 
 
 <CodeBlockSimple input='1.to_f()
 "1.4".to_f()
+"abc".to_f()
 nil.to_f()
 ' output='1.0
 1.4
-0.0
+nil
+nil
 ' />
 
 
 ### to_i()
-> Returns `INTEGER`
+> Returns `INTEGER|NIL`
 
-Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
+Converts an object to its integer representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0`. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
 
 
 <CodeBlockSimple input='true.to_i()
@@ -131,7 +133,7 @@ false.to_i()
 0o125
 0x2322
 0b1010
-0
+nil
 ' />
 
 

--- a/docs/docs/literals/http.md
+++ b/docs/docs/literals/http.md
@@ -70,24 +70,26 @@ Returns an array of all supported methods names.
 
 
 ### to_f()
-> Returns `FLOAT`
+> Returns `FLOAT|NIL`
 
-If possible converts an object to its float representation. If not 0.0 is returned.
+Converts an object to its float representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0.0`.
 
 
 <CodeBlockSimple input='1.to_f()
 "1.4".to_f()
+"abc".to_f()
 nil.to_f()
 ' output='1.0
 1.4
-0.0
+nil
+nil
 ' />
 
 
 ### to_i()
-> Returns `INTEGER`
+> Returns `INTEGER|NIL`
 
-Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
+Converts an object to its integer representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0`. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
 
 
 <CodeBlockSimple input='true.to_i()
@@ -107,7 +109,7 @@ false.to_i()
 0o125
 0x2322
 0b1010
-0
+nil
 ' />
 
 

--- a/docs/docs/literals/integer.md
+++ b/docs/docs/literals/integer.md
@@ -56,24 +56,26 @@ Returns an array of all supported methods names.
 
 
 ### to_f()
-> Returns `FLOAT`
+> Returns `FLOAT|NIL`
 
-If possible converts an object to its float representation. If not 0.0 is returned.
+Converts an object to its float representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0.0`.
 
 
 <CodeBlockSimple input='1.to_f()
 "1.4".to_f()
+"abc".to_f()
 nil.to_f()
 ' output='1.0
 1.4
-0.0
+nil
+nil
 ' />
 
 
 ### to_i()
-> Returns `INTEGER`
+> Returns `INTEGER|NIL`
 
-Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
+Converts an object to its integer representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0`. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
 
 
 <CodeBlockSimple input='true.to_i()
@@ -93,7 +95,7 @@ false.to_i()
 0o125
 0x2322
 0b1010
-0
+nil
 ' />
 
 

--- a/docs/docs/literals/matrix.md
+++ b/docs/docs/literals/matrix.md
@@ -205,24 +205,26 @@ Returns an array of all supported methods names.
 
 
 ### to_f()
-> Returns `FLOAT`
+> Returns `FLOAT|NIL`
 
-If possible converts an object to its float representation. If not 0.0 is returned.
+Converts an object to its float representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0.0`.
 
 
 <CodeBlockSimple input='1.to_f()
 "1.4".to_f()
+"abc".to_f()
 nil.to_f()
 ' output='1.0
 1.4
-0.0
+nil
+nil
 ' />
 
 
 ### to_i()
-> Returns `INTEGER`
+> Returns `INTEGER|NIL`
 
-Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
+Converts an object to its integer representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0`. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
 
 
 <CodeBlockSimple input='true.to_i()
@@ -242,7 +244,7 @@ false.to_i()
 0o125
 0x2322
 0b1010
-0
+nil
 ' />
 
 

--- a/docs/docs/literals/nil.md
+++ b/docs/docs/literals/nil.md
@@ -24,24 +24,26 @@ Returns an array of all supported methods names.
 
 
 ### to_f()
-> Returns `FLOAT`
+> Returns `FLOAT|NIL`
 
-If possible converts an object to its float representation. If not 0.0 is returned.
+Converts an object to its float representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0.0`.
 
 
 <CodeBlockSimple input='1.to_f()
 "1.4".to_f()
+"abc".to_f()
 nil.to_f()
 ' output='1.0
 1.4
-0.0
+nil
+nil
 ' />
 
 
 ### to_i()
-> Returns `INTEGER`
+> Returns `INTEGER|NIL`
 
-Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
+Converts an object to its integer representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0`. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
 
 
 <CodeBlockSimple input='true.to_i()
@@ -61,7 +63,7 @@ false.to_i()
 0o125
 0x2322
 0b1010
-0
+nil
 ' />
 
 

--- a/docs/docs/literals/string.md
+++ b/docs/docs/literals/string.md
@@ -209,24 +209,26 @@ Returns an array of all supported methods names.
 
 
 ### to_f()
-> Returns `FLOAT`
+> Returns `FLOAT|NIL`
 
-If possible converts an object to its float representation. If not 0.0 is returned.
+Converts an object to its float representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0.0`.
 
 
 <CodeBlockSimple input='1.to_f()
 "1.4".to_f()
+"abc".to_f()
 nil.to_f()
 ' output='1.0
 1.4
-0.0
+nil
+nil
 ' />
 
 
 ### to_i()
-> Returns `INTEGER`
+> Returns `INTEGER|NIL`
 
-Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
+Converts an object to its integer representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0`. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly.
 
 
 <CodeBlockSimple input='true.to_i()
@@ -246,7 +248,7 @@ false.to_i()
 0o125
 0x2322
 0b1010
-0
+nil
 ' />
 
 

--- a/docs/literals/object.yml
+++ b/docs/literals/object.yml
@@ -18,7 +18,7 @@ methods:
       "test"
       "1.4"
   to_i:
-    description: "Converts an object to its integer representation, or `0` when it cannot. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly."
+    description: "Converts an object to its integer representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0`. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly."
     input: |
       true.to_i()
       false.to_i()
@@ -38,17 +38,19 @@ methods:
       0o125
       0x2322
       0b1010
-      0
+      nil
   to_f:
-    description: "If possible converts an object to its float representation. If not 0.0 is returned."
+    description: "Converts an object to its float representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0.0`."
     input: |
       1.to_f()
       "1.4".to_f()
+      "abc".to_f()
       nil.to_f()
     output: |
       1.0
       1.4
-      0.0
+      nil
+      nil
   to_json:
     description: "Returns the object as json notation."
     input: |

--- a/object/array.go
+++ b/object/array.go
@@ -207,11 +207,19 @@ func init() {
 				var result int
 
 				for i, element := range ao.Elements {
-					if val, ok := element.(Integerable); ok {
-						result += int(val.ToIntegerObj().Value)
-					} else {
+					val, ok := element.(Integerable)
+					if !ok {
 						return NewErrorFormat("Found non number element %s on index %d", element.Type(), i)
 					}
+
+					// A convertible type can still fail to convert, for
+					// instance a string that does not parse as a number.
+					integer, ok := val.ToIntegerObj().(*Integer)
+					if !ok {
+						return NewErrorFormat("Found non number element %s on index %d", element.Type(), i)
+					}
+
+					result += int(integer.Value)
 				}
 				return NewInteger(result)
 			},

--- a/object/array_test.go
+++ b/object/array_test.go
@@ -74,6 +74,10 @@ func TestArrayObjectMethods(t *testing.T) {
 		{"[1,2,3].join('-')", "1-2-3"},
 		{"['1',2, 2.5,{}].sum()", "Found non number element HASH on index 3"},
 		{"['1', 2, 2.5].sum()", 5},
+		// A type can be convertible in principle and still fail to convert:
+		// nil and a non-numeric string both used to contribute a silent 0.
+		{"[1, nil].sum()", "Found non number element NIL on index 1"},
+		{"['abc'].sum()", "Found non number element STRING on index 0"},
 		{`[[1, 2], [3, 4]].to_m()`, "2x2 matrix\n┌          ┐\n│ 1.0  2.0 │\n│ 3.0  4.0 │\n└          ┘"},
 		{`[[1, 2], [3, 4]].to_m().to_a()`, "[[1.0, 2.0], [3.0, 4.0]]"},
 		{`[1, 2].to_m()`, "failed to convert array to matrix: matrix must be created from 2D array"},

--- a/object/boolean.go
+++ b/object/boolean.go
@@ -46,14 +46,14 @@ func (b *Boolean) ToStringObj() *String {
 	return NewString(strconv.FormatBool(b.Value))
 }
 
-func (b *Boolean) ToIntegerObj() *Integer {
+func (b *Boolean) ToIntegerObj() Object {
 	if b.Value {
 		return NewInteger(1)
 	}
 	return NewInteger(0)
 }
 
-func (b *Boolean) ToFloatObj() *Float {
+func (b *Boolean) ToFloatObj() Object {
 	if b.Value {
 		return NewFloat(1.0)
 	}

--- a/object/float.go
+++ b/object/float.go
@@ -54,10 +54,10 @@ func (f *Float) ToStringObj() *String {
 	return NewString(f.toString())
 }
 
-func (f *Float) ToIntegerObj() *Integer {
+func (f *Float) ToIntegerObj() Object {
 	return NewInteger(int(f.Value))
 }
 
-func (f *Float) ToFloatObj() *Float {
+func (f *Float) ToFloatObj() Object {
 	return f
 }

--- a/object/hash_test.go
+++ b/object/hash_test.go
@@ -39,8 +39,8 @@ func TestHashObjectMethods(t *testing.T) {
 		{`{"a": 1, "b": 2}.get("a", 10)`, 1},
 		{`{"a": 1, "b": 2}.get("c", 10)`, 10},
 		{`{"a": 1, "b": 2}.to_s()`, ""},
-		{`{"a": 1, "b": 2}.to_i()`, 0},
-		{`{"a": 1, "b": 2}.to_f()`, 0.0},
+		{`{"a": 1, "b": 2}.to_i()`, nil},
+		{`{"a": 1, "b": 2}.to_f()`, nil},
 	}
 
 	testInput(t, tests)

--- a/object/integer.go
+++ b/object/integer.go
@@ -88,11 +88,11 @@ func (i *Integer) ToStringObj() *String {
 	return NewString(i.Inspect())
 }
 
-func (i *Integer) ToIntegerObj() *Integer {
+func (i *Integer) ToIntegerObj() Object {
 	return i
 }
 
-func (i *Integer) ToFloatObj() *Float {
+func (i *Integer) ToFloatObj() Object {
 	return NewFloat(float64(i.Value))
 }
 

--- a/object/nil.go
+++ b/object/nil.go
@@ -14,14 +14,6 @@ func (n *Nil) ToStringObj() *String {
 	return NewString("")
 }
 
-func (n *Nil) ToIntegerObj() *Integer {
-	return NewInteger(0.0)
-}
-
-func (n *Nil) ToFloatObj() *Float {
-	return NewFloat(0.0)
-}
-
 func init() {
 	objectMethods[NIL_OBJ] = map[string]ObjectMethod{}
 }

--- a/object/nil_test.go
+++ b/object/nil_test.go
@@ -18,8 +18,8 @@ func TestNilObjectMethods(t *testing.T) {
 	tests := []inputTestCase{
 		{`[1][1].nope()`, "test:1:7: undefined method `.nope()` for NIL"},
 		{`[1][1].to_s()`, ""},
-		{`[1][1].to_i()`, 0},
-		{`[1][1].to_f()`, 0.0},
+		{`[1][1].to_i()`, nil},
+		{`[1][1].to_f()`, nil},
 	}
 
 	testInput(t, tests)

--- a/object/object.go
+++ b/object/object.go
@@ -38,12 +38,16 @@ type Stringable interface {
 	ToStringObj() *String
 }
 
+// Integerable is implemented by objects that can attempt an integer
+// conversion. The result is NIL when the value cannot be converted.
 type Integerable interface {
-	ToIntegerObj() *Integer
+	ToIntegerObj() Object
 }
 
+// Floatable is implemented by objects that can attempt a float
+// conversion. The result is NIL when the value cannot be converted.
 type Floatable interface {
-	ToFloatObj() *Float
+	ToFloatObj() Object
 }
 
 var ANY_OBJ = []string{
@@ -231,20 +235,21 @@ func init() {
 		"to_i": ObjectMethod{
 			Layout: MethodLayout{
 				ReturnPattern: Args(
-					Arg(INTEGER_OBJ),
+					Arg(INTEGER_OBJ, NIL_OBJ),
 				),
 			},
 			method: func(o Object, _ []Object, _ Environment) Object {
 				if integerable, ok := o.(Integerable); ok {
 					return integerable.ToIntegerObj()
 				}
-				return NewInteger(0)
+
+				return NIL
 			},
 		},
 		"to_f": ObjectMethod{
 			Layout: MethodLayout{
 				ReturnPattern: Args(
-					Arg(FLOAT_OBJ),
+					Arg(FLOAT_OBJ, NIL_OBJ),
 				),
 			},
 			method: func(o Object, _ []Object, _ Environment) Object {
@@ -252,7 +257,7 @@ func init() {
 					return floatable.ToFloatObj()
 				}
 
-				return NewFloat(0.0)
+				return NIL
 			},
 		},
 		"to_json": ObjectMethod{

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -69,6 +69,13 @@ func testInput(t *testing.T, tests []inputTestCase) {
 			}
 		case bool:
 			testBooleanObject(t, evaluated, expected)
+		case nil:
+			// A nil expectation means the conversion could not be performed.
+			// Without this case the type switch matched nothing and the
+			// assertion silently passed whatever it was given.
+			if _, ok := evaluated.(*object.Nil); !ok {
+				t.Errorf("input %q: object is not Nil. got=%T (%+v)", tt.input, evaluated, evaluated)
+			}
 		}
 	}
 }

--- a/object/string.go
+++ b/object/string.go
@@ -321,7 +321,7 @@ func (s *String) ToStringObj() *String {
 	return s
 }
 
-func (s *String) ToIntegerObj() *Integer {
+func (s *String) ToIntegerObj() Object {
 	base := 10
 	digits := s.Value
 
@@ -346,10 +346,7 @@ func (s *String) ToIntegerObj() *Integer {
 	i, err := strconv.ParseInt(sign+digits, base, 64)
 
 	if err != nil {
-		// Returning 0 on a failed conversion is the long-standing behaviour,
-		// tracked separately in #232. Do not print the Go error: it lands on
-		// stdout and corrupts the program's own output.
-		return NewInteger(0)
+		return NIL
 	}
 
 	return NewIntegerWithBase(int(i), base)
@@ -373,8 +370,13 @@ func isLegacyOctal(digits string) bool {
 	return true
 }
 
-func (s *String) ToFloatObj() *Float {
-	f, _ := strconv.ParseFloat(s.Value, 64)
+func (s *String) ToFloatObj() Object {
+	f, err := strconv.ParseFloat(s.Value, 64)
+
+	if err != nil {
+		return NIL
+	}
+
 	return NewFloat(f)
 }
 

--- a/object/string_test.go
+++ b/object/string_test.go
@@ -35,9 +35,9 @@ func TestStringObjectMethods(t *testing.T) {
 		{`"test".find("e")`, 1},
 		{`"test".find()`, "to few arguments: got=0, want=1"},
 		{`"test".size()`, 4},
-		{`"test".to_i()`, 0},
+		{`"test".to_i()`, nil},
 		{`"125".to_i()`, 125},
-		{`"test125".to_i()`, 0},
+		{`"test125".to_i()`, nil},
 		{`"0125".to_i()`, 85},
 		{`"1010".to_i()`, 1010},
 		{`"-1010".to_i()`, -1010},
@@ -174,4 +174,23 @@ func TestStringInspect(t *testing.T) {
 			t.Errorf("Inspect() for %q: got=%q, want=%q", tt.input, result, tt.expected)
 		}
 	}
+}
+
+// TestStringConversionFailureIsNil covers the change from silent zeros to nil:
+// a failed conversion has to be distinguishable from a successful one that
+// happens to produce 0.
+func TestStringConversionFailureIsNil(t *testing.T) {
+	tests := []inputTestCase{
+		{`"0".to_i()`, 0},
+		{`"abc".to_i()`, nil},
+		{`"".to_i()`, nil},
+		{`"12abc".to_i()`, nil},
+		{`"0.0".to_f()`, 0.0},
+		{`"abc".to_f()`, nil},
+		{`"".to_f()`, nil},
+		// to_s never fails, so nil keeps rendering as the empty string.
+		{`nil.to_s()`, ""},
+	}
+
+	testInput(t, tests)
 }


### PR DESCRIPTION
Closes #232. Closes #236.

**Breaking.**

A failed conversion was indistinguishable from a successful one: `"abc".to_i()` and `"0".to_i()` both gave `0`, and `"abc".to_f()` gave `0.0`.

## The issue's proposed API cannot be built

#232 recommends returning an ERROR and inspecting it:

```js
result = "abc".to_i()
if result.type() == "ERROR"
  puts("Conversion failed: " + result.message())
end
```

Errors abort rather than being returned as values, so the assignment never completes and the type check is unreachable. Verified against every error-producing form:

```js
r = raise("boom")   // "still running" never prints
r = "x".nope()      // aborts
r = 5 % 0           // aborts
```

Errors are observable only through `begin`/`rescue`. (Also, the accessor is `.msg()`, not `.message()`.)

## What this does instead

Return `nil`. It is distinguishable from `0`, does not abort, composes with `==`, and matches how the language already reports absence — a hash miss is `nil`.

| | before | after |
|---|---|---|
| `"12".to_i()` | `12` | `12` |
| `"0".to_i()` | `0` | `0` |
| `"abc".to_i()` | `0` | `nil` |
| `"".to_i()` | `0` | `nil` |
| `"abc".to_f()` | `0.0` | `nil` |
| `[].to_i()`, `{}.to_i()`, `nil.to_i()` | `0` | `nil` |
| `true.to_i()` | `1` | `1` |
| `nil.to_s()` | `""` | `""` |

`Integerable` and `Floatable` now return `Object` so an implementation can report failure. `Nil` stops implementing them — it is not convertible to a number, so it should not claim to be. That also removes the `NewInteger(0.0)` float-into-int call, which is #236.

`to_s` is deliberately untouched. It cannot fail, and `nil.to_s()` returning `""` is a representation choice, not a silent error — changing it would put the literal string `"nil"` into every concatenation.

## Knock-on

`Array.sum` checked only that an element's *type* was convertible. A `nil` or a non-numeric string passed that check and then contributed a silent `0`. It now rejects them:

```js
[1, "2"].sum()   // 3, unchanged
[1, nil].sum()   // Found non number element NIL on index 1
["abc"].sum()    // Found non number element STRING on index 0
```

## Breaking-change note

Any script relying on a malformed field quietly becoming `0` will now see `nil`, and downstream arithmetic will error. That is the intent, but the failure surfaces at the arithmetic rather than at the conversion.

## Verified

Also fixed a hole in the test helper: `testInput` had no `case nil:`, so a `nil` expectation matched nothing in the type switch and silently passed. Six existing assertions were relying on that.

Every tracked `.rl` file produces byte-identical output to `main` — checked by md5 against a pre-change binary, so the intentional error demos are not masking a regression. Docs regenerated; `to_i`/`to_f` now read `Returns INTEGER|NIL`. `yarn build` succeeds.