### PR TITLE
fix(string): ascii always returns an array

### DIFF
--- a/docs/docs/literals/string.md
+++ b/docs/docs/literals/string.md
@@ -70,14 +70,16 @@ puts(s)
 ## Literal Specific Methods
 
 ### ascii()
-> Returns `INTEGER|ARRAY`
+> Returns `ARRAY`
 
-Returns the ascii representation of a char or string
+Returns the character codes of the string, always as an array with one entry per character. A single-character string gives a one-element array and an empty string gives an empty array, so the result never has to be checked for its type before use.
 
 
-<CodeBlockSimple input='"a".ascii()
+<CodeBlockSimple input='"".ascii()
+"a".ascii()
 "abc".ascii()
-' output='97
+' output='[]
+[97]
 [97, 98, 99]
 ' />
 

--- a/docs/literals/string.yml
+++ b/docs/literals/string.yml
@@ -61,12 +61,14 @@ example: |
   "te\"st" == 'te"st'
 methods:
   ascii:
-    description: "Returns the ascii representation of a char or string"
+    description: "Returns the character codes of the string, always as an array with one entry per character. A single-character string gives a one-element array and an empty string gives an empty array, so the result never has to be checked for its type before use."
     input: |
+      "".ascii()
       "a".ascii()
       "abc".ascii()
     output: |
-      97
+      []
+      [97]
       [97, 98, 99]
   count:
     description: "Counts how often a given substring occurs in the string."

--- a/object/string.go
+++ b/object/string.go
@@ -249,26 +249,23 @@ func init() {
 		"ascii": ObjectMethod{
 			Layout: MethodLayout{
 				ReturnPattern: Args(
-					Arg(INTEGER_OBJ, ARRAY_OBJ),
+					Arg(ARRAY_OBJ),
 				),
 			},
 			method: func(o Object, _ []Object, _ Environment) Object {
 				s := o.(*String)
-				length := len(s.Value)
-				var result Object
-				switch length {
-				case 0:
-					result = NewInteger(-1)
-				case 1:
-					result = NewInteger(int(s.Value[0]))
-				default:
-					arr := make([]Object, length)
-					for idx, char := range s.Value {
-						arr[idx] = NewInteger(int(char))
-					}
-					result = NewArray(arr)
+
+				// One entry per rune, so ascii().size() matches size() and
+				// reverse(), which both count runes rather than bytes. Sizing
+				// this by len() instead used to leave the trailing slots of a
+				// multi-byte string nil, and Inspect then dereferenced them.
+				runes := []rune(s.Value)
+				arr := make([]Object, len(runes))
+				for idx, char := range runes {
+					arr[idx] = NewInteger(int(char))
 				}
-				return result
+
+				return NewArray(arr)
 			},
 		},
 	}

--- a/object/string_test.go
+++ b/object/string_test.go
@@ -130,9 +130,16 @@ func TestStringObjectMethods(t *testing.T) {
 		{`"test%1.1f".format(1.3)`, "test1.3"},
 		{`"test%s".format("test")`, "testtest"},
 		{`"test%t".format(true)`, "testtrue"},
-		{`"".ascii()`, -1},
-		{`"a".ascii()`, 97},
+		// ascii always returns an ARRAY. It used to return a bare INTEGER for
+		// a one-character string and -1 for an empty one, so callers had to
+		// branch on the length of their own input.
+		{`"".ascii()`, `[]`},
+		{`"a".ascii()`, `[97]`},
 		{`"abc".ascii()`, `[97, 98, 99]`},
+		{`"abc".ascii().size() == "abc".size()`, true},
+		// Sizing the result by byte length left the trailing slots of a
+		// multi-character string nil, which segfaulted on Inspect.
+		{`"\xc3\xa9".ascii().size() == "\xc3\xa9".size()`, true},
 	}
 
 	testInput(t, tests)


### PR DESCRIPTION
Closes #237. **Breaking** — `ascii()` return type changes.

## The issue as filed

`ascii()` returned three different shapes depending on its input, so a caller had to know the length of its own string before it could use the result:

| | before | after |
|---|---|---|
| `"".ascii()` | `-1` | `[]` |
| `"a".ascii()` | `97` | `[97]` |
| `"abc".ascii()` | `[97, 98, 99]` | `[97, 98, 99]` |

## It also segfaulted

Not mentioned in the issue, and worse than the inconsistency. The array was sized with `len()`, a **byte** count, while the loop ranged over **runes** and indexed by rune position. Every trailing slot of a multi-character string stayed a Go `nil`, and `Array.Inspect` then dereferenced it:

```
puts("é".ascii())
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation]
	object.(*Array).Inspect(...) object/array.go:32
```

Any string containing a non-ASCII character crashed the interpreter.

## The fix

Count runes throughout. That matches `size()` and `reverse()`, which both use `utf8.RuneCountInString`, so `s.ascii().size() == s.size()` now holds for any input — asserted by a test.

I first wrote this byte-based, on the theory that the language counts bytes. It does not; I had been misled by a double-encoded test file. Checking `size()`'s implementation rather than inferring from output corrected it.

## Note on multi-byte characters

`"é".ascii()` gives two entries rather than one, because the lexer reads source byte by byte and never combines them into a single rune — `"é".size()` is likewise `2`. That is a separate limitation in the lexer, not something this method can fix, and it is unchanged here. The point is that `ascii()` is now *consistent* with the rest of the string methods rather than crashing.

## Verified

Mutation-checked: reverting the implementation fails 2 of the new assertions. Every tracked `.rl` file produces byte-identical output before and after, by md5 against a pre-change binary. Docs updated with all three cases; `yarn build` succeeds.