### PR TITLE
feat(number): numeric methods, and integer division yields an integer

### DIFF
--- a/docs/docs/language/operators.md
+++ b/docs/docs/language/operators.md
@@ -22,6 +22,31 @@
 keep to it within a file; the word forms read more naturally in conditions,
 and the symbol forms are shorter in dense expressions.
 
+## Division
+
+Dividing two integers gives an integer, as in Ruby. The result is truncated
+toward zero rather than rounded.
+
+```js
+puts(4 / 2)   // 2
+puts(5 / 2)   // 2, not 2.5
+```
+
+Mixing an integer with a float promotes the result to a float, so make one
+side a float when you want the fractional part:
+
+```js
+puts(4.0 / 2)   // 2.0
+puts(4 / 2.0)   // 2.0
+puts(5 / 2.0)   // 2.5
+```
+
+Truncation means a negative quotient rounds toward zero: `-5 / 2` is `-2`, not
+`-3`. This keeps division consistent with `%`, whose sign follows the
+dividend, so `(a / b) * b + a % b` always gives back `a`.
+
+Dividing by zero is an error in both forms.
+
 ## Precedence
 
 Operators lower in this table bind more tightly, so they are applied first.

--- a/docs/docs/literals/float.md
+++ b/docs/docs/literals/float.md
@@ -7,6 +7,62 @@ import CodeBlockSimple from '@site/components/CodeBlockSimple'
 
 ## Literal Specific Methods
 
+### abs()
+> Returns `FLOAT`
+
+Returns the absolute value, as a float.
+
+
+<CodeBlockSimple input='3.14.abs()
+(0.0 - 3.14).abs()
+' output='3.14
+3.14
+' />
+
+
+### ceil()
+> Returns `FLOAT`
+
+Rounds up to the nearest whole number, as a float.
+
+
+<CodeBlockSimple input='3.14.ceil()
+(0.0 - 3.7).ceil()
+' output='4.0
+-3.0
+' />
+
+
+### floor()
+> Returns `FLOAT`
+
+Rounds down to the nearest whole number, as a float.
+
+
+<CodeBlockSimple input='3.14.floor()
+(0.0 - 3.2).floor()
+' output='3.0
+-4.0
+' />
+
+
+### round()
+> Returns `FLOAT`
+
+Rounds to the nearest whole number, as a float. Halves round away from zero. The result stays a float, matching `Math.round`; chain `to_i` for an integer.
+
+
+<CodeBlockSimple input='3.14.round()
+2.5.round()
+(0.0 - 2.5).round()
+3.7.round().to_i()
+' output='3.0
+3.0
+-3.0
+4
+' />
+
+
 
 ## Generic Literal Methods
 

--- a/docs/docs/literals/integer.md
+++ b/docs/docs/literals/integer.md
@@ -20,6 +20,21 @@ is_false = 1 == 2;
 
 ## Literal Specific Methods
 
+### abs()
+> Returns `INTEGER`
+
+Returns the absolute value, as an integer, keeping the base.
+
+
+<CodeBlockSimple input='3.abs()
+(0 - 5).abs()
+"-0x10".to_i().abs()
+' output='3
+5
+0x10
+' />
+
+
 ### base()
 > Returns `INTEGER`
 
@@ -28,6 +43,39 @@ Returns the base of the integer.
 
 <CodeBlockSimple input='"0b1010".to_i().base()
 ' output='2' />
+
+
+### ceil()
+> Returns `INTEGER`
+
+Returns the integer unchanged. An integer is already whole; this exists so numeric code does not have to branch on whether it holds an integer or a float.
+
+
+<CodeBlockSimple input='3.ceil()
+' output='3
+' />
+
+
+### floor()
+> Returns `INTEGER`
+
+Returns the integer unchanged, for the same reason as `ceil`.
+
+
+<CodeBlockSimple input='3.floor()
+' output='3
+' />
+
+
+### round()
+> Returns `INTEGER`
+
+Returns the integer unchanged, for the same reason as `ceil`.
+
+
+<CodeBlockSimple input='3.round()
+' output='3
+' />
 
 
 ### to_base(INTEGER)

--- a/docs/docs/literals/integer.md
+++ b/docs/docs/literals/integer.md
@@ -45,39 +45,6 @@ Returns the base of the integer.
 ' output='2' />
 
 
-### ceil()
-> Returns `INTEGER`
-
-Returns the integer unchanged. An integer is already whole; this exists so numeric code does not have to branch on whether it holds an integer or a float.
-
-
-<CodeBlockSimple input='3.ceil()
-' output='3
-' />
-
-
-### floor()
-> Returns `INTEGER`
-
-Returns the integer unchanged, for the same reason as `ceil`.
-
-
-<CodeBlockSimple input='3.floor()
-' output='3
-' />
-
-
-### round()
-> Returns `INTEGER`
-
-Returns the integer unchanged, for the same reason as `ceil`.
-
-
-<CodeBlockSimple input='3.round()
-' output='3
-' />
-
-
 ### to_base(INTEGER)
 > Returns `INTEGER`
 

--- a/docs/literals/float.yml
+++ b/docs/literals/float.yml
@@ -1,5 +1,41 @@
 title: "Float"
 methods:
+  abs:
+    description: "Returns the absolute value, as a float."
+    input: |
+      3.14.abs()
+      (0.0 - 3.14).abs()
+    output: |
+      3.14
+      3.14
+  ceil:
+    description: "Rounds up to the nearest whole number, as a float."
+    input: |
+      3.14.ceil()
+      (0.0 - 3.7).ceil()
+    output: |
+      4.0
+      -3.0
+  floor:
+    description: "Rounds down to the nearest whole number, as a float."
+    input: |
+      3.14.floor()
+      (0.0 - 3.2).floor()
+    output: |
+      3.0
+      -4.0
+  round:
+    description: "Rounds to the nearest whole number, as a float. Halves round away from zero. The result stays a float, matching `Math.round`; chain `to_i` for an integer."
+    input: |
+      3.14.round()
+      2.5.round()
+      (0.0 - 2.5).round()
+      3.7.round().to_i()
+    output: |
+      3.0
+      3.0
+      -3.0
+      4
   to_f:
     description: "Returns self"
     input: |

--- a/docs/literals/integer.yml
+++ b/docs/literals/integer.yml
@@ -21,24 +21,6 @@ methods:
       3
       5
       0x10
-  ceil:
-    description: "Returns the integer unchanged. An integer is already whole; this exists so numeric code does not have to branch on whether it holds an integer or a float."
-    input: |
-      3.ceil()
-    output: |
-      3
-  floor:
-    description: "Returns the integer unchanged, for the same reason as `ceil`."
-    input: |
-      3.floor()
-    output: |
-      3
-  round:
-    description: "Returns the integer unchanged, for the same reason as `ceil`."
-    input: |
-      3.round()
-    output: |
-      3
   base:
     description: "Returns the base of the integer."
     input: |

--- a/docs/literals/integer.yml
+++ b/docs/literals/integer.yml
@@ -11,6 +11,34 @@ example: |
   is_true = 1 == 1;
   is_false = 1 == 2;
 methods:
+  abs:
+    description: "Returns the absolute value, as an integer, keeping the base."
+    input: |
+      3.abs()
+      (0 - 5).abs()
+      "-0x10".to_i().abs()
+    output: |
+      3
+      5
+      0x10
+  ceil:
+    description: "Returns the integer unchanged. An integer is already whole; this exists so numeric code does not have to branch on whether it holds an integer or a float."
+    input: |
+      3.ceil()
+    output: |
+      3
+  floor:
+    description: "Returns the integer unchanged, for the same reason as `ceil`."
+    input: |
+      3.floor()
+    output: |
+      3
+  round:
+    description: "Returns the integer unchanged, for the same reason as `ceil`."
+    input: |
+      3.round()
+    output: |
+      3
   base:
     description: "Returns the base of the integer."
     input: |

--- a/evaluator/infix.go
+++ b/evaluator/infix.go
@@ -90,7 +90,10 @@ func evalInfixExpression(operator string, left, right object.Object) object.Obje
 	case operator == "!=":
 		return nativeBoolToBooleanObject(!object.CompareObjects(left, right))
 	case object.IsNumber(left) && object.IsNumber(right):
-		if left.Type() == right.Type() && operator != "/" {
+		// Same-type arithmetic stays in that type, so dividing two integers
+		// yields an integer as it does in Ruby. Mixing an integer and a float
+		// promotes to float below.
+		if left.Type() == right.Type() {
 			if left.Type() == object.INTEGER_OBJ {
 				return evalIntegerInfix(operator, left, right)
 			} else if left.Type() == object.FLOAT_OBJ {
@@ -98,7 +101,6 @@ func evalInfixExpression(operator string, left, right object.Object) object.Obje
 			}
 		}
 
-		leftOrig, rightOrig := left, right
 		if left.Type() == object.INTEGER_OBJ {
 			left = left.(*object.Integer).ToFloatObj()
 		}
@@ -106,12 +108,7 @@ func evalInfixExpression(operator string, left, right object.Object) object.Obje
 			right = right.(*object.Integer).ToFloatObj()
 		}
 
-		result := evalFloatInfix(operator, left, right)
-
-		if object.IsNumber(result) && leftOrig.Type() == object.INTEGER_OBJ && rightOrig.Type() == object.INTEGER_OBJ {
-			return result.(*object.Float).TryInteger()
-		}
-		return result
+		return evalFloatInfix(operator, left, right)
 	case ((left.Type() == object.STRING_OBJ && right.Type() == object.INTEGER_OBJ) || (right.Type() == object.STRING_OBJ && left.Type() == object.INTEGER_OBJ)) && operator == "*":
 		var stringObj string
 		var intObj int

--- a/object/float.go
+++ b/object/float.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
+	"math"
 	"strconv"
 )
 
@@ -25,7 +26,48 @@ func (f *Float) HashKey() HashKey {
 }
 
 func init() {
-	objectMethods[FLOAT_OBJ] = map[string]ObjectMethod{}
+	objectMethods[FLOAT_OBJ] = map[string]ObjectMethod{
+		"abs": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(FLOAT_OBJ),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				return NewFloat(math.Abs(o.(*Float).Value))
+			},
+		},
+		"ceil": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(FLOAT_OBJ),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				return NewFloat(math.Ceil(o.(*Float).Value))
+			},
+		},
+		"floor": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(FLOAT_OBJ),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				return NewFloat(math.Floor(o.(*Float).Value))
+			},
+		},
+		"round": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(FLOAT_OBJ),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				return NewFloat(math.Round(o.(*Float).Value))
+			},
+		},
+	}
 }
 
 func (f *Float) InvokeMethod(method string, env Environment, args ...Object) Object {

--- a/object/float_test.go
+++ b/object/float_test.go
@@ -29,6 +29,21 @@ func TestFloatObjectMethods(t *testing.T) {
 		{`2.2.nope()`, "test:1:4: undefined method `.nope()` for FLOAT"},
 		{"1.1.to_json()", "1.1"},
 		{"3.123456.to_json()", "3.123456"},
+		// round, ceil, floor and abs preserve the receiver's type, so a
+		// FLOAT stays a FLOAT rather than collapsing to an INTEGER.
+		{`3.14.round()`, 3.0},
+		{`3.14.ceil()`, 4.0},
+		{`3.14.floor()`, 3.0},
+		{`3.14.abs()`, 3.14},
+		{`(0.0 - 3.14).abs()`, 3.14},
+		{`0.0.abs()`, 0.0},
+		// math.Round rounds halves away from zero.
+		{`2.5.round()`, 3.0},
+		{`(0.0 - 2.5).round()`, -3.0},
+		{`(0.0 - 3.7).ceil()`, -3.0},
+		{`(0.0 - 3.2).floor()`, -4.0},
+		// The method form agrees with the Math module form.
+		{`3.14.round().to_s() == Math.round(3.14).to_s()`, true},
 	}
 
 	testInput(t, tests)

--- a/object/integer.go
+++ b/object/integer.go
@@ -36,6 +36,54 @@ func (i *Integer) HashKey() HashKey {
 
 func init() {
 	objectMethods[INTEGER_OBJ] = map[string]ObjectMethod{
+		"abs": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(INTEGER_OBJ),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				i := o.(*Integer)
+				if i.Value < 0 {
+					return NewIntegerWithBase(-i.Value, i.Base)
+				}
+
+				return i
+			},
+		},
+		// round, ceil and floor exist on INTEGER so that numeric code can be
+		// written without first checking which of the two number types it
+		// holds. An integer is already whole, so each returns the receiver.
+		"ceil": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(INTEGER_OBJ),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				return o
+			},
+		},
+		"floor": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(INTEGER_OBJ),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				return o
+			},
+		},
+		"round": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(INTEGER_OBJ),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				return o
+			},
+		},
 		"base": ObjectMethod{
 			Layout: MethodLayout{
 				ReturnPattern: Args(

--- a/object/integer.go
+++ b/object/integer.go
@@ -51,39 +51,6 @@ func init() {
 				return i
 			},
 		},
-		// round, ceil and floor exist on INTEGER so that numeric code can be
-		// written without first checking which of the two number types it
-		// holds. An integer is already whole, so each returns the receiver.
-		"ceil": ObjectMethod{
-			Layout: MethodLayout{
-				ReturnPattern: Args(
-					Arg(INTEGER_OBJ),
-				),
-			},
-			method: func(o Object, _ []Object, _ Environment) Object {
-				return o
-			},
-		},
-		"floor": ObjectMethod{
-			Layout: MethodLayout{
-				ReturnPattern: Args(
-					Arg(INTEGER_OBJ),
-				),
-			},
-			method: func(o Object, _ []Object, _ Environment) Object {
-				return o
-			},
-		},
-		"round": ObjectMethod{
-			Layout: MethodLayout{
-				ReturnPattern: Args(
-					Arg(INTEGER_OBJ),
-				),
-			},
-			method: func(o Object, _ []Object, _ Environment) Object {
-				return o
-			},
-		},
 		"base": ObjectMethod{
 			Layout: MethodLayout{
 				ReturnPattern: Args(

--- a/object/integer_test.go
+++ b/object/integer_test.go
@@ -23,11 +23,6 @@ func testIntegerObject(t *testing.T, obj object.Object, expected int) bool {
 
 func TestIntegerObjectMethods(t *testing.T) {
 	tests := []inputTestCase{
-		// A whole number is already rounded, so round, ceil and floor return
-		// the receiver. They exist so numeric code need not branch on type.
-		{`3.round()`, 3},
-		{`3.ceil()`, 3},
-		{`3.floor()`, 3},
 		{`3.abs()`, 3},
 		{`(0 - 5).abs()`, 5},
 		{`0.abs()`, 0},

--- a/object/integer_test.go
+++ b/object/integer_test.go
@@ -23,6 +23,17 @@ func testIntegerObject(t *testing.T, obj object.Object, expected int) bool {
 
 func TestIntegerObjectMethods(t *testing.T) {
 	tests := []inputTestCase{
+		// A whole number is already rounded, so round, ceil and floor return
+		// the receiver. They exist so numeric code need not branch on type.
+		{`3.round()`, 3},
+		{`3.ceil()`, 3},
+		{`3.floor()`, 3},
+		{`3.abs()`, 3},
+		{`(0 - 5).abs()`, 5},
+		{`0.abs()`, 0},
+		// abs keeps the integer's base.
+		{`"-0x10".to_i().abs().base()`, 16},
+		{`"0x10".to_i().abs().to_s()`, "0x10"},
 		{`2.to_s()`, "2"},
 		{`2.to_f()`, 2.0},
 		{`2.to_i()`, 2},

--- a/object/number_test.go
+++ b/object/number_test.go
@@ -34,8 +34,20 @@ func TestNumberObjects(t *testing.T) {
 		{"0*1", 0},
 
 		{"1/1", 1},
-		{"1/2", 0.5},
+		// Dividing two integers yields an integer, as in Ruby. The result is
+		// truncated toward zero, which keeps it consistent with %, whose sign
+		// follows the dividend.
+		{"1/2", 0},
 		{"2/1", 2},
+		{"5/2", 2},
+		{"4/2", 2},
+		{"0-5", -5},
+		{"(0-5)/2", -2},
+		{"(0-5)%2", -1},
+		// Mixing the two promotes to float.
+		{"4.0/2", 2.0},
+		{"4/2.0", 2.0},
+		{"5/2.0", 2.5},
 
 		// float | float
 		{"1.0 == 1.0", true},


### PR DESCRIPTION
Closes #238. **Breaking** — integer division changes.

Two commits: the methods, then the division change that reshaped them.

## 1. abs, ceil, floor and round

Float had no literal-specific methods, so rounding meant reaching for `Math`. Integer was worse — there was no way to take the absolute value of one at all:

```js
Math.abs(-5)   // ERROR: wrong argument type on position 1: got=INTEGER, want=FLOAT
(-5).abs()     // ERROR: undefined method `.abs()` for INTEGER
```

The methods preserve the receiver's type, so a FLOAT stays a FLOAT:

```js
3.14.round()   // 3.0     3.14.abs()    // 3.14
3.14.ceil()    // 4.0     (0 - 5).abs() // 5
3.14.floor()   // 3.0     (0 - 3.14).abs() // 3.14
```

#238 shows `3.14.round()` giving INTEGER `3`. I went with FLOAT because `Math.round(3.14)` already returns `3.0`, and two spellings of one operation returning different types would be a trap. `to_i` covers the other case; a test asserts the two forms agree.

Float gets all four. **Integer gets only `abs`** — see below.

`abs` keeps the integer's base, so `"-0x10".to_i().abs()` is `0x10`.

## 2. Integer division

Division was the one arithmetic operator excluded from the same-type path, so int/int was computed as a float and demoted back only when the result happened to be whole. That made the *result type depend on the operands' values*:

```js
4 / 2   // 2     (INTEGER)
5 / 2   // 2.5   (FLOAT)
```

Now it follows Ruby:

| | before | after |
|---|---|---|
| `4 / 2` | `2` | `2` |
| `5 / 2` | `2.5` | `2` |
| `4.0 / 2` | `2.0` | `2.0` |
| `4 / 2.0` | `2.0` | `2.0` |
| `5 / 2.0` | `2.5` | `2.5` |

**On negatives:** the quotient truncates toward zero, so `-5 / 2` is `-2`. Ruby floors and would give `-3`. I did not match Ruby there because `%` in this language already takes its sign from the dividend (`-5 % 2` is `-1`, where Ruby gives `1`). Truncating keeps the two operators consistent, so `(a / b) * b + a % b` still returns `a`. Matching Ruby properly means changing `%` too — a separate decision, happy to do it if you want the arithmetic to match end to end.

## Why Integer lost round/ceil/floor

The first commit added them as identities, justified by "numeric code should not have to branch on type" — which was only true *because* `/` returned either type depending on values. With that fixed, the justification is gone and they are three no-op methods, so they are removed. `abs` stays on its own merits.

The demote-back branch in `evalInfixExpression` is now unreachable and removed with them.

## Verified

Every documented example run against a build. Every tracked `.rl` file in the repo produces byte-identical output before and after, checked by md5 against a pre-change binary — the division change does not disturb any existing example. Docs cover the division rule, including the negative case and the `%` interaction; `yarn build` succeeds.