### PR TITLE
docs: operators, precedence, scoping, escapes and hash keys

### DIFF
--- a/docs/docs/control_expressions/foreach.md
+++ b/docs/docs/control_expressions/foreach.md
@@ -41,6 +41,36 @@ b = iterate(a)
 // b is now [1,2,3,4,5]
 ```
 
+## Scope of the loop variable
+
+The loop variable is created in the loop's own scope, so it does not exist
+after the loop finishes:
+
+```js
+foreach j in [1, 2, 3]
+end
+
+puts(j)  // ERROR: identifier not found: j
+```
+
+If a variable of that name already exists outside the loop, though, the loop
+assigns to *that* variable rather than creating a new one, and it keeps the
+last value the loop gave it:
+
+```js
+i = 100
+
+foreach i in [1, 2, 3]
+end
+
+puts(i)  // 3, not 100
+```
+
+This follows from how assignment works generally: assigning to a name that
+already exists further out updates it in place instead of shadowing it. Use a
+loop variable name that is not already taken if you need to keep the outer
+value.
+
 ## Using an integer
 Count form zero to a given number (excluding):
 

--- a/docs/docs/language/operators.md
+++ b/docs/docs/language/operators.md
@@ -1,8 +1,64 @@
 # Operators
 
+## Available operators
+
 | Operator | Description |
 | -------- | ----------- |
-| `==`, `!=` | Equals, Not Equal |
-| `<`, `>`, `<=`, `>=` | Comparsion |
-| `and`, `&&` | Logical And |
-| `or`, `‖` | Logical Or |
+| `=` | Assignment |
+| `? :` | Ternary conditional |
+| `and`, `&&` | Logical and |
+| `or`, `\|\|` | Logical or |
+| `==`, `!=` | Equal, not equal |
+| `<`, `>`, `<=`, `>=` | Comparison |
+| `+`, `-` | Addition, subtraction |
+| `*`, `/` | Multiplication, division |
+| `%` | Modulo |
+| `-`, `!` | Prefix negation, prefix not |
+| `()` | Call |
+| `.` | Member access |
+| `[]` | Index |
+
+`and` and `&&` are the same operator, as are `or` and `||`. Pick one style and
+keep to it within a file; the word forms read more naturally in conditions,
+and the symbol forms are shorter in dense expressions.
+
+## Precedence
+
+Operators lower in this table bind more tightly, so they are applied first.
+
+| | Operators | Example |
+| - | --------- | ------- |
+| 1 | `=` | `a = 1 + 2` assigns `3` |
+| 2 | `? :` | `a == 1 ? "y" : "n"` |
+| 3 | `and`, `&&`, `or`, `\|\|` | see the note below |
+| 4 | `==`, `!=` | `2 + 3 == 5` is `true` |
+| 5 | `<`, `>`, `<=`, `>=` | `1 < 2 and 3 > 2` is `true` |
+| 6 | `+`, `-` | |
+| 7 | `*`, `/` | `1 + 2 * 3` is `7` |
+| 8 | `%` | `2 * 10 % 4` is `4` |
+| 9 | prefix `-`, `!` | `-2 * 3` is `-6` |
+| 10 | `()`, `.` | |
+| 11 | `[]` | |
+
+Parentheses override all of it: `(1 + 2) * 3` is `9`.
+
+Note that `%` binds more tightly than `*` and `/`, which is not true in every
+language. `2 * 10 % 4` groups as `2 * (10 % 4)`, giving `4` rather than `0`.
+
+### `and` and `or` share one level
+
+Unlike most languages, `and` does **not** bind more tightly than `or`. They sit
+at the same precedence and group left to right, so:
+
+```js
+true or false and false
+```
+
+is `(true or false) and false`, which is `false` — not `true or (false and
+false)`, which would be `true`. Parenthesise whenever a condition mixes the
+two:
+
+```js
+puts(true or (false and false))  // true
+puts((true or false) and false)  // false
+```

--- a/docs/docs/literals/array.md
+++ b/docs/docs/literals/array.md
@@ -197,11 +197,13 @@ Returns a copy of the array with deduplicated elements. Raises an error if a ele
 ### methods()
 > Returns `ARRAY`
 
-Returns an array of all supported methods names.
+Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array.
 
 
-<CodeBlockSimple input='"test".methods()
-' output='["upcase", "find", "format", "reverse", "split", "replace", "strip!", "count", "reverse!", "lines", "downcase!", "upcase!", "size", "strip", "downcase"]
+<CodeBlockSimple input='"test".methods().sort()
+true.methods()
+' output='["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+[]
 ' />
 
 
@@ -265,23 +267,21 @@ a.to_json()
 ### to_s()
 > Returns `STRING`
 
-If possible converts an object to its string representation. If not empty string is returned.
+Converts an object to its string representation, or the empty string when it has none. Takes no arguments; an integer renders in its own base, so use `to_base` first to change it.
 
 
 <CodeBlockSimple input='true.to_s()
 1234.to_s()
-1234.to_s(2)
-1234.to_s(8)
-1234.to_s(10)
 "test".to_s()
 1.4.to_s()
+nil.to_s()
+"0b1010".to_i().to_s()
 ' output='"true"
-"1234"
-"10011010010"
-"2322"
 "1234"
 "test"
 "1.4"
+""
+"0b1010"
 ' />
 
 
@@ -299,12 +299,11 @@ Returns the type of the object.
 ### wat()
 > Returns `STRING`
 
-Returns the supported methods with usage information.
+Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none.
 
 
 <CodeBlockSimple input='true.wat()
-' output='"BOOLEAN supports the following methods:
-  to_s()"
+' output='"BOOLEAN supports the following methods:\n"
 ' />
 
 

--- a/docs/docs/literals/boolean.md
+++ b/docs/docs/literals/boolean.md
@@ -27,11 +27,13 @@ is_true = a != b;
 ### methods()
 > Returns `ARRAY`
 
-Returns an array of all supported methods names.
+Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array.
 
 
-<CodeBlockSimple input='"test".methods()
-' output='["upcase", "find", "format", "reverse", "split", "replace", "strip!", "count", "reverse!", "lines", "downcase!", "upcase!", "size", "strip", "downcase"]
+<CodeBlockSimple input='"test".methods().sort()
+true.methods()
+' output='["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+[]
 ' />
 
 
@@ -95,23 +97,21 @@ a.to_json()
 ### to_s()
 > Returns `STRING`
 
-If possible converts an object to its string representation. If not empty string is returned.
+Converts an object to its string representation, or the empty string when it has none. Takes no arguments; an integer renders in its own base, so use `to_base` first to change it.
 
 
 <CodeBlockSimple input='true.to_s()
 1234.to_s()
-1234.to_s(2)
-1234.to_s(8)
-1234.to_s(10)
 "test".to_s()
 1.4.to_s()
+nil.to_s()
+"0b1010".to_i().to_s()
 ' output='"true"
-"1234"
-"10011010010"
-"2322"
 "1234"
 "test"
 "1.4"
+""
+"0b1010"
 ' />
 
 
@@ -129,12 +129,11 @@ Returns the type of the object.
 ### wat()
 > Returns `STRING`
 
-Returns the supported methods with usage information.
+Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none.
 
 
 <CodeBlockSimple input='true.wat()
-' output='"BOOLEAN supports the following methods:
-  to_s()"
+' output='"BOOLEAN supports the following methods:\n"
 ' />
 
 

--- a/docs/docs/literals/error.md
+++ b/docs/docs/literals/error.md
@@ -62,11 +62,13 @@ Please note that performing `.msg()` on a ERROR object does result in a STRING o
 ### methods()
 > Returns `ARRAY`
 
-Returns an array of all supported methods names.
+Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array.
 
 
-<CodeBlockSimple input='"test".methods()
-' output='["upcase", "find", "format", "reverse", "split", "replace", "strip!", "count", "reverse!", "lines", "downcase!", "upcase!", "size", "strip", "downcase"]
+<CodeBlockSimple input='"test".methods().sort()
+true.methods()
+' output='["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+[]
 ' />
 
 
@@ -130,23 +132,21 @@ a.to_json()
 ### to_s()
 > Returns `STRING`
 
-If possible converts an object to its string representation. If not empty string is returned.
+Converts an object to its string representation, or the empty string when it has none. Takes no arguments; an integer renders in its own base, so use `to_base` first to change it.
 
 
 <CodeBlockSimple input='true.to_s()
 1234.to_s()
-1234.to_s(2)
-1234.to_s(8)
-1234.to_s(10)
 "test".to_s()
 1.4.to_s()
+nil.to_s()
+"0b1010".to_i().to_s()
 ' output='"true"
-"1234"
-"10011010010"
-"2322"
 "1234"
 "test"
 "1.4"
+""
+"0b1010"
 ' />
 
 
@@ -164,12 +164,11 @@ Returns the type of the object.
 ### wat()
 > Returns `STRING`
 
-Returns the supported methods with usage information.
+Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none.
 
 
 <CodeBlockSimple input='true.wat()
-' output='"BOOLEAN supports the following methods:
-  to_s()"
+' output='"BOOLEAN supports the following methods:\n"
 ' />
 
 

--- a/docs/docs/literals/file.md
+++ b/docs/docs/literals/file.md
@@ -81,11 +81,13 @@ Writes the given string to the file. Returns number of written bytes on success.
 ### methods()
 > Returns `ARRAY`
 
-Returns an array of all supported methods names.
+Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array.
 
 
-<CodeBlockSimple input='"test".methods()
-' output='["upcase", "find", "format", "reverse", "split", "replace", "strip!", "count", "reverse!", "lines", "downcase!", "upcase!", "size", "strip", "downcase"]
+<CodeBlockSimple input='"test".methods().sort()
+true.methods()
+' output='["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+[]
 ' />
 
 
@@ -149,23 +151,21 @@ a.to_json()
 ### to_s()
 > Returns `STRING`
 
-If possible converts an object to its string representation. If not empty string is returned.
+Converts an object to its string representation, or the empty string when it has none. Takes no arguments; an integer renders in its own base, so use `to_base` first to change it.
 
 
 <CodeBlockSimple input='true.to_s()
 1234.to_s()
-1234.to_s(2)
-1234.to_s(8)
-1234.to_s(10)
 "test".to_s()
 1.4.to_s()
+nil.to_s()
+"0b1010".to_i().to_s()
 ' output='"true"
-"1234"
-"10011010010"
-"2322"
 "1234"
 "test"
 "1.4"
+""
+"0b1010"
 ' />
 
 
@@ -183,12 +183,11 @@ Returns the type of the object.
 ### wat()
 > Returns `STRING`
 
-Returns the supported methods with usage information.
+Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none.
 
 
 <CodeBlockSimple input='true.wat()
-' output='"BOOLEAN supports the following methods:
-  to_s()"
+' output='"BOOLEAN supports the following methods:\n"
 ' />
 
 

--- a/docs/docs/literals/float.md
+++ b/docs/docs/literals/float.md
@@ -13,11 +13,13 @@ import CodeBlockSimple from '@site/components/CodeBlockSimple'
 ### methods()
 > Returns `ARRAY`
 
-Returns an array of all supported methods names.
+Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array.
 
 
-<CodeBlockSimple input='"test".methods()
-' output='["upcase", "find", "format", "reverse", "split", "replace", "strip!", "count", "reverse!", "lines", "downcase!", "upcase!", "size", "strip", "downcase"]
+<CodeBlockSimple input='"test".methods().sort()
+true.methods()
+' output='["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+[]
 ' />
 
 
@@ -81,23 +83,21 @@ a.to_json()
 ### to_s()
 > Returns `STRING`
 
-If possible converts an object to its string representation. If not empty string is returned.
+Converts an object to its string representation, or the empty string when it has none. Takes no arguments; an integer renders in its own base, so use `to_base` first to change it.
 
 
 <CodeBlockSimple input='true.to_s()
 1234.to_s()
-1234.to_s(2)
-1234.to_s(8)
-1234.to_s(10)
 "test".to_s()
 1.4.to_s()
+nil.to_s()
+"0b1010".to_i().to_s()
 ' output='"true"
-"1234"
-"10011010010"
-"2322"
 "1234"
 "test"
 "1.4"
+""
+"0b1010"
 ' />
 
 
@@ -115,12 +115,11 @@ Returns the type of the object.
 ### wat()
 > Returns `STRING`
 
-Returns the supported methods with usage information.
+Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none.
 
 
 <CodeBlockSimple input='true.wat()
-' output='"BOOLEAN supports the following methods:
-  to_s()"
+' output='"BOOLEAN supports the following methods:\n"
 ' />
 
 

--- a/docs/docs/literals/hash.md
+++ b/docs/docs/literals/hash.md
@@ -2,6 +2,25 @@ import CodeBlockSimple from '@site/components/CodeBlockSimple'
 
 # Hash
 
+Hash keys are not restricted to strings. Any hashable value works, and a
+single hash may mix key types freely: `STRING`, `INTEGER`, `FLOAT`,
+`BOOLEAN`, `ARRAY` and `HASH`.
+
+```js
+h = {"a": 1, 2: true, 3.5: "float", true: "bool", [1, 2]: "array"}
+
+puts(h["a"])     // 1
+puts(h[2])       // true
+puts(h[3.5])     // "float"
+puts(h[true])    // "bool"
+puts(h[[1, 2]])  // "array"
+```
+
+`NIL` and functions are not hashable and are rejected as keys, with
+`unusable as hash key: NIL` and `expected index to be hashable`
+respectively.
+
+Reading a key that is not present returns `nil`.
 
 
 
@@ -85,11 +104,13 @@ Returns the values of the hash.
 ### methods()
 > Returns `ARRAY`
 
-Returns an array of all supported methods names.
+Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array.
 
 
-<CodeBlockSimple input='"test".methods()
-' output='["upcase", "find", "format", "reverse", "split", "replace", "strip!", "count", "reverse!", "lines", "downcase!", "upcase!", "size", "strip", "downcase"]
+<CodeBlockSimple input='"test".methods().sort()
+true.methods()
+' output='["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+[]
 ' />
 
 
@@ -153,23 +174,21 @@ a.to_json()
 ### to_s()
 > Returns `STRING`
 
-If possible converts an object to its string representation. If not empty string is returned.
+Converts an object to its string representation, or the empty string when it has none. Takes no arguments; an integer renders in its own base, so use `to_base` first to change it.
 
 
 <CodeBlockSimple input='true.to_s()
 1234.to_s()
-1234.to_s(2)
-1234.to_s(8)
-1234.to_s(10)
 "test".to_s()
 1.4.to_s()
+nil.to_s()
+"0b1010".to_i().to_s()
 ' output='"true"
-"1234"
-"10011010010"
-"2322"
 "1234"
 "test"
 "1.4"
+""
+"0b1010"
 ' />
 
 
@@ -187,12 +206,11 @@ Returns the type of the object.
 ### wat()
 > Returns `STRING`
 
-Returns the supported methods with usage information.
+Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none.
 
 
 <CodeBlockSimple input='true.wat()
-' output='"BOOLEAN supports the following methods:
-  to_s()"
+' output='"BOOLEAN supports the following methods:\n"
 ' />
 
 

--- a/docs/docs/literals/http.md
+++ b/docs/docs/literals/http.md
@@ -61,11 +61,13 @@ Starts a blocking webserver on the given port.
 ### methods()
 > Returns `ARRAY`
 
-Returns an array of all supported methods names.
+Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array.
 
 
-<CodeBlockSimple input='"test".methods()
-' output='["upcase", "find", "format", "reverse", "split", "replace", "strip!", "count", "reverse!", "lines", "downcase!", "upcase!", "size", "strip", "downcase"]
+<CodeBlockSimple input='"test".methods().sort()
+true.methods()
+' output='["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+[]
 ' />
 
 
@@ -129,23 +131,21 @@ a.to_json()
 ### to_s()
 > Returns `STRING`
 
-If possible converts an object to its string representation. If not empty string is returned.
+Converts an object to its string representation, or the empty string when it has none. Takes no arguments; an integer renders in its own base, so use `to_base` first to change it.
 
 
 <CodeBlockSimple input='true.to_s()
 1234.to_s()
-1234.to_s(2)
-1234.to_s(8)
-1234.to_s(10)
 "test".to_s()
 1.4.to_s()
+nil.to_s()
+"0b1010".to_i().to_s()
 ' output='"true"
-"1234"
-"10011010010"
-"2322"
 "1234"
 "test"
 "1.4"
+""
+"0b1010"
 ' />
 
 
@@ -163,12 +163,11 @@ Returns the type of the object.
 ### wat()
 > Returns `STRING`
 
-Returns the supported methods with usage information.
+Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none.
 
 
 <CodeBlockSimple input='true.wat()
-' output='"BOOLEAN supports the following methods:
-  to_s()"
+' output='"BOOLEAN supports the following methods:\n"
 ' />
 
 

--- a/docs/docs/literals/integer.md
+++ b/docs/docs/literals/integer.md
@@ -47,11 +47,13 @@ Converts the integer into a integer with the given base
 ### methods()
 > Returns `ARRAY`
 
-Returns an array of all supported methods names.
+Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array.
 
 
-<CodeBlockSimple input='"test".methods()
-' output='["upcase", "find", "format", "reverse", "split", "replace", "strip!", "count", "reverse!", "lines", "downcase!", "upcase!", "size", "strip", "downcase"]
+<CodeBlockSimple input='"test".methods().sort()
+true.methods()
+' output='["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+[]
 ' />
 
 
@@ -115,23 +117,21 @@ a.to_json()
 ### to_s()
 > Returns `STRING`
 
-If possible converts an object to its string representation. If not empty string is returned.
+Converts an object to its string representation, or the empty string when it has none. Takes no arguments; an integer renders in its own base, so use `to_base` first to change it.
 
 
 <CodeBlockSimple input='true.to_s()
 1234.to_s()
-1234.to_s(2)
-1234.to_s(8)
-1234.to_s(10)
 "test".to_s()
 1.4.to_s()
+nil.to_s()
+"0b1010".to_i().to_s()
 ' output='"true"
-"1234"
-"10011010010"
-"2322"
 "1234"
 "test"
 "1.4"
+""
+"0b1010"
 ' />
 
 
@@ -149,12 +149,11 @@ Returns the type of the object.
 ### wat()
 > Returns `STRING`
 
-Returns the supported methods with usage information.
+Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none.
 
 
 <CodeBlockSimple input='true.wat()
-' output='"BOOLEAN supports the following methods:
-  to_s()"
+' output='"BOOLEAN supports the following methods:\n"
 ' />
 
 

--- a/docs/docs/literals/matrix.md
+++ b/docs/docs/literals/matrix.md
@@ -196,11 +196,13 @@ m.transpose()
 ### methods()
 > Returns `ARRAY`
 
-Returns an array of all supported methods names.
+Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array.
 
 
-<CodeBlockSimple input='"test".methods()
-' output='["upcase", "find", "format", "reverse", "split", "replace", "strip!", "count", "reverse!", "lines", "downcase!", "upcase!", "size", "strip", "downcase"]
+<CodeBlockSimple input='"test".methods().sort()
+true.methods()
+' output='["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+[]
 ' />
 
 
@@ -264,23 +266,21 @@ a.to_json()
 ### to_s()
 > Returns `STRING`
 
-If possible converts an object to its string representation. If not empty string is returned.
+Converts an object to its string representation, or the empty string when it has none. Takes no arguments; an integer renders in its own base, so use `to_base` first to change it.
 
 
 <CodeBlockSimple input='true.to_s()
 1234.to_s()
-1234.to_s(2)
-1234.to_s(8)
-1234.to_s(10)
 "test".to_s()
 1.4.to_s()
+nil.to_s()
+"0b1010".to_i().to_s()
 ' output='"true"
-"1234"
-"10011010010"
-"2322"
 "1234"
 "test"
 "1.4"
+""
+"0b1010"
 ' />
 
 
@@ -298,12 +298,11 @@ Returns the type of the object.
 ### wat()
 > Returns `STRING`
 
-Returns the supported methods with usage information.
+Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none.
 
 
 <CodeBlockSimple input='true.wat()
-' output='"BOOLEAN supports the following methods:
-  to_s()"
+' output='"BOOLEAN supports the following methods:\n"
 ' />
 
 

--- a/docs/docs/literals/nil.md
+++ b/docs/docs/literals/nil.md
@@ -15,11 +15,13 @@ It will be returned if something returns nothing (eg. puts or an empty break/nex
 ### methods()
 > Returns `ARRAY`
 
-Returns an array of all supported methods names.
+Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array.
 
 
-<CodeBlockSimple input='"test".methods()
-' output='["upcase", "find", "format", "reverse", "split", "replace", "strip!", "count", "reverse!", "lines", "downcase!", "upcase!", "size", "strip", "downcase"]
+<CodeBlockSimple input='"test".methods().sort()
+true.methods()
+' output='["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+[]
 ' />
 
 
@@ -83,23 +85,21 @@ a.to_json()
 ### to_s()
 > Returns `STRING`
 
-If possible converts an object to its string representation. If not empty string is returned.
+Converts an object to its string representation, or the empty string when it has none. Takes no arguments; an integer renders in its own base, so use `to_base` first to change it.
 
 
 <CodeBlockSimple input='true.to_s()
 1234.to_s()
-1234.to_s(2)
-1234.to_s(8)
-1234.to_s(10)
 "test".to_s()
 1.4.to_s()
+nil.to_s()
+"0b1010".to_i().to_s()
 ' output='"true"
-"1234"
-"10011010010"
-"2322"
 "1234"
 "test"
 "1.4"
+""
+"0b1010"
 ' />
 
 
@@ -117,12 +117,11 @@ Returns the type of the object.
 ### wat()
 > Returns `STRING`
 
-Returns the supported methods with usage information.
+Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none.
 
 
 <CodeBlockSimple input='true.wat()
-' output='"BOOLEAN supports the following methods:
-  to_s()"
+' output='"BOOLEAN supports the following methods:\n"
 ' />
 
 

--- a/docs/docs/literals/string.md
+++ b/docs/docs/literals/string.md
@@ -2,6 +2,29 @@ import CodeBlockSimple from '@site/components/CodeBlockSimple'
 
 # String
 
+Strings can be written with double or single quotes, and the two differ in
+how they treat escapes.
+
+A **double-quoted** string processes escape sequences: `\"` for a quote,
+`\n` for a newline, `\t` for a tab, `\r` for a carriage return.
+
+```js
+puts("test\"string")   // test"string
+puts("a\tb")           // a<tab>b
+```
+
+A **single-quoted** string is raw: nothing is escaped and a backslash is an
+ordinary character. This makes it convenient for text containing double
+quotes.
+
+```js
+puts('test "string"')  // test "string"
+puts('a\tb')           // a\tb, a literal backslash and t
+```
+
+Because a single-quoted string performs no escaping, it cannot contain a
+single quote at all -- `'test \'string'` is a parse error. Use a
+double-quoted string when you need one.
 
 
 
@@ -200,11 +223,13 @@ Replaces all lowercase characters with upcase counterparts.
 ### methods()
 > Returns `ARRAY`
 
-Returns an array of all supported methods names.
+Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array.
 
 
-<CodeBlockSimple input='"test".methods()
-' output='["upcase", "find", "format", "reverse", "split", "replace", "strip!", "count", "reverse!", "lines", "downcase!", "upcase!", "size", "strip", "downcase"]
+<CodeBlockSimple input='"test".methods().sort()
+true.methods()
+' output='["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+[]
 ' />
 
 
@@ -268,23 +293,21 @@ a.to_json()
 ### to_s()
 > Returns `STRING`
 
-If possible converts an object to its string representation. If not empty string is returned.
+Converts an object to its string representation, or the empty string when it has none. Takes no arguments; an integer renders in its own base, so use `to_base` first to change it.
 
 
 <CodeBlockSimple input='true.to_s()
 1234.to_s()
-1234.to_s(2)
-1234.to_s(8)
-1234.to_s(10)
 "test".to_s()
 1.4.to_s()
+nil.to_s()
+"0b1010".to_i().to_s()
 ' output='"true"
-"1234"
-"10011010010"
-"2322"
 "1234"
 "test"
 "1.4"
+""
+"0b1010"
 ' />
 
 
@@ -302,12 +325,11 @@ Returns the type of the object.
 ### wat()
 > Returns `STRING`
 
-Returns the supported methods with usage information.
+Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none.
 
 
 <CodeBlockSimple input='true.wat()
-' output='"BOOLEAN supports the following methods:
-  to_s()"
+' output='"BOOLEAN supports the following methods:\n"
 ' />
 
 

--- a/docs/literals/hash.yml
+++ b/docs/literals/hash.yml
@@ -1,4 +1,24 @@
 title: "Hash"
+description: |
+  Hash keys are not restricted to strings. Any hashable value works, and a
+  single hash may mix key types freely: `STRING`, `INTEGER`, `FLOAT`,
+  `BOOLEAN`, `ARRAY` and `HASH`.
+
+  ```js
+  h = {"a": 1, 2: true, 3.5: "float", true: "bool", [1, 2]: "array"}
+
+  puts(h["a"])     // 1
+  puts(h[2])       // true
+  puts(h[3.5])     // "float"
+  puts(h[true])    // "bool"
+  puts(h[[1, 2]])  // "array"
+  ```
+
+  `NIL` and functions are not hashable and are rejected as keys, with
+  `unusable as hash key: NIL` and `expected index to be hashable`
+  respectively.
+
+  Reading a key that is not present returns `nil`.
 example: |
   people = [{"name": "Anna", "age": 24}, {"name": "Bob", "age": 99}];
 

--- a/docs/literals/object.yml
+++ b/docs/literals/object.yml
@@ -1,22 +1,20 @@
 methods:
   to_s:
-    description: "If possible converts an object to its string representation. If not empty string is returned."
+    description: "Converts an object to its string representation, or the empty string when it has none. Takes no arguments; an integer renders in its own base, so use `to_base` first to change it."
     input: |
       true.to_s()
       1234.to_s()
-      1234.to_s(2)
-      1234.to_s(8)
-      1234.to_s(10)
       "test".to_s()
       1.4.to_s()
+      nil.to_s()
+      "0b1010".to_i().to_s()
     output: |
       "true"
       "1234"
-      "10011010010"
-      "2322"
-      "1234"
       "test"
       "1.4"
+      ""
+      "0b1010"
   to_i:
     description: "Converts an object to its integer representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0`. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly."
     input: |
@@ -60,18 +58,19 @@ methods:
       {"test": 1234}
       "{\"test\":1234}"
   methods:
-    description: "Returns an array of all supported methods names."
+    description: "Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array."
     input: |
-      "test".methods()
+      "test".methods().sort()
+      true.methods()
     output: |
-      ["upcase", "find", "format", "reverse", "split", "replace", "strip!", "count", "reverse!", "lines", "downcase!", "upcase!", "size", "strip", "downcase"]
+      ["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+      []
   wat:
-    description: "Returns the supported methods with usage information."
+    description: "Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none."
     input: |
       true.wat()
     output: |
-      "BOOLEAN supports the following methods:
-        to_s()"
+      "BOOLEAN supports the following methods:\n"
   type:
     description: "Returns the type of the object."
     input: |

--- a/docs/literals/string.yml
+++ b/docs/literals/string.yml
@@ -1,5 +1,28 @@
 title: "String"
-description:
+description: |
+  Strings can be written with double or single quotes, and the two differ in
+  how they treat escapes.
+
+  A **double-quoted** string processes escape sequences: `\"` for a quote,
+  `\n` for a newline, `\t` for a tab, `\r` for a carriage return.
+
+  ```js
+  puts("test\"string")   // test"string
+  puts("a\tb")           // a<tab>b
+  ```
+
+  A **single-quoted** string is raw: nothing is escaped and a backslash is an
+  ordinary character. This makes it convenient for text containing double
+  quotes.
+
+  ```js
+  puts('test "string"')  // test "string"
+  puts('a\tb')           // a\tb, a literal backslash and t
+  ```
+
+  Because a single-quoted string performs no escaping, it cannot contain a
+  single quote at all -- `'test \'string'` is a parse error. Use a
+  double-quoted string when you need one.
 example: |
   a = "test_string";
 


### PR DESCRIPTION
Closes #233, #234, #239, #240, #241, #242.

Documentation only — no behaviour changes. Every example was run against a build before being written down.

## Operators and precedence (#242, #234)

`operators.md` showed `‖` (U+2016 DOUBLE VERTICAL LINE) for logical or, not `||`. Rewritten with the full operator set, a note that `and`/`&&` and `or`/`||` are the same operators, and a precedence table read off the parser's own `precedences` map.

Two findings there are worth more than a table row, because both contradict what the issue assumed:

**`%` binds more tightly than `*` and `/`.** `2 * 10 % 4` groups as `2 * (10 % 4)` and gives `4`, not `0`.

**`and` and `or` share one precedence level.** #234 proposed the standard ordering with `and` above `or`, but they are both `LOGICAL` in the parser and group left to right:

```js
true or false and false   // (true or false) and false  ->  false
```

Most languages give `true` here. The docs now call this out with worked examples both ways.

## Loop variable scope (#239)

Answers the issue's question directly — it is `3`, not `100` — and explains why:

```js
foreach j in [1, 2, 3]
end
puts(j)     // ERROR: identifier not found: j   (fresh name, scoped to the loop)

i = 100
foreach i in [1, 2, 3]
end
puts(i)     // 3   (name already existed, so the loop assigned to it)
```

## String quotes (#240)

Answers the issue's open question. Double-quoted strings process escapes; single-quoted strings are raw, so a backslash is an ordinary character. Consequently a single-quoted string cannot contain a single quote at all — `'test \'string'` is a parse error, which is what the issue was unsure about.

## Hash keys (#241)

`STRING`, `INTEGER`, `FLOAT`, `BOOLEAN`, `ARRAY` and `HASH` all work and may be mixed in one hash. `NIL` and functions are rejected. A missing key reads as `nil`.

## Generic method examples (#233)

The generic block is rendered onto every literal page, and several of its examples did not run at all:

- `to_s` was shown three times with a base argument (`1234.to_s(2)`), but it takes none — those error with `to many arguments: got=1, want=0`.
- `wat()`'s documented output was invented; the real output for `BOOLEAN` lists no methods.
- `methods()` documented a stale list **in an order the runtime does not guarantee**. It comes from Go map iteration, and I confirmed it genuinely varies between consecutive runs. The example now calls `.sort()`, which is stable, and the description says the order is unspecified and that the list covers only literal-specific methods.

I did not restructure the generic block onto a single shared page, which #233 also suggests. That is a docs-site layout change rather than a correctness fix, and it touches `generate.go`, the templates and the sidebar — happy to do it separately if you want it.

`yarn build` succeeds.