### PR TITLE
feat(planet): planets, a package system for RocketLang

### DIFF
--- a/docs/docs/language/modules.md
+++ b/docs/docs/language/modules.md
@@ -23,13 +23,25 @@ end
 ```
 
 `a` and `Private` are both private. Capitalization means nothing — before
-`0.24` an uppercase name was exported automatically, and that rule is gone.
+`0.24` an uppercase name was exported automatically, and that rule is gone. The
+mixed casing above is deliberate: `A` and `lower` are both exported, `Private`
+is not, and nothing about the names decides that.
+
+Since capitalization no longer carries meaning, there is no reason to capitalize
+an exported function. Names that match the language's own methods — `upcase`,
+`to_s`, `include?` — read more naturally:
+
+```js
+export def snake_case(s)
+  return s.replace(" ", "_")
+end
+```
 
 You can also export a name that is already bound:
 
 ```js
-Square = def(x) return x * x end
-export Square
+square = def(x) return x * x end
+export square
 ```
 
 ## Importing
@@ -112,16 +124,16 @@ instead of trying to re-export the module itself:
 
 ```js
 // math.rl
-import "./stats" as Stats
+import "./stats" as stats
 
-export def Sum(a, b) return a + b end
-export def Mean(numbers) return Stats.Mean(numbers) end
+export def sum(a, b) return a + b end
+export def mean(numbers) return stats.mean(numbers) end
 ```
 
 ```js
 import "./math"
-math.Sum(1, 2)          // 3
-math.Mean([1, 2])       // reaches Stats through the wrapper function
+math.sum(1, 2)          // 3
+math.mean([1, 2])       // reaches stats through the wrapper function
 ```
 
 ### Where an import may appear

--- a/docs/docs/language/planets.md
+++ b/docs/docs/language/planets.md
@@ -26,8 +26,8 @@ import "core/stats" as stats
 
 scores = [42, 17, 99, 63]
 
-puts(list.Filter(scores, def(n) return n > 40 end))  // [42, 99, 63]
-puts(stats.Mean(scores))                             // 55.25
+puts(list.filter(scores, def(n) return n > 40 end))  // [42, 99, 63]
+puts(stats.mean(scores))                             // 55.25
 ```
 
 [flipez/rocket-lang-core](https://github.com/flipez/rocket-lang-core) is a
@@ -199,10 +199,13 @@ Export what callers should see, and keep the rest private:
 
 ```js
 // strings.rl
-export def Snake(s)
+export def snake_case(s)
   return s.replace(" ", "_")
 end
 ```
+
+Capitalization carries no meaning — `export` is what decides whether a name is
+public. An unexported `Helper` is private and an exported `helper` is not.
 
 Tag a release:
 

--- a/docs/docs/language/planets.md
+++ b/docs/docs/language/planets.md
@@ -12,26 +12,33 @@ $ rocket-lang planet init
 created planets.yml
 added .planets/ to .gitignore
 
-$ rocket-lang planet get flipez/rocket-lang-utils
-resolved flipez/rocket-lang-utils to v1.1.0
-installed utils v1.1.0 (364d720) to .planets/utils
+$ rocket-lang planet get flipez/rocket-lang-core@main
+installed core main (7441c48) to .planets/core
 recorded in planets.yml
 
-import it with:  import "utils/<module>"
+import it with:  import "core/<module>"
 ```
 
 ```js
-import "utils/strings" as strings
+import "core/list" as list
+import "core/stats" as stats
 
-puts(strings.Snake("hello world"))  // hello_world
+scores = [42, 17, 99, 63]
+
+puts(list.Filter(scores, def(n) return n > 40 end))  // [42, 99, 63]
+puts(stats.Mean(scores))                             // 55.25
 ```
+
+[flipez/rocket-lang-core](https://github.com/flipez/rocket-lang-core) is a
+small planet of generic helpers, and is used as the example throughout this
+page.
 
 ## Sources
 
 A source can be written four ways:
 
 ```
-flipez/rocket-lang-utils          github.com is assumed
+flipez/rocket-lang-core           github.com is assumed
 codeberg.org/flipez/utils         any host, when the first segment has a dot
 https://example.com/utils.git     an explicit git URL
 ../sibling-project                a local path, for a monorepo or a private planet
@@ -40,14 +47,14 @@ https://example.com/utils.git     an explicit git URL
 Add `@<version>` to pin one:
 
 ```
-rocket-lang planet get flipez/rocket-lang-utils@v1.2.0
+rocket-lang planet get flipez/rocket-lang-core@v1.2.0
 ```
 
 ## Names
 
 A planet is imported under an **alias**, which is the key in `planets.yml` and
 the directory name under `.planets/`. It is derived from the source, dropping a
-redundant `rocket-lang-` prefix, so `flipez/rocket-lang-utils` becomes `utils`.
+redundant `rocket-lang-` prefix, so `flipez/rocket-lang-core` becomes `core`.
 
 Choose your own with `--as`:
 
@@ -66,14 +73,14 @@ import "<alias>/<module>"
 ```
 
 The module is a file inside the planet, written **without** the `.rl`
-extension. A planet with `strings.rl` and `math.rl` offers:
+extension. A planet with `list.rl` and `stats.rl` offers:
 
 ```js
-import "utils/strings" as strings
-import "utils/math" as math
+import "core/list" as list
+import "core/stats" as stats
 ```
 
-A planet directory is not importable on its own — `import "utils"` does not
+A planet directory is not importable on its own — `import "core"` does not
 resolve. Imports name a file, as they do everywhere else in the language.
 
 Your own modules always win a name clash: the working directory is searched
@@ -89,10 +96,10 @@ ignoring prereleases, and records both the tag and the commit it resolved to:
 
 ```yaml
 planets:
-  utils:
-    source: flipez/rocket-lang-utils
-    version: v1.1.0
-    commit: 364d7201a12f07ce31a46671b8499535b403894f
+  core:
+    source: flipez/rocket-lang-core
+    version: main
+    commit: 7441c4811ff048ed4e4ee1a1a371ca837f4f52ef
 ```
 
 The commit is what makes an install reproducible. Once recorded, `planet
@@ -127,9 +134,9 @@ Running `get` again on an installed planet reports what is there and changes
 nothing, so a routine `get` can never move a dependency by surprise:
 
 ```
-$ rocket-lang planet get flipez/rocket-lang-utils
-utils is already installed at v1.1.0
-pass an explicit version to change it, for example flipez/rocket-lang-utils@v1.2.3
+$ rocket-lang planet get flipez/rocket-lang-core
+core is already installed at main
+pass an explicit version to change it, for example flipez/rocket-lang-core@v1.2.3
 ```
 
 ## Commands
@@ -147,8 +154,7 @@ correct, so repeated runs are cheap:
 
 ```
 $ rocket-lang planet install
-up to date  helpers v1.1.0
-up to date  utils v1.1.0
+up to date  core main
 ```
 
 `planet list` reports when what is installed disagrees with the manifest.
@@ -158,10 +164,11 @@ up to date  utils v1.1.0
 ```
 planets.yml
 .planets/
-  utils/
+  core/
     .planet          <- what is installed here
+    list.rl
+    stats.rl
     strings.rl
-    math.rl
 main.rl
 ```
 

--- a/docs/docs/language/planets.md
+++ b/docs/docs/language/planets.md
@@ -12,7 +12,8 @@ $ rocket-lang planet init
 created planets.yml
 added .planets/ to .gitignore
 
-$ rocket-lang planet get flipez/rocket-lang-core@main
+$ rocket-lang planet get flipez/rocket-lang-core
+resolved flipez/rocket-lang-core to the main branch; it publishes no version tags
 installed core main (7441c48) to .planets/core
 recorded in planets.yml
 
@@ -117,14 +118,19 @@ rocket-lang planet get flipez/rocket-lang-core@main
 rocket-lang planet get flipez/rocket-lang-core@6daa0cc
 ```
 
-A bare `planet get` still requires tags, because there is no sensible default
-otherwise:
+A bare `planet get` picks the highest version tag when the planet publishes
+any, and otherwise falls back to the planet's default branch, saying so:
 
 ```
 $ rocket-lang planet get flipez/rocket-lang-core
-planet get: https://github.com/flipez/rocket-lang-core publishes no version
-tags; pass an explicit @version
+resolved flipez/rocket-lang-core to the main branch; it publishes no version tags
 ```
+
+A tag always wins over the branch, even when the branch is further ahead — a
+release is a deliberate statement and an untagged commit is not.
+
+The branch name comes from the remote rather than being assumed, so a planet
+whose default branch is `master` or `trunk` works without saying so.
 
 Tracking a branch is not the same as following it: the commit is recorded at
 install time and pinned from then on, so everyone who checks the project out

--- a/docs/docs/language/planets.md
+++ b/docs/docs/language/planets.md
@@ -95,8 +95,33 @@ planets:
     commit: 364d7201a12f07ce31a46671b8499535b403894f
 ```
 
-The commit is what makes an install reproducible, because a tag can be moved
-after the fact.
+The commit is what makes an install reproducible. Once recorded, `planet
+install` checks out **that commit** rather than re-resolving the reference, so a
+tag that is force-moved or a branch that advances cannot change what a checkout
+gets. Only an explicit `planet get <source>@<version>` moves it.
+
+### Branches and commits
+
+A version does not have to be a tag. Any reference git understands works,
+which is useful for a planet that has not tagged a release yet:
+
+```
+rocket-lang planet get flipez/rocket-lang-core@main
+rocket-lang planet get flipez/rocket-lang-core@6daa0cc
+```
+
+A bare `planet get` still requires tags, because there is no sensible default
+otherwise:
+
+```
+$ rocket-lang planet get flipez/rocket-lang-core
+planet get: https://github.com/flipez/rocket-lang-core publishes no version
+tags; pass an explicit @version
+```
+
+Tracking a branch is not the same as following it: the commit is recorded at
+install time and pinned from then on, so everyone who checks the project out
+gets the same code.
 
 Running `get` again on an installed planet reports what is there and changes
 nothing, so a routine `get` can never move a dependency by surprise:

--- a/docs/docs/language/planets.md
+++ b/docs/docs/language/planets.md
@@ -1,0 +1,191 @@
+# Planets
+> 👉 Planets were introduced in `0.25`
+
+A **planet** is a reusable RocketLang library: a git repository of `.rl` files
+that a project pulls in and imports. Planets live in `.planets/` and are
+recorded in `planets.yml`.
+
+## Getting started
+
+```
+$ rocket-lang planet init
+created planets.yml
+added .planets/ to .gitignore
+
+$ rocket-lang planet get flipez/rocket-lang-utils
+resolved flipez/rocket-lang-utils to v1.1.0
+installed utils v1.1.0 (364d720) to .planets/utils
+recorded in planets.yml
+
+import it with:  import "utils/<module>"
+```
+
+```js
+import "utils/strings" as strings
+
+puts(strings.Snake("hello world"))  // hello_world
+```
+
+## Sources
+
+A source can be written four ways:
+
+```
+flipez/rocket-lang-utils          github.com is assumed
+codeberg.org/flipez/utils         any host, when the first segment has a dot
+https://example.com/utils.git     an explicit git URL
+../sibling-project                a local path, for a monorepo or a private planet
+```
+
+Add `@<version>` to pin one:
+
+```
+rocket-lang planet get flipez/rocket-lang-utils@v1.2.0
+```
+
+## Names
+
+A planet is imported under an **alias**, which is the key in `planets.yml` and
+the directory name under `.planets/`. It is derived from the source, dropping a
+redundant `rocket-lang-` prefix, so `flipez/rocket-lang-utils` becomes `utils`.
+
+Choose your own with `--as`:
+
+```
+rocket-lang planet get codeberg.org/flipez/utils --as helpers
+```
+
+An alias has to be usable in an import. `my-lib` is not, because `my-lib.Foo`
+parses as subtraction, so `--as` is required for a source whose name would
+produce one.
+
+## Importing
+
+```js
+import "<alias>/<module>"
+```
+
+The module is a file inside the planet, written **without** the `.rl`
+extension. A planet with `strings.rl` and `math.rl` offers:
+
+```js
+import "utils/strings" as strings
+import "utils/math" as math
+```
+
+A planet directory is not importable on its own — `import "utils"` does not
+resolve. Imports name a file, as they do everywhere else in the language.
+
+Your own modules always win a name clash: the working directory is searched
+before `.planets/`. `planet get` refuses an alias that a local module would
+shadow, so the conflict surfaces at install time rather than as a mystery at
+run time.
+
+## Versions
+
+Versions are git tags read as semver, and always exact — there are no ranges.
+`planet get` without a version picks the highest `major.minor.patch` tag,
+ignoring prereleases, and records both the tag and the commit it resolved to:
+
+```yaml
+planets:
+  utils:
+    source: flipez/rocket-lang-utils
+    version: v1.1.0
+    commit: 364d7201a12f07ce31a46671b8499535b403894f
+```
+
+The commit is what makes an install reproducible, because a tag can be moved
+after the fact.
+
+Running `get` again on an installed planet reports what is there and changes
+nothing, so a routine `get` can never move a dependency by surprise:
+
+```
+$ rocket-lang planet get flipez/rocket-lang-utils
+utils is already installed at v1.1.0
+pass an explicit version to change it, for example flipez/rocket-lang-utils@v1.2.3
+```
+
+## Commands
+
+```
+rocket-lang planet init                       create planets.yml
+rocket-lang planet get <source>[@<version>]   fetch, install and record
+rocket-lang planet install                    install everything the manifest lists
+rocket-lang planet list                       show what this project uses
+rocket-lang planet remove <alias>             delete from disk and the manifest
+```
+
+`planet install` is what a checkout or a CI job runs. It skips anything already
+correct, so repeated runs are cheap:
+
+```
+$ rocket-lang planet install
+up to date  helpers v1.1.0
+up to date  utils v1.1.0
+```
+
+`planet list` reports when what is installed disagrees with the manifest.
+
+## What is on disk
+
+```
+planets.yml
+.planets/
+  utils/
+    .planet          <- what is installed here
+    strings.rl
+    math.rl
+main.rl
+```
+
+`.planet` records the source, version and commit of that directory. It carries
+no timestamp, so it is a pure function of what was installed.
+
+`.planets/` is gitignored by default, and `planet init` adds it to an existing
+`.gitignore`. Commit it instead if you want the tree self-contained — see
+publishing below.
+
+## Publishing a planet
+
+A planet is an ordinary git repository of `.rl` files with semver tags. Nothing
+else is required: no manifest, no registration.
+
+```
+strings.rl
+math.rl
+```
+
+Export what callers should see, and keep the rest private:
+
+```js
+// strings.rl
+export def Snake(s)
+  return s.replace(" ", "_")
+end
+```
+
+Tag a release:
+
+```
+git tag -a v1.0.0 -m v1.0.0 && git push --tags
+```
+
+**If your planet depends on another planet**, install it and commit your own
+`.planets/`, then import it relatively:
+
+```js
+import "./.planets/other/mod" as other
+```
+
+`planet get` clones and does not install recursively, so a dependency that is
+not committed will be missing for anyone who fetches your planet.
+
+## Requirements and limits
+
+- `planet` needs the `git` command on `PATH`.
+- Planets are unavailable in the browser playground: there is no filesystem to
+  install into.
+- Version ranges, a lockfile and automatic transitive dependencies are not
+  implemented.

--- a/docs/docs/language/planets.md
+++ b/docs/docs/language/planets.md
@@ -1,5 +1,5 @@
 # Planets
-> 👉 Planets were introduced in `0.25`
+> 👉 Planets were introduced in `0.24`
 
 A **planet** is a reusable RocketLang library: a git repository of `.rl` files
 that a project pulls in and imports. Planets live in `.planets/` and are

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -1232,3 +1232,30 @@ func TestLoopsReturnNil(t *testing.T) {
 		}
 	}
 }
+
+// TestImportRejectsUnusableImplicitBinding covers a silent failure that
+// predates planets: an implicit binding taken from the path could contain
+// characters that cannot be referenced afterwards. "my-lib" bound fine, but
+// my-lib.X parses as subtraction, so the module was unreachable and the import
+// reported nothing. Planet names routinely contain hyphens, which makes this
+// common rather than exotic.
+func TestImportRejectsUnusableImplicitBinding(t *testing.T) {
+	evaluated := testEval(`import "../fixtures/hyphen-name"`)
+
+	err, ok := evaluated.(*object.Error)
+	if !ok {
+		t.Fatalf("expected an error, got=%T (%+v)", evaluated, evaluated)
+	}
+	if !strings.Contains(err.Message, "cannot bind module as 'hyphen-name'") {
+		t.Errorf("expected the unusable-name error, got=%q", err.Message)
+	}
+	if !strings.Contains(err.Message, "use 'as'") {
+		t.Errorf("the error does not point at the fix: %q", err.Message)
+	}
+}
+
+// TestImportWithAsAcceptsAnyPath is the counterpart: an explicit alias makes a
+// path that cannot supply a usable name importable.
+func TestImportWithAsAcceptsAnyPath(t *testing.T) {
+	testIntegerObject(t, testEval(`import "../fixtures/hyphen-name" as hyphen; hyphen.Value`), 7)
+}

--- a/evaluator/import.go
+++ b/evaluator/import.go
@@ -7,8 +7,10 @@ import (
 	"strings"
 
 	"github.com/flipez/rocket-lang/ast"
+	"github.com/flipez/rocket-lang/lexer"
 	"github.com/flipez/rocket-lang/object"
 	"github.com/flipez/rocket-lang/stdlib"
+	"github.com/flipez/rocket-lang/token"
 	"github.com/flipez/rocket-lang/utilities"
 )
 
@@ -34,6 +36,14 @@ func evalImport(ie *ast.Import, env *object.Environment) object.Object {
 	name := ie.Alias
 	if name == "" {
 		name = filepath.Base(ie.Path)
+
+		// An implicit name comes from the path, which may contain characters
+		// that cannot be referenced afterwards. "my-lib" binds, but my-lib.Foo
+		// parses as subtraction, so the module would be unreachable. Planet
+		// names routinely contain hyphens, which makes this common.
+		if !isUsableBinding(name) {
+			return object.NewErrorFormat("%s:%d:%d: Import Error: cannot bind module as '%s': not a usable name, use 'as' to choose one", ie.Token.File, ie.Token.LineNumber, ie.Token.LinePosition, name)
+		}
 	}
 
 	if cached, ok := reg.Get(filename); ok {
@@ -199,4 +209,18 @@ func exportNames(hash *object.Hash) string {
 	}
 
 	return strings.Join(names, ", ")
+}
+
+// isUsableBinding reports whether name can be written in source and referenced.
+// Rather than restate the lexer's rules, it asks the lexer: a usable name is one
+// that lexes to exactly one identifier and nothing else.
+func isUsableBinding(name string) bool {
+	l := lexer.New(name, "")
+
+	first := l.NextToken()
+	if first.Type != token.IDENT || first.Literal != name {
+		return false
+	}
+
+	return l.NextToken().Type == token.EOF
 }

--- a/fixtures/hyphen-name.rl
+++ b/fixtures/hyphen-name.rl
@@ -1,0 +1,1 @@
+export Value = 7

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -16,12 +17,26 @@ import (
 	"github.com/flipez/rocket-lang/utilities"
 )
 
+// subcommands are matched against the first argument before it is treated as a
+// program file. A file whose name collides with one is reached as ./name, or by
+// giving it the usual .rl extension.
+var subcommands = map[string]func([]string, io.Writer, io.Writer) int{
+	"planet": planet.Command,
+}
+
 func main() {
+	if len(os.Args) > 1 {
+		if run, ok := subcommands[os.Args[1]]; ok {
+			os.Exit(run(os.Args[2:], os.Stdout, os.Stderr))
+		}
+	}
+
 	version := flag.BoolP("version", "v", false, "Prints the version and build date.")
 	exec := flag.StringP("exec", "e", "", "Runs the given code.")
 
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: rocket-lang [flags] [program file] [arguments]\n\nAvailable flags:\n")
+		fmt.Fprintf(os.Stderr, "Usage: rocket-lang [flags] [program file] [arguments]\n")
+		fmt.Fprintf(os.Stderr, "       rocket-lang planet <command>\n\nAvailable flags:\n")
 
 		flag.PrintDefaults()
 	}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	flag "github.com/spf13/pflag"
 
@@ -10,7 +11,9 @@ import (
 	"github.com/flipez/rocket-lang/lexer"
 	"github.com/flipez/rocket-lang/object"
 	"github.com/flipez/rocket-lang/parser"
+	"github.com/flipez/rocket-lang/planet"
 	"github.com/flipez/rocket-lang/repl"
+	"github.com/flipez/rocket-lang/utilities"
 )
 
 func main() {
@@ -24,6 +27,8 @@ func main() {
 	}
 
 	flag.Parse()
+
+	configureSearchPath()
 
 	if *version {
 		print(repl.SplashVersion())
@@ -42,6 +47,32 @@ func main() {
 		if err == nil {
 			runProgram(string(file), os.Args[1])
 		}
+	}
+}
+
+// configureSearchPath appends the current project's planet directory to the
+// module search path. It goes after ROCKETLANGPATH and the working directory,
+// so a project's own modules always win a name clash with an installed planet.
+func configureSearchPath() {
+	utilities.InitSearchPaths()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+
+	root, ok := planet.FindRoot(cwd)
+	if !ok {
+		return
+	}
+
+	planetsDir := filepath.Join(root, planet.DirName)
+	if !utilities.Exists(planetsDir) {
+		return
+	}
+
+	if err := utilities.AddPath(planetsDir); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not add %s to the search path: %s\n", planetsDir, err)
 	}
 }
 

--- a/planet/command.go
+++ b/planet/command.go
@@ -174,10 +174,18 @@ func cmdGet(args []string, out io.Writer) error {
 	}
 
 	if version == "" {
-		if version, err = LatestTag(source.URL); err != nil {
+		isTag := false
+		if version, isTag, err = ResolveVersion(source.URL); err != nil {
 			return err
 		}
-		fmt.Fprintf(out, "resolved %s to %s\n", raw, version)
+
+		if isTag {
+			fmt.Fprintf(out, "resolved %s to %s\n", raw, version)
+		} else {
+			// Worth saying out loud: a branch is not a release, and it will
+			// move. The commit is pinned, so this install stays reproducible.
+			fmt.Fprintf(out, "resolved %s to the %s branch; it publishes no version tags\n", raw, version)
+		}
 	}
 
 	manifest.Planets[alias] = Entry{Source: raw, Version: version}

--- a/planet/command.go
+++ b/planet/command.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	flag "github.com/spf13/pflag"
 )
 
 const usage = `Usage: rocket-lang planet <command> [arguments]
@@ -129,31 +127,29 @@ func ignorePlanetsDir(root string, out io.Writer) error {
 }
 
 func cmdGet(args []string, out io.Writer) error {
-	fs := flag.NewFlagSet("rocket-lang planet get", flag.ContinueOnError)
-	alias := fs.String("as", "", "name to import the planet under")
-
-	if err := fs.Parse(args); err != nil {
+	sources, alias, err := parseGetArgs(args)
+	if err != nil {
 		return err
 	}
 
-	if fs.NArg() != 1 {
-		return fmt.Errorf("expected one source, for example flipez/rocket-lang-utils")
+	if len(sources) != 1 {
+		return fmt.Errorf("expected one source, for example flipez/rocket-lang-core")
 	}
 
-	raw, version, _ := strings.Cut(fs.Arg(0), "@")
+	raw, version, _ := strings.Cut(sources[0], "@")
 
 	source, err := ParseSource(raw)
 	if err != nil {
 		return err
 	}
 
-	if *alias == "" {
-		if *alias, err = DefaultAlias(raw); err != nil {
+	if alias == "" {
+		if alias, err = DefaultAlias(raw); err != nil {
 			return err
 		}
 	}
-	if !IsValidAlias(*alias) {
-		return fmt.Errorf("%q would not be usable in an import; choose a name made of letters, digits and underscores", *alias)
+	if !IsValidAlias(alias) {
+		return fmt.Errorf("%q would not be usable in an import; choose a name made of letters, digits and underscores", alias)
 	}
 
 	manifest, err := currentManifest()
@@ -161,15 +157,15 @@ func cmdGet(args []string, out io.Writer) error {
 		return err
 	}
 
-	if conflict, found := LocalModuleConflict(manifest, *alias); found {
-		return fmt.Errorf("this project already has %s, which would shadow a planet named %q; install it under a different name with --as", conflict, *alias)
+	if conflict, found := LocalModuleConflict(manifest, alias); found {
+		return fmt.Errorf("this project already has %s, which would shadow a planet named %q; install it under a different name with --as", conflict, alias)
 	}
 
 	// A bare get on an installed planet reports and stops, so a routine get can
 	// never silently move a dependency.
-	if existing, ok := manifest.Planets[*alias]; ok && version == "" {
-		if stamp, stamped := ReadStamp(manifest.Dir(*alias)); stamped {
-			fmt.Fprintf(out, "%s is already installed at %s\n", *alias, stamp.Version)
+	if existing, ok := manifest.Planets[alias]; ok && version == "" {
+		if stamp, stamped := ReadStamp(manifest.Dir(alias)); stamped {
+			fmt.Fprintf(out, "%s is already installed at %s\n", alias, stamp.Version)
 			fmt.Fprintf(out, "pass an explicit version to change it, for example %s@%s\n", raw, "v1.2.3")
 			return nil
 		}
@@ -184,24 +180,54 @@ func cmdGet(args []string, out io.Writer) error {
 		fmt.Fprintf(out, "resolved %s to %s\n", raw, version)
 	}
 
-	manifest.Planets[*alias] = Entry{Source: raw, Version: version}
+	manifest.Planets[alias] = Entry{Source: raw, Version: version}
 
-	commit, err := Install(manifest, *alias, out)
+	commit, err := Install(manifest, alias, out)
 	if err != nil {
-		delete(manifest.Planets, *alias)
+		delete(manifest.Planets, alias)
 		return err
 	}
 
-	manifest.Planets[*alias] = Entry{Source: raw, Version: version, Commit: commit}
+	manifest.Planets[alias] = Entry{Source: raw, Version: version, Commit: commit}
 
 	if err := manifest.Save(); err != nil {
 		return err
 	}
 
 	fmt.Fprintf(out, "recorded in %s\n", ManifestName)
-	fmt.Fprintf(out, "\nimport it with:  import \"%s/<module>\"\n", *alias)
+	fmt.Fprintf(out, "\nimport it with:  import \"%s/<module>\"\n", alias)
 
 	return nil
+}
+
+// parseGetArgs reads `get` arguments. It is hand-rolled rather than using
+// flag.FlagSet because the standard library stops parsing flags at the first
+// positional argument, which would make `get <source> --as name` fail -- and
+// that reads more naturally than putting the flag first.
+func parseGetArgs(args []string) (sources []string, alias string, err error) {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+
+		switch {
+		case arg == "--as", arg == "-as":
+			if i+1 >= len(args) {
+				return nil, "", fmt.Errorf("--as needs a name")
+			}
+			alias = args[i+1]
+			i++
+
+		case strings.HasPrefix(arg, "--as="):
+			alias = strings.TrimPrefix(arg, "--as=")
+
+		case strings.HasPrefix(arg, "-"):
+			return nil, "", fmt.Errorf("unknown option %q", arg)
+
+		default:
+			sources = append(sources, arg)
+		}
+	}
+
+	return sources, alias, nil
 }
 
 func cmdInstall(out io.Writer) error {

--- a/planet/command.go
+++ b/planet/command.go
@@ -1,0 +1,279 @@
+//go:build !wasm
+
+package planet
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	flag "github.com/spf13/pflag"
+)
+
+const usage = `Usage: rocket-lang planet <command> [arguments]
+
+Commands:
+  init                        create %s in the current directory
+  get <source>[@<version>]    fetch a planet, install it and record it
+  install                     install every planet the manifest lists
+  list                        show what this project uses
+  remove <alias>              delete a planet from disk and the manifest
+
+A source is owner/name (GitHub by default), host/owner/name, a git URL or a
+local path:
+
+  rocket-lang planet get flipez/rocket-lang-utils
+  rocket-lang planet get flipez/rocket-lang-utils@v1.2.0
+  rocket-lang planet get codeberg.org/flipez/utils --as helpers
+`
+
+// Command runs the planet subcommand. It returns a process exit code rather
+// than exiting, so it stays testable.
+func Command(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintf(stderr, usage, ManifestName)
+		return 2
+	}
+
+	verb, rest := args[0], args[1:]
+
+	var err error
+	switch verb {
+	case "init":
+		err = cmdInit(stdout)
+	case "get":
+		err = cmdGet(rest, stdout)
+	case "install":
+		err = cmdInstall(stdout)
+	case "list":
+		err = cmdList(stdout)
+	case "remove":
+		err = cmdRemove(rest, stdout)
+	case "help", "--help", "-h":
+		fmt.Fprintf(stdout, usage, ManifestName)
+		return 0
+	default:
+		fmt.Fprintf(stderr, "unknown planet command %q\n\n", verb)
+		fmt.Fprintf(stderr, usage, ManifestName)
+		return 2
+	}
+
+	if err != nil {
+		fmt.Fprintf(stderr, "planet %s: %s\n", verb, err)
+		return 1
+	}
+
+	return 0
+}
+
+func cmdInit(out io.Writer) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	path := filepath.Join(cwd, ManifestName)
+	if _, err := os.Stat(path); err == nil {
+		return fmt.Errorf("%s already exists", ManifestName)
+	}
+
+	manifest := New(cwd)
+	if err := manifest.Save(); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "created %s\n", ManifestName)
+
+	if err := ignorePlanetsDir(cwd, out); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ignorePlanetsDir adds the planet directory to an existing .gitignore.
+// Consumers are expected to ignore it and run planet install; an author who
+// vendors dependencies inside their own planet overrides that deliberately.
+func ignorePlanetsDir(root string, out io.Writer) error {
+	path := filepath.Join(root, ".gitignore")
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		// No .gitignore to amend. Creating one is more presumptuous than
+		// leaving it alone, so say what to do instead.
+		fmt.Fprintf(out, "note: add %s/ to .gitignore, or commit it to vendor your planets\n", DirName)
+		return nil
+	}
+
+	for _, line := range strings.Split(string(content), "\n") {
+		if strings.TrimSpace(strings.TrimSuffix(line, "/")) == DirName {
+			return nil
+		}
+	}
+
+	amended := string(content)
+	if !strings.HasSuffix(amended, "\n") {
+		amended += "\n"
+	}
+	amended += DirName + "/\n"
+
+	if err := os.WriteFile(path, []byte(amended), 0o644); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "added %s/ to .gitignore\n", DirName)
+
+	return nil
+}
+
+func cmdGet(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("rocket-lang planet get", flag.ContinueOnError)
+	alias := fs.String("as", "", "name to import the planet under")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if fs.NArg() != 1 {
+		return fmt.Errorf("expected one source, for example flipez/rocket-lang-utils")
+	}
+
+	raw, version, _ := strings.Cut(fs.Arg(0), "@")
+
+	source, err := ParseSource(raw)
+	if err != nil {
+		return err
+	}
+
+	if *alias == "" {
+		if *alias, err = DefaultAlias(raw); err != nil {
+			return err
+		}
+	}
+	if !IsValidAlias(*alias) {
+		return fmt.Errorf("%q would not be usable in an import; choose a name made of letters, digits and underscores", *alias)
+	}
+
+	manifest, err := currentManifest()
+	if err != nil {
+		return err
+	}
+
+	if conflict, found := LocalModuleConflict(manifest, *alias); found {
+		return fmt.Errorf("this project already has %s, which would shadow a planet named %q; install it under a different name with --as", conflict, *alias)
+	}
+
+	// A bare get on an installed planet reports and stops, so a routine get can
+	// never silently move a dependency.
+	if existing, ok := manifest.Planets[*alias]; ok && version == "" {
+		if stamp, stamped := ReadStamp(manifest.Dir(*alias)); stamped {
+			fmt.Fprintf(out, "%s is already installed at %s\n", *alias, stamp.Version)
+			fmt.Fprintf(out, "pass an explicit version to change it, for example %s@%s\n", raw, "v1.2.3")
+			return nil
+		}
+
+		version = existing.Version
+	}
+
+	if version == "" {
+		if version, err = LatestTag(source.URL); err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "resolved %s to %s\n", raw, version)
+	}
+
+	manifest.Planets[*alias] = Entry{Source: raw, Version: version}
+
+	commit, err := Install(manifest, *alias, out)
+	if err != nil {
+		delete(manifest.Planets, *alias)
+		return err
+	}
+
+	manifest.Planets[*alias] = Entry{Source: raw, Version: version, Commit: commit}
+
+	if err := manifest.Save(); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "recorded in %s\n", ManifestName)
+	fmt.Fprintf(out, "\nimport it with:  import \"%s/<module>\"\n", *alias)
+
+	return nil
+}
+
+func cmdInstall(out io.Writer) error {
+	manifest, err := currentManifest()
+	if err != nil {
+		return err
+	}
+
+	return InstallAll(manifest, out)
+}
+
+func cmdList(out io.Writer) error {
+	manifest, err := currentManifest()
+	if err != nil {
+		return err
+	}
+
+	aliases := manifest.Aliases()
+	if len(aliases) == 0 {
+		fmt.Fprintf(out, "no planets in %s\n", ManifestName)
+		return nil
+	}
+
+	width := 0
+	for _, alias := range aliases {
+		if len(alias) > width {
+			width = len(alias)
+		}
+	}
+
+	for _, alias := range aliases {
+		entry := manifest.Planets[alias]
+
+		state := "not installed"
+		if stamp, ok := ReadStamp(manifest.Dir(alias)); ok {
+			switch {
+			case stamp.Matches(entry):
+				state = "installed"
+			default:
+				state = fmt.Sprintf("installed %s, manifest says %s", stamp.Version, entry.Version)
+			}
+		}
+
+		fmt.Fprintf(out, "%-*s  %-10s  %s  (%s)\n", width, alias, entry.Version, entry.Source, state)
+	}
+
+	return nil
+}
+
+func cmdRemove(args []string, out io.Writer) error {
+	if len(args) != 1 {
+		return fmt.Errorf("expected one planet name")
+	}
+
+	manifest, err := currentManifest()
+	if err != nil {
+		return err
+	}
+
+	return Remove(manifest, args[0], out)
+}
+
+func currentManifest() (*Manifest, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	manifest, err := Load(cwd)
+	if err != nil {
+		return nil, fmt.Errorf("%w\nrun `rocket-lang planet init` to start one", err)
+	}
+
+	return manifest, nil
+}

--- a/planet/command_test.go
+++ b/planet/command_test.go
@@ -1,0 +1,222 @@
+//go:build !wasm
+
+package planet
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// inProject runs Command with the working directory set to a fresh project, and
+// returns the exit code with everything written to stdout and stderr.
+func inProject(t *testing.T, dir string, args ...string) (int, string) {
+	t.Helper()
+
+	t.Chdir(dir)
+
+	var out strings.Builder
+	code := Command(args, &out, &out)
+
+	return code, out.String()
+}
+
+func TestCommandInitCreatesTheManifest(t *testing.T) {
+	dir := t.TempDir()
+
+	code, out := inProject(t, dir, "init")
+	if code != 0 {
+		t.Fatalf("init exited %d: %s", code, out)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, ManifestName)); err != nil {
+		t.Errorf("init did not create %s", ManifestName)
+	}
+
+	// A second init must refuse rather than overwrite a manifest with entries.
+	code, out = inProject(t, dir, "init")
+	if code == 0 {
+		t.Errorf("a second init succeeded: %s", out)
+	}
+}
+
+func TestCommandInitAmendsAnExistingGitignore(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("build/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if code, out := inProject(t, dir, "init"); code != 0 {
+		t.Fatalf("init exited %d: %s", code, out)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(content), DirName+"/") {
+		t.Errorf(".gitignore = %q, want it to mention %s/", content, DirName)
+	}
+	if !strings.Contains(string(content), "build/") {
+		t.Error("init clobbered the existing .gitignore content")
+	}
+
+	// Running init elsewhere must not duplicate the entry when re-run; check
+	// idempotency of the amend by calling the helper directly.
+	if err := ignorePlanetsDir(dir, &strings.Builder{}); err != nil {
+		t.Fatal(err)
+	}
+	content, _ = os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if strings.Count(string(content), DirName+"/") != 1 {
+		t.Errorf(".gitignore has the entry %d times, want 1", strings.Count(string(content), DirName+"/"))
+	}
+}
+
+func TestCommandGetInstallsAndRecords(t *testing.T) {
+	repo := newRepo(t, "v1.0.0", "v2.0.0")
+	dir := t.TempDir()
+
+	if code, out := inProject(t, dir, "init"); code != 0 {
+		t.Fatalf("init exited %d: %s", code, out)
+	}
+
+	code, out := inProject(t, dir, "get", repo, "--as", "utils")
+	if code != 0 {
+		t.Fatalf("get exited %d: %s", code, out)
+	}
+
+	// No version was given, so the highest tag should have been chosen.
+	if !strings.Contains(out, "v2.0.0") {
+		t.Errorf("get did not resolve to v2.0.0: %s", out)
+	}
+
+	manifest, err := LoadFrom(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := manifest.Planets["utils"]
+	if entry.Version != "v2.0.0" || entry.Commit == "" {
+		t.Errorf("manifest entry = %+v, want v2.0.0 with a commit", entry)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, DirName, "utils", "mod.rl")); err != nil {
+		t.Errorf("planet content missing: %s", err)
+	}
+}
+
+func TestCommandGetIsIdempotentWithoutAVersion(t *testing.T) {
+	repo := newRepo(t, "v1.0.0", "v2.0.0")
+	dir := t.TempDir()
+
+	inProject(t, dir, "init")
+	inProject(t, dir, "get", repo, "--as", "utils")
+
+	// Pin to the older tag, then a bare get must report rather than upgrade.
+	manifest, _ := LoadFrom(dir)
+	manifest.Planets["utils"] = Entry{Source: repo, Version: "v1.0.0"}
+	if err := manifest.Save(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Install(manifest, "utils", &strings.Builder{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := manifest.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	code, out := inProject(t, dir, "get", repo, "--as", "utils")
+	if code != 0 {
+		t.Fatalf("get exited %d: %s", code, out)
+	}
+	if !strings.Contains(out, "already installed at v1.0.0") {
+		t.Errorf("a bare get did not report the installed version: %s", out)
+	}
+
+	reloaded, _ := LoadFrom(dir)
+	if reloaded.Planets["utils"].Version != "v1.0.0" {
+		t.Errorf("a bare get moved the pinned version to %q", reloaded.Planets["utils"].Version)
+	}
+}
+
+func TestCommandGetRefusesAShadowingAlias(t *testing.T) {
+	repo := newRepo(t, "v1.0.0")
+	dir := t.TempDir()
+
+	inProject(t, dir, "init")
+	if err := os.WriteFile(filepath.Join(dir, "utils.rl"), []byte("export X = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, out := inProject(t, dir, "get", repo, "--as", "utils")
+	if code == 0 {
+		t.Fatalf("get succeeded despite a local utils.rl: %s", out)
+	}
+	if !strings.Contains(out, "shadow") {
+		t.Errorf("the error did not explain the shadowing: %s", out)
+	}
+}
+
+func TestCommandGetRefusesAnUnusableAlias(t *testing.T) {
+	repo := newRepo(t, "v1.0.0")
+	dir := t.TempDir()
+
+	inProject(t, dir, "init")
+
+	code, out := inProject(t, dir, "get", repo, "--as", "my-lib")
+	if code == 0 {
+		t.Fatalf("get accepted an alias that cannot be imported: %s", out)
+	}
+}
+
+func TestCommandListAndRemove(t *testing.T) {
+	repo := newRepo(t, "v1.0.0")
+	dir := t.TempDir()
+
+	inProject(t, dir, "init")
+	inProject(t, dir, "get", repo, "--as", "utils")
+
+	code, out := inProject(t, dir, "list")
+	if code != 0 {
+		t.Fatalf("list exited %d: %s", code, out)
+	}
+	if !strings.Contains(out, "utils") || !strings.Contains(out, "installed") {
+		t.Errorf("list output = %q", out)
+	}
+
+	if code, out = inProject(t, dir, "remove", "utils"); code != 0 {
+		t.Fatalf("remove exited %d: %s", code, out)
+	}
+
+	manifest, _ := LoadFrom(dir)
+	if len(manifest.Planets) != 0 {
+		t.Error("remove left the manifest entry behind")
+	}
+
+	code, out = inProject(t, dir, "list")
+	if code != 0 || !strings.Contains(out, "no planets") {
+		t.Errorf("list after remove: code %d, output %q", code, out)
+	}
+}
+
+func TestCommandExitCodes(t *testing.T) {
+	dir := t.TempDir()
+
+	tests := []struct {
+		args []string
+		want int
+	}{
+		{nil, 2},                // no verb prints usage
+		{[]string{"nope"}, 2},   // unknown verb
+		{[]string{"help"}, 0},   // help is a success
+		{[]string{"list"}, 1},   // outside a project
+		{[]string{"get"}, 1},    // missing source
+		{[]string{"remove"}, 1}, // missing name
+	}
+
+	for _, tt := range tests {
+		if code, out := inProject(t, dir, tt.args...); code != tt.want {
+			t.Errorf("planet %v exited %d, want %d: %s", tt.args, code, tt.want, out)
+		}
+	}
+}

--- a/planet/command_wasm.go
+++ b/planet/command_wasm.go
@@ -1,0 +1,16 @@
+//go:build wasm
+
+package planet
+
+import (
+	"fmt"
+	"io"
+)
+
+// Command is unavailable under wasm: there is no filesystem to install into and
+// no process to run git in. Imports do not resolve there either.
+func Command(_ []string, _ io.Writer, stderr io.Writer) int {
+	fmt.Fprintln(stderr, "planet is not available in this build")
+
+	return 2
+}

--- a/planet/git.go
+++ b/planet/git.go
@@ -88,7 +88,9 @@ func Tags(url string) ([]string, error) {
 	return tags, nil
 }
 
-// LatestTag returns the highest semver tag a remote publishes.
+// LatestTag returns the highest semver tag a remote publishes, or an empty
+// string when it publishes none. That is not an error: a planet that has not
+// tagged a release yet is still usable through its default branch.
 func LatestTag(url string) (string, error) {
 	tags, err := Tags(url)
 	if err != nil {
@@ -96,10 +98,61 @@ func LatestTag(url string) (string, error) {
 	}
 
 	if len(tags) == 0 {
-		return "", fmt.Errorf("%s publishes no version tags; pass an explicit @version", url)
+		return "", nil
 	}
 
 	return tags[len(tags)-1], nil
+}
+
+// DefaultBranch asks the remote which branch its HEAD points at. The answer is
+// read from the remote rather than assumed to be "main", since plenty of
+// repositories use master, trunk or something else entirely.
+func DefaultBranch(url string) (string, error) {
+	if err := requireGit(); err != nil {
+		return "", err
+	}
+
+	out, err := git("", "ls-remote", "--symref", url, "HEAD")
+	if err != nil {
+		return "", err
+	}
+
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.HasPrefix(line, "ref:") {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		if branch := strings.TrimPrefix(fields[1], "refs/heads/"); branch != "" {
+			return branch, nil
+		}
+	}
+
+	return "", fmt.Errorf("%s does not report a default branch", url)
+}
+
+// ResolveVersion picks what to install when no version was asked for: the
+// highest semver tag if the planet publishes any, otherwise its default branch.
+// isTag says which, so a caller can point out that it settled for a branch.
+func ResolveVersion(url string) (version string, isTag bool, err error) {
+	tag, err := LatestTag(url)
+	if err != nil {
+		return "", false, err
+	}
+	if tag != "" {
+		return tag, true, nil
+	}
+
+	branch, err := DefaultBranch(url)
+	if err != nil {
+		return "", false, err
+	}
+
+	return branch, false, nil
 }
 
 // Checkout clones url into dest and checks out ref, which may be a tag, a

--- a/planet/git.go
+++ b/planet/git.go
@@ -1,0 +1,177 @@
+//go:build !wasm
+
+package planet
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// requireGit reports a usable git binary, or explains what is missing. This is
+// the only external process the interpreter depends on.
+func requireGit() error {
+	if _, err := exec.LookPath("git"); err != nil {
+		return fmt.Errorf("planet needs the `git` command, which was not found on PATH")
+	}
+
+	return nil
+}
+
+func git(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+
+	out, err := cmd.Output()
+	if err != nil {
+		message := strings.TrimSpace(stderr.String())
+		if message == "" {
+			message = err.Error()
+		}
+
+		return "", fmt.Errorf("git %s: %s", strings.Join(args, " "), message)
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}
+
+// Tags returns the semver-looking tags a remote publishes, highest last. Tags
+// that do not parse as a version are ignored rather than rejected, since
+// repositories carry all sorts of tags.
+func Tags(url string) ([]string, error) {
+	if err := requireGit(); err != nil {
+		return nil, err
+	}
+
+	out, err := git("", "ls-remote", "--tags", url)
+	if err != nil {
+		return nil, err
+	}
+
+	var tags []string
+	seen := map[string]bool{}
+
+	for _, line := range strings.Split(out, "\n") {
+		_, ref, found := strings.Cut(line, "\t")
+		if !found {
+			continue
+		}
+
+		// Annotated tags also appear as refs/tags/x^{}; both name one version.
+		name := strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(ref), "refs/tags/"), "^{}")
+		if name == "" || seen[name] {
+			continue
+		}
+
+		if _, ok := parseVersion(name); !ok {
+			continue
+		}
+
+		seen[name] = true
+		tags = append(tags, name)
+	}
+
+	sort.Slice(tags, func(i, j int) bool {
+		a, _ := parseVersion(tags[i])
+		b, _ := parseVersion(tags[j])
+
+		return a.less(b)
+	})
+
+	return tags, nil
+}
+
+// LatestTag returns the highest semver tag a remote publishes.
+func LatestTag(url string) (string, error) {
+	tags, err := Tags(url)
+	if err != nil {
+		return "", err
+	}
+
+	if len(tags) == 0 {
+		return "", fmt.Errorf("%s publishes no version tags; pass an explicit @version", url)
+	}
+
+	return tags[len(tags)-1], nil
+}
+
+// Checkout clones url at tag into dest and returns the resolved commit.
+//
+// --depth 1 is deliberately not used: shallow fetching is unsupported over
+// git's dumb HTTP protocol, which is what lets a plain static file server act
+// as a planet mirror. Planet repositories are small enough that a full clone
+// costs little.
+func Checkout(url, tag, dest string) (string, error) {
+	if err := requireGit(); err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return "", err
+	}
+
+	if _, err := git("", "clone", "--quiet", "--branch", tag, url, dest); err != nil {
+		return "", err
+	}
+
+	commit, err := git(dest, "rev-parse", "HEAD")
+	if err != nil {
+		return "", err
+	}
+
+	// Provenance lives in the stamp file, so the history is not kept.
+	if err := os.RemoveAll(filepath.Join(dest, ".git")); err != nil {
+		return "", err
+	}
+
+	return commit, nil
+}
+
+type version struct{ major, minor, patch int }
+
+func (a version) less(b version) bool {
+	if a.major != b.major {
+		return a.major < b.major
+	}
+	if a.minor != b.minor {
+		return a.minor < b.minor
+	}
+
+	return a.patch < b.patch
+}
+
+// parseVersion reads a v-prefixed or bare major.minor.patch tag. Anything with
+// a prerelease or build suffix is rejected, so `planet get` without a version
+// never selects a release candidate by accident.
+func parseVersion(tag string) (version, bool) {
+	parts := strings.Split(strings.TrimPrefix(tag, "v"), ".")
+	if len(parts) != 3 {
+		return version{}, false
+	}
+
+	var parsed version
+	for i, part := range parts {
+		n, err := strconv.Atoi(part)
+		if err != nil || n < 0 {
+			return version{}, false
+		}
+
+		switch i {
+		case 0:
+			parsed.major = n
+		case 1:
+			parsed.minor = n
+		case 2:
+			parsed.patch = n
+		}
+	}
+
+	return parsed, true
+}

--- a/planet/git.go
+++ b/planet/git.go
@@ -102,13 +102,15 @@ func LatestTag(url string) (string, error) {
 	return tags[len(tags)-1], nil
 }
 
-// Checkout clones url at tag into dest and returns the resolved commit.
+// Checkout clones url into dest and checks out ref, which may be a tag, a
+// branch or a commit. It returns the resolved commit.
 //
-// --depth 1 is deliberately not used: shallow fetching is unsupported over
-// git's dumb HTTP protocol, which is what lets a plain static file server act
-// as a planet mirror. Planet repositories are small enough that a full clone
-// costs little.
-func Checkout(url, tag, dest string) (string, error) {
+// The clone is not shallow, and deliberately so on two counts. Shallow
+// fetching is unsupported over git's dumb HTTP protocol, which is what lets a
+// plain static file server act as a planet mirror; and a full clone is what
+// makes checking out a recorded commit possible, which is how an install is
+// pinned against a moved tag or a branch that has advanced.
+func Checkout(url, ref, dest string) (string, error) {
 	if err := requireGit(); err != nil {
 		return "", err
 	}
@@ -117,7 +119,11 @@ func Checkout(url, tag, dest string) (string, error) {
 		return "", err
 	}
 
-	if _, err := git("", "clone", "--quiet", "--branch", tag, url, dest); err != nil {
+	if _, err := git("", "clone", "--quiet", url, dest); err != nil {
+		return "", err
+	}
+
+	if _, err := git(dest, "checkout", "--quiet", ref); err != nil {
 		return "", err
 	}
 

--- a/planet/git.go
+++ b/planet/git.go
@@ -105,11 +105,17 @@ func LatestTag(url string) (string, error) {
 // Checkout clones url into dest and checks out ref, which may be a tag, a
 // branch or a commit. It returns the resolved commit.
 //
-// The clone is not shallow, and deliberately so on two counts. Shallow
-// fetching is unsupported over git's dumb HTTP protocol, which is what lets a
-// plain static file server act as a planet mirror; and a full clone is what
-// makes checking out a recorded commit possible, which is how an install is
-// pinned against a moved tag or a branch that has advanced.
+// The clone is deliberately not shallow. A full clone is what lets an arbitrary
+// recorded commit be checked out, which is how an install is pinned against a
+// moved tag or a branch that has advanced. Fetching a single commit shallowly
+// is possible, but only when the server sets uploadpack.allowReachableSHA1InWant
+// -- GitHub does, a self-hosted Gitea may not -- so it would need a full-clone
+// fallback anyway.
+//
+// The cost is small for the libraries planets tend to be: cloning a two-commit
+// repository takes the same time either way, because network latency dominates.
+// Shallow only pays on a repository with real history, which is worth revisiting
+// if that becomes common.
 func Checkout(url, ref, dest string) (string, error) {
 	if err := requireGit(); err != nil {
 		return "", err

--- a/planet/git_test.go
+++ b/planet/git_test.go
@@ -1,0 +1,152 @@
+//go:build !wasm
+
+package planet
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// newRepo builds a real git repository with the given tags, so the git layer is
+// exercised against git itself rather than a mock, without touching a network.
+func newRepo(t *testing.T, tags ...string) string {
+	t.Helper()
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not available")
+	}
+
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %s", args, out)
+		}
+	}
+
+	run("init", "--quiet", "--initial-branch", "main")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "test")
+
+	for i, tag := range tags {
+		name := filepath.Join(dir, "mod.rl")
+		if err := os.WriteFile(name, []byte("export V = "+string(rune('0'+i))+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		run("add", "mod.rl")
+		run("commit", "--quiet", "-m", tag)
+		run("tag", "-a", tag, "-m", tag)
+	}
+
+	return dir
+}
+
+func TestTagsFiltersAndOrders(t *testing.T) {
+	// Deliberately out of order, with tags that are not versions at all.
+	repo := newRepo(t, "v1.0.0", "v1.10.0", "v1.2.0", "nightly", "v2.0.0", "v1.2.3-rc1")
+
+	tags, err := Tags(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"v1.0.0", "v1.2.0", "v1.10.0", "v2.0.0"}
+	if len(tags) != len(want) {
+		t.Fatalf("Tags() = %v, want %v", tags, want)
+	}
+	for i := range want {
+		if tags[i] != want[i] {
+			t.Fatalf("Tags() = %v, want %v", tags, want)
+		}
+	}
+}
+
+func TestLatestTagIsHighestNotNewest(t *testing.T) {
+	// v1.10.0 is committed after v2.0.0, so anything ordering by date or by
+	// string would pick the wrong one.
+	repo := newRepo(t, "v2.0.0", "v1.10.0")
+
+	latest, err := LatestTag(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if latest != "v2.0.0" {
+		t.Errorf("LatestTag() = %q, want v2.0.0", latest)
+	}
+}
+
+func TestLatestTagWithoutVersionTags(t *testing.T) {
+	repo := newRepo(t, "nightly")
+
+	if _, err := LatestTag(repo); err == nil {
+		t.Error("LatestTag succeeded on a repo with no version tags")
+	}
+}
+
+func TestCheckoutReturnsCommitAndDropsHistory(t *testing.T) {
+	repo := newRepo(t, "v1.0.0", "v2.0.0")
+	dest := filepath.Join(t.TempDir(), "utils")
+
+	commit, err := Checkout(repo, "v1.0.0", dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(commit) != 40 {
+		t.Errorf("commit = %q, want a 40-character sha", commit)
+	}
+
+	if _, err := os.Stat(filepath.Join(dest, "mod.rl")); err != nil {
+		t.Errorf("checkout is missing mod.rl: %s", err)
+	}
+
+	// History is not kept; the stamp file records provenance instead.
+	if _, err := os.Stat(filepath.Join(dest, ".git")); !os.IsNotExist(err) {
+		t.Error(".git survived the checkout")
+	}
+
+	// v1.0.0 wrote V = 0 and v2.0.0 wrote V = 1, so the content proves the
+	// requested tag was checked out rather than the default branch.
+	content, err := os.ReadFile(filepath.Join(dest, "mod.rl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "export V = 0\n" {
+		t.Errorf("checked out %q, want the v1.0.0 content", content)
+	}
+}
+
+func TestCheckoutRejectsUnknownTag(t *testing.T) {
+	repo := newRepo(t, "v1.0.0")
+
+	if _, err := Checkout(repo, "v9.9.9", filepath.Join(t.TempDir(), "x")); err == nil {
+		t.Error("Checkout succeeded for a tag that does not exist")
+	}
+}
+
+func TestParseVersion(t *testing.T) {
+	ok := map[string]version{
+		"v1.2.3": {1, 2, 3},
+		"1.2.3":  {1, 2, 3},
+		"v0.0.0": {0, 0, 0},
+	}
+	for tag, want := range ok {
+		got, valid := parseVersion(tag)
+		if !valid || got != want {
+			t.Errorf("parseVersion(%q) = %+v, %v", tag, got, valid)
+		}
+	}
+
+	// Prereleases are rejected so a bare `planet get` never selects one.
+	for _, tag := range []string{"", "v1", "v1.2", "v1.2.3.4", "v1.2.x", "nightly", "v1.2.3-rc1", "v-1.2.3"} {
+		if _, valid := parseVersion(tag); valid {
+			t.Errorf("parseVersion(%q) accepted it", tag)
+		}
+	}
+}

--- a/planet/git_test.go
+++ b/planet/git_test.go
@@ -14,6 +14,15 @@ import (
 func newRepo(t *testing.T, tags ...string) string {
 	t.Helper()
 
+	return newRepoOnBranch(t, "main", tags...)
+}
+
+// newRepoOnBranch builds a real git repository whose default branch is named
+// branch, so the default-branch lookup is tested against something other than
+// main.
+func newRepoOnBranch(t *testing.T, branch string, tags ...string) string {
+	t.Helper()
+
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git is not available")
 	}
@@ -29,7 +38,7 @@ func newRepo(t *testing.T, tags ...string) string {
 		}
 	}
 
-	run("init", "--quiet", "--initial-branch", "main")
+	run("init", "--quiet", "--initial-branch", branch)
 	run("config", "user.email", "test@example.com")
 	run("config", "user.name", "test")
 
@@ -81,11 +90,57 @@ func TestLatestTagIsHighestNotNewest(t *testing.T) {
 	}
 }
 
+// TestLatestTagWithoutVersionTags: no tags is not an error. A planet that has
+// not tagged a release is still usable through its default branch, so the empty
+// answer lets ResolveVersion fall back rather than failing the install.
 func TestLatestTagWithoutVersionTags(t *testing.T) {
 	repo := newRepo(t, "nightly")
 
-	if _, err := LatestTag(repo); err == nil {
-		t.Error("LatestTag succeeded on a repo with no version tags")
+	tag, err := LatestTag(repo)
+	if err != nil {
+		t.Fatalf("LatestTag errored on a repo with no version tags: %s", err)
+	}
+	if tag != "" {
+		t.Errorf("LatestTag() = %q, want an empty string", tag)
+	}
+}
+
+// TestDefaultBranchIsReadFromTheRemote covers not hardcoding "main": the branch
+// name is whatever the remote says its HEAD points at.
+func TestDefaultBranchIsReadFromTheRemote(t *testing.T) {
+	repo := newRepoOnBranch(t, "trunk", "v1.0.0")
+
+	branch, err := DefaultBranch(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if branch != "trunk" {
+		t.Errorf("DefaultBranch() = %q, want trunk", branch)
+	}
+}
+
+func TestResolveVersionPrefersATag(t *testing.T) {
+	repo := newRepo(t, "v1.0.0", "v2.0.0")
+
+	version, isTag, err := ResolveVersion(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != "v2.0.0" || !isTag {
+		t.Errorf("ResolveVersion() = %q, isTag %v; want v2.0.0, true", version, isTag)
+	}
+}
+
+func TestResolveVersionFallsBackToTheDefaultBranch(t *testing.T) {
+	// Tagged, but not with anything that parses as a version.
+	repo := newRepoOnBranch(t, "trunk", "nightly")
+
+	version, isTag, err := ResolveVersion(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != "trunk" || isTag {
+		t.Errorf("ResolveVersion() = %q, isTag %v; want trunk, false", version, isTag)
 	}
 }
 

--- a/planet/install.go
+++ b/planet/install.go
@@ -39,7 +39,15 @@ func Install(m *Manifest, alias string, out io.Writer) (string, error) {
 		return "", err
 	}
 
-	commit, err := Checkout(source.URL, version, staging)
+	// A recorded commit wins over the ref. That is what pins an install: a tag
+	// can be moved and a branch advances, so re-resolving the ref would hand
+	// back different code than the manifest describes.
+	ref := version
+	if entry.Commit != "" {
+		ref = entry.Commit
+	}
+
+	commit, err := Checkout(source.URL, ref, staging)
 	if err != nil {
 		os.RemoveAll(staging)
 		return "", err

--- a/planet/install.go
+++ b/planet/install.go
@@ -25,7 +25,7 @@ func Install(m *Manifest, alias string, out io.Writer) (string, error) {
 
 	version := entry.Version
 	if version == "" {
-		if version, err = LatestTag(source.URL); err != nil {
+		if version, _, err = ResolveVersion(source.URL); err != nil {
 			return "", err
 		}
 	}

--- a/planet/install.go
+++ b/planet/install.go
@@ -1,0 +1,165 @@
+//go:build !wasm
+
+package planet
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Install materialises one alias from the manifest, replacing whatever is
+// there. It returns the resolved commit.
+func Install(m *Manifest, alias string, out io.Writer) (string, error) {
+	entry, ok := m.Planets[alias]
+	if !ok {
+		return "", fmt.Errorf("no planet named %q in %s", alias, ManifestName)
+	}
+
+	source, err := ParseSource(entry.Source)
+	if err != nil {
+		return "", err
+	}
+
+	version := entry.Version
+	if version == "" {
+		if version, err = LatestTag(source.URL); err != nil {
+			return "", err
+		}
+	}
+
+	dir := m.Dir(alias)
+
+	// Clone beside the target and swap, so a failed fetch cannot leave a
+	// half-written planet where a working one used to be.
+	staging := dir + ".incoming"
+	if err := os.RemoveAll(staging); err != nil {
+		return "", err
+	}
+
+	commit, err := Checkout(source.URL, version, staging)
+	if err != nil {
+		os.RemoveAll(staging)
+		return "", err
+	}
+
+	if err := WriteStamp(staging, Stamp{Source: entry.Source, Version: version, Commit: commit}); err != nil {
+		os.RemoveAll(staging)
+		return "", err
+	}
+
+	if err := os.RemoveAll(dir); err != nil {
+		os.RemoveAll(staging)
+		return "", err
+	}
+	if err := os.Rename(staging, dir); err != nil {
+		return "", err
+	}
+
+	fmt.Fprintf(out, "installed %s %s (%s) to %s\n", alias, version, shortCommit(commit), relativeTo(m.Root(), dir))
+
+	return commit, nil
+}
+
+// InstallAll materialises every planet the manifest lists, skipping any whose
+// stamp already matches. That is what makes repeated runs cheap and what lets a
+// vendored planet directory be left alone.
+func InstallAll(m *Manifest, out io.Writer) error {
+	aliases := m.Aliases()
+	if len(aliases) == 0 {
+		fmt.Fprintf(out, "no planets in %s\n", ManifestName)
+		return nil
+	}
+
+	for _, alias := range aliases {
+		entry := m.Planets[alias]
+
+		if stamp, ok := ReadStamp(m.Dir(alias)); ok && stamp.Matches(entry) {
+			fmt.Fprintf(out, "up to date  %s %s\n", alias, stamp.Version)
+			continue
+		}
+
+		commit, err := Install(m, alias, out)
+		if err != nil {
+			return fmt.Errorf("%s: %w", alias, err)
+		}
+
+		// Record the commit a bare manifest entry resolved to, so the next
+		// install is reproducible.
+		if entry.Commit != commit {
+			entry.Commit = commit
+			if entry.Version == "" {
+				if stamp, ok := ReadStamp(m.Dir(alias)); ok {
+					entry.Version = stamp.Version
+				}
+			}
+			m.Planets[alias] = entry
+			if err := m.Save(); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// Remove deletes an alias from disk and from the manifest.
+func Remove(m *Manifest, alias string, out io.Writer) error {
+	if _, ok := m.Planets[alias]; !ok {
+		return fmt.Errorf("no planet named %q in %s", alias, ManifestName)
+	}
+
+	if err := os.RemoveAll(m.Dir(alias)); err != nil {
+		return err
+	}
+
+	delete(m.Planets, alias)
+	if err := m.Save(); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "removed %s\n", alias)
+
+	return nil
+}
+
+// LocalModuleConflict reports a module in the project root that would shadow an
+// alias. The search path puts the working directory first, so such a planet
+// would be installed and then silently never used -- better to refuse at
+// install time, where it is actionable.
+func LocalModuleConflict(m *Manifest, alias string) (string, bool) {
+	candidates := []string{
+		filepath.Join(m.Root(), alias+".rl"),
+		filepath.Join(m.Root(), alias),
+	}
+
+	for _, candidate := range candidates {
+		info, err := os.Stat(candidate)
+		if err != nil {
+			continue
+		}
+		if strings.HasSuffix(candidate, ".rl") || info.IsDir() {
+			return relativeTo(m.Root(), candidate), true
+		}
+	}
+
+	return "", false
+}
+
+func shortCommit(commit string) string {
+	if len(commit) > 7 {
+		return commit[:7]
+	}
+
+	return commit
+}
+
+func relativeTo(root, path string) string {
+	if rel, err := filepath.Rel(root, path); err == nil {
+		return rel
+	}
+
+	return path
+}

--- a/planet/install_test.go
+++ b/planet/install_test.go
@@ -5,6 +5,7 @@ package planet
 import (
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -178,5 +179,104 @@ func TestLocalModuleConflict(t *testing.T) {
 
 	if _, conflict := LocalModuleConflict(m, "other"); conflict {
 		t.Error("reported a conflict for an unrelated alias")
+	}
+}
+
+// moveBranch advances main in a repo built by newRepo, so drift can be tested.
+func moveBranch(t *testing.T, repo, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(repo, "mod.rl"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, args := range [][]string{{"add", "mod.rl"}, {"commit", "--quiet", "-m", "moved"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %s", args, out)
+		}
+	}
+}
+
+// TestInstallPinsToTheRecordedCommit is the property that makes the commit
+// field load-bearing rather than decorative. A branch advances and a tag can be
+// force-moved, so re-resolving the ref would hand back different code than the
+// manifest describes.
+func TestInstallPinsToTheRecordedCommit(t *testing.T) {
+	repo := newRepo(t, "v1.0.0")
+	m := projectWith(t, repo, "dep", "main")
+
+	if err := InstallAll(m, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+
+	pinned := m.Planets["dep"].Commit
+	if pinned == "" {
+		t.Fatal("no commit was recorded")
+	}
+
+	moveBranch(t, repo, "export V = 99\n")
+
+	// A fresh checkout, as a CI job would have.
+	if err := os.RemoveAll(m.PlanetsDir()); err != nil {
+		t.Fatal(err)
+	}
+	if err := InstallAll(m, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := m.Planets["dep"].Commit; got != pinned {
+		t.Errorf("the recorded commit changed from %s to %s", pinned, got)
+	}
+
+	stamp, _ := ReadStamp(m.Dir("dep"))
+	if stamp.Commit != pinned {
+		t.Errorf("installed %s, want the pinned %s", stamp.Commit, pinned)
+	}
+
+	content, _ := os.ReadFile(filepath.Join(m.Dir("dep"), "mod.rl"))
+	if string(content) == "export V = 99\n" {
+		t.Error("install followed the branch instead of the recorded commit")
+	}
+}
+
+// TestInstallFollowsTheRefWhenNoCommitIsRecorded is the counterpart: without a
+// commit there is nothing to pin to, so the ref decides.
+func TestInstallFollowsTheRefWhenNoCommitIsRecorded(t *testing.T) {
+	repo := newRepo(t, "v1.0.0")
+	m := projectWith(t, repo, "dep", "main")
+
+	if err := InstallAll(m, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+
+	moveBranch(t, repo, "export V = 99\n")
+
+	// Clearing the commit is what planet get does for an explicit version.
+	entry := m.Planets["dep"]
+	entry.Commit = ""
+	m.Planets["dep"] = entry
+
+	if err := os.RemoveAll(m.PlanetsDir()); err != nil {
+		t.Fatal(err)
+	}
+	if err := InstallAll(m, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+
+	content, _ := os.ReadFile(filepath.Join(m.Dir("dep"), "mod.rl"))
+	if string(content) != "export V = 99\n" {
+		t.Errorf("content = %q, want the advanced branch content", content)
+	}
+}
+
+// TestCheckoutAcceptsABranch covers using a branch name as a version, which
+// git's clone accepts as readily as a tag.
+func TestCheckoutAcceptsABranch(t *testing.T) {
+	repo := newRepo(t, "v1.0.0")
+
+	if _, err := Checkout(repo, "main", filepath.Join(t.TempDir(), "x")); err != nil {
+		t.Errorf("Checkout of a branch failed: %s", err)
 	}
 }

--- a/planet/install_test.go
+++ b/planet/install_test.go
@@ -1,0 +1,182 @@
+//go:build !wasm
+
+package planet
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func projectWith(t *testing.T, repo, alias, version string) *Manifest {
+	t.Helper()
+
+	m := New(t.TempDir())
+	m.Planets[alias] = Entry{Source: repo, Version: version}
+	if err := m.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	return m
+}
+
+func TestInstallWritesTheStamp(t *testing.T) {
+	repo := newRepo(t, "v1.0.0")
+	m := projectWith(t, repo, "utils", "v1.0.0")
+
+	commit, err := Install(m, "utils", io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stamp, ok := ReadStamp(m.Dir("utils"))
+	if !ok {
+		t.Fatal("no stamp written")
+	}
+	if stamp.Version != "v1.0.0" || stamp.Commit != commit || stamp.Source != repo {
+		t.Errorf("stamp = %+v, want source %q version v1.0.0 commit %q", stamp, repo, commit)
+	}
+}
+
+func TestInstallAllSkipsWhatAlreadyMatches(t *testing.T) {
+	repo := newRepo(t, "v1.0.0")
+	m := projectWith(t, repo, "utils", "v1.0.0")
+
+	if err := InstallAll(m, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+
+	// Leave a marker inside the installed directory. A skipped install must not
+	// disturb it; a re-clone would wipe it out.
+	marker := filepath.Join(m.Dir("utils"), "marker")
+	if err := os.WriteFile(marker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := InstallAll(m, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(marker); err != nil {
+		t.Error("a second InstallAll re-cloned an up-to-date planet")
+	}
+}
+
+func TestInstallAllReinstallsOnVersionChange(t *testing.T) {
+	repo := newRepo(t, "v1.0.0", "v2.0.0")
+	m := projectWith(t, repo, "utils", "v1.0.0")
+
+	if err := InstallAll(m, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+
+	entry := m.Planets["utils"]
+	entry.Version = "v2.0.0"
+	entry.Commit = ""
+	m.Planets["utils"] = entry
+
+	if err := InstallAll(m, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+
+	stamp, _ := ReadStamp(m.Dir("utils"))
+	if stamp.Version != "v2.0.0" {
+		t.Errorf("stamp version = %q, want v2.0.0", stamp.Version)
+	}
+
+	// v2.0.0 was the second commit, so its content differs from v1.0.0's.
+	content, _ := os.ReadFile(filepath.Join(m.Dir("utils"), "mod.rl"))
+	if string(content) != "export V = 1\n" {
+		t.Errorf("content = %q, want the v2.0.0 content", content)
+	}
+}
+
+func TestInstallAllRecordsTheResolvedCommit(t *testing.T) {
+	repo := newRepo(t, "v1.0.0", "v2.0.0")
+
+	// A manifest entry with no version, as a hand-written one might be.
+	m := projectWith(t, repo, "utils", "")
+
+	if err := InstallAll(m, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded, err := LoadFrom(m.Root())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entry := reloaded.Planets["utils"]
+	if entry.Commit == "" {
+		t.Error("the resolved commit was not written back to the manifest")
+	}
+	if entry.Version != "v2.0.0" {
+		t.Errorf("version = %q, want the highest tag v2.0.0", entry.Version)
+	}
+}
+
+func TestInstallLeavesTheOldCopyOnFailure(t *testing.T) {
+	repo := newRepo(t, "v1.0.0")
+	m := projectWith(t, repo, "utils", "v1.0.0")
+
+	if _, err := Install(m, "utils", io.Discard); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ask for a tag that does not exist. The working copy must survive.
+	entry := m.Planets["utils"]
+	entry.Version = "v9.9.9"
+	m.Planets["utils"] = entry
+
+	if _, err := Install(m, "utils", io.Discard); err == nil {
+		t.Fatal("Install succeeded for a missing tag")
+	}
+
+	if _, err := os.Stat(filepath.Join(m.Dir("utils"), "mod.rl")); err != nil {
+		t.Error("a failed install destroyed the previous copy")
+	}
+	if _, err := os.Stat(m.Dir("utils") + ".incoming"); !os.IsNotExist(err) {
+		t.Error("a failed install left its staging directory behind")
+	}
+}
+
+func TestRemoveDeletesFromDiskAndManifest(t *testing.T) {
+	repo := newRepo(t, "v1.0.0")
+	m := projectWith(t, repo, "utils", "v1.0.0")
+
+	if _, err := Install(m, "utils", io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if err := Remove(m, "utils", io.Discard); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(m.Dir("utils")); !os.IsNotExist(err) {
+		t.Error("the directory survived remove")
+	}
+
+	reloaded, _ := LoadFrom(m.Root())
+	if _, ok := reloaded.Planets["utils"]; ok {
+		t.Error("the manifest entry survived remove")
+	}
+}
+
+func TestLocalModuleConflict(t *testing.T) {
+	m := New(t.TempDir())
+
+	if _, conflict := LocalModuleConflict(m, "utils"); conflict {
+		t.Error("reported a conflict with nothing on disk")
+	}
+
+	if err := os.WriteFile(filepath.Join(m.Root(), "utils.rl"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, conflict := LocalModuleConflict(m, "utils"); !conflict {
+		t.Error("missed a conflict with a local utils.rl")
+	}
+
+	if _, conflict := LocalModuleConflict(m, "other"); conflict {
+		t.Error("reported a conflict for an unrelated alias")
+	}
+}

--- a/planet/manifest.go
+++ b/planet/manifest.go
@@ -1,0 +1,128 @@
+package planet
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ManifestName is the file whose presence marks a project root.
+const ManifestName = "planets.yml"
+
+// DirName holds installed planets, relative to the project root.
+const DirName = ".planets"
+
+// StampName records what was installed in a planet's directory.
+const StampName = ".planet"
+
+// Entry is one planet as the manifest records it. Version is the tag that was
+// asked for; Commit is what that tag resolved to, which is what makes an
+// install reproducible when a tag is later moved.
+type Entry struct {
+	Source  string `yaml:"source"`
+	Version string `yaml:"version"`
+	Commit  string `yaml:"commit"`
+}
+
+// Manifest is planets.yml. Keys of Planets are aliases chosen by the consumer,
+// and double as directory names under .planets.
+type Manifest struct {
+	RocketLang string           `yaml:"rocket-lang,omitempty"`
+	Planets    map[string]Entry `yaml:"planets"`
+
+	// root is the directory the manifest was read from, not serialised.
+	root string
+}
+
+// Root returns the project root: the directory holding the manifest.
+func (m *Manifest) Root() string { return m.root }
+
+// PlanetsDir returns the directory installed planets live in.
+func (m *Manifest) PlanetsDir() string { return filepath.Join(m.root, DirName) }
+
+// Dir returns where a given alias is installed.
+func (m *Manifest) Dir(alias string) string { return filepath.Join(m.PlanetsDir(), alias) }
+
+// Aliases returns the aliases in sorted order, so output and iteration are
+// deterministic rather than following Go's map ordering.
+func (m *Manifest) Aliases() []string {
+	aliases := make([]string, 0, len(m.Planets))
+	for alias := range m.Planets {
+		aliases = append(aliases, alias)
+	}
+	sort.Strings(aliases)
+
+	return aliases
+}
+
+// FindRoot walks up from dir looking for a manifest, and returns the directory
+// containing it. It reports whether one was found rather than erroring, since
+// "not in a project" is an ordinary state.
+func FindRoot(dir string) (string, bool) {
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", false
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ManifestName)); err == nil {
+			return dir, true
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
+}
+
+// Load reads the manifest for the project containing dir.
+func Load(dir string) (*Manifest, error) {
+	root, ok := FindRoot(dir)
+	if !ok {
+		return nil, fmt.Errorf("no %s found in %s or any parent directory", ManifestName, dir)
+	}
+
+	return LoadFrom(root)
+}
+
+// LoadFrom reads the manifest in exactly root, without searching upwards.
+func LoadFrom(root string) (*Manifest, error) {
+	path := filepath.Join(root, ManifestName)
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	manifest := &Manifest{root: root}
+	if err := yaml.Unmarshal(content, manifest); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+
+	if manifest.Planets == nil {
+		manifest.Planets = map[string]Entry{}
+	}
+
+	return manifest, nil
+}
+
+// Save writes the manifest back. yaml.v3 does not preserve comments or key
+// order, so the file is tool-managed by design.
+func (m *Manifest) Save() error {
+	content, err := yaml.Marshal(m)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(m.root, ManifestName), content, 0o644)
+}
+
+// New returns an empty manifest rooted at root, without writing it.
+func New(root string) *Manifest {
+	return &Manifest{root: root, Planets: map[string]Entry{}}
+}

--- a/planet/manifest_test.go
+++ b/planet/manifest_test.go
@@ -1,0 +1,125 @@
+package planet
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFindRootWalksUp(t *testing.T) {
+	root := t.TempDir()
+	deep := filepath.Join(root, "a", "b", "c")
+
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ManifestName), []byte("planets: {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok := FindRoot(deep)
+	if !ok {
+		t.Fatalf("FindRoot(%q) found nothing, want %q", deep, root)
+	}
+
+	// The temp dir may itself sit under a symlink, so compare resolved paths.
+	wantResolved, _ := filepath.EvalSymlinks(root)
+	gotResolved, _ := filepath.EvalSymlinks(got)
+	if gotResolved != wantResolved {
+		t.Errorf("FindRoot(%q) = %q, want %q", deep, gotResolved, wantResolved)
+	}
+}
+
+func TestFindRootReportsAbsence(t *testing.T) {
+	// A temp dir with no manifest anywhere above it inside the sandbox. The
+	// walk stops at the filesystem root rather than looping.
+	if _, ok := FindRoot(t.TempDir()); ok {
+		t.Error("FindRoot found a manifest where none was written")
+	}
+}
+
+func TestLoadAndSaveRoundTrip(t *testing.T) {
+	root := t.TempDir()
+
+	manifest := New(root)
+	manifest.RocketLang = ">=0.24"
+	manifest.Planets["utils"] = Entry{
+		Source:  "github.com/flipez/rocket-lang-utils",
+		Version: "v1.2.0",
+		Commit:  "a3f21c9",
+	}
+
+	if err := manifest.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := LoadFrom(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if loaded.RocketLang != ">=0.24" {
+		t.Errorf("rocket-lang = %q, want %q", loaded.RocketLang, ">=0.24")
+	}
+
+	entry, ok := loaded.Planets["utils"]
+	if !ok {
+		t.Fatal("utils missing after round trip")
+	}
+	if entry.Source != "github.com/flipez/rocket-lang-utils" || entry.Version != "v1.2.0" || entry.Commit != "a3f21c9" {
+		t.Errorf("entry round-tripped wrong: %+v", entry)
+	}
+}
+
+func TestLoadTreatsMissingPlanetsAsEmpty(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ManifestName), []byte("rocket-lang: \">=0.24\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := LoadFrom(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A nil map would panic on assignment in planet get.
+	if loaded.Planets == nil {
+		t.Fatal("Planets is nil, want an empty map")
+	}
+	if len(loaded.Planets) != 0 {
+		t.Errorf("Planets has %d entries, want 0", len(loaded.Planets))
+	}
+}
+
+func TestAliasesAreSorted(t *testing.T) {
+	manifest := New(t.TempDir())
+	for _, alias := range []string{"zeta", "alpha", "mid"} {
+		manifest.Planets[alias] = Entry{Source: "x"}
+	}
+
+	got := manifest.Aliases()
+	want := []string{"alpha", "mid", "zeta"}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Aliases() = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestPathHelpers(t *testing.T) {
+	manifest := New("/proj")
+
+	if got := manifest.PlanetsDir(); got != filepath.Join("/proj", ".planets") {
+		t.Errorf("PlanetsDir() = %q", got)
+	}
+	if got := manifest.Dir("utils"); got != filepath.Join("/proj", ".planets", "utils") {
+		t.Errorf("Dir() = %q", got)
+	}
+}
+
+func TestLoadReportsNoProject(t *testing.T) {
+	if _, err := Load(t.TempDir()); err == nil {
+		t.Error("Load succeeded with no manifest present")
+	}
+}

--- a/planet/source.go
+++ b/planet/source.go
@@ -2,6 +2,7 @@ package planet
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 )
 
@@ -14,59 +15,86 @@ type Source struct {
 	Raw string
 	// URL is what git is given.
 	URL string
-	// Alias is the default binding name derived from the source.
-	Alias string
 }
 
-// ParseSource turns what the user typed into a git URL and a default alias.
+// ParseSource turns what the user typed into something git can clone.
 //
 //	flipez/rocket-lang-utils   -> https://github.com/flipez/rocket-lang-utils
 //	codeberg.org/flipez/utils  -> https://codeberg.org/flipez/utils
-//	https://example.com/u.git   -> as written
+//	https://example.com/u.git  -> as written
+//	git@github.com:u/n.git     -> as written
+//	/srv/planets/utils         -> as written, a local clone
+//	../sibling-project         -> resolved against the working directory
+//
+// Deriving an alias is deliberately separate: a source can be perfectly
+// cloneable while its last path segment makes no sense as an identifier.
 func ParseSource(raw string) (Source, error) {
-	raw = strings.TrimSuffix(strings.TrimSpace(raw), "/")
+	raw = strings.TrimSpace(raw)
+	trimmed := strings.TrimSuffix(raw, "/")
 
-	if raw == "" {
+	if trimmed == "" {
 		return Source{}, fmt.Errorf("empty planet source")
 	}
 
-	var url string
-
 	switch {
-	case strings.Contains(raw, "://"), strings.HasPrefix(raw, "git@"):
-		url = raw
-	case looksHostQualified(raw):
-		url = "https://" + raw
-	default:
-		parts := strings.Split(raw, "/")
-		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-			return Source{}, fmt.Errorf("cannot read %q as a planet source: expected owner/name, host/owner/name or a URL", raw)
+	case strings.Contains(trimmed, "://"), strings.HasPrefix(trimmed, "git@"):
+		return Source{Raw: raw, URL: trimmed}, nil
+
+	case isLocalPath(trimmed):
+		absolute, err := filepath.Abs(trimmed)
+		if err != nil {
+			return Source{}, err
 		}
-		url = "https://" + defaultHost + "/" + raw
+
+		return Source{Raw: raw, URL: absolute}, nil
+
+	case looksHostQualified(trimmed):
+		return Source{Raw: raw, URL: "https://" + trimmed}, nil
 	}
 
-	alias, err := aliasFor(raw)
-	if err != nil {
-		return Source{}, err
+	parts := strings.Split(trimmed, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return Source{}, fmt.Errorf("cannot read %q as a planet source: expected owner/name, host/owner/name, a URL or a local path", raw)
 	}
 
-	return Source{Raw: raw, URL: url, Alias: alias}, nil
+	return Source{Raw: raw, URL: "https://" + defaultHost + "/" + trimmed}, nil
+}
+
+// isLocalPath reports whether raw names a directory on this machine rather than
+// a remote. An explicitly relative or absolute path is the signal; a bare
+// owner/name is never treated as local.
+func isLocalPath(raw string) bool {
+	return filepath.IsAbs(raw) ||
+		strings.HasPrefix(raw, "./") ||
+		strings.HasPrefix(raw, "../") ||
+		raw == "." ||
+		raw == ".."
 }
 
 // looksHostQualified reports whether the first segment names a host. A dot in
-// the first segment is the signal, which is what distinguishes
-// codeberg.org/owner/name from owner/name.
+// the first segment is the signal, which distinguishes codeberg.org/owner/name
+// from owner/name without maintaining a list of known hosts.
 func looksHostQualified(raw string) bool {
 	parts := strings.SplitN(raw, "/", 2)
 
 	return len(parts) == 2 && strings.Contains(parts[0], ".")
 }
 
-// aliasFor derives a default alias from a source: the last path segment, with a
-// .git suffix and any rocket-lang prefix removed, since "rocket-lang-utils" as
-// an alias is redundant inside a RocketLang project.
-func aliasFor(raw string) (string, error) {
-	segments := strings.Split(strings.TrimSuffix(raw, ".git"), "/")
+// DefaultAlias derives a binding name from a source: the last path segment with
+// a .git suffix and any redundant rocket-lang prefix removed. It fails rather
+// than returning something unusable, because an alias that is not a legal
+// identifier produces an import that can never be referenced -- "my-lib.Foo"
+// parses as subtraction.
+func DefaultAlias(raw string) (string, error) {
+	cleaned := strings.TrimSuffix(strings.TrimSuffix(strings.TrimSpace(raw), "/"), ".git")
+	cleaned = strings.ReplaceAll(cleaned, "\\", "/")
+
+	// git@host:owner/name puts the interesting part after the colon.
+	if _, after, found := strings.Cut(cleaned, ":"); found && !strings.Contains(after, "//") {
+		cleaned = after
+	}
+
+	segments := strings.Split(cleaned, "/")
 	alias := segments[len(segments)-1]
 
 	for _, prefix := range []string{"rocket-lang-", "rocketlang-", "rl-"} {
@@ -77,15 +105,14 @@ func aliasFor(raw string) (string, error) {
 	}
 
 	if !IsValidAlias(alias) {
-		return "", fmt.Errorf("cannot derive an alias from %q: %q is not usable as an identifier, pass one with --as", raw, alias)
+		return "", fmt.Errorf("cannot derive a name from %q: %q would not be usable in an import, pass one with --as", raw, alias)
 	}
 
 	return alias, nil
 }
 
-// IsValidAlias reports whether alias can be written in an import and used as a
-// binding. A hyphen is the common failure: "str-help.Foo" parses as
-// subtraction, so the binding would be unreachable.
+// IsValidAlias reports whether alias can be written in an import and then
+// referenced. A hyphen is the common failure.
 func IsValidAlias(alias string) bool {
 	if alias == "" {
 		return false

--- a/planet/source.go
+++ b/planet/source.go
@@ -1,0 +1,104 @@
+package planet
+
+import (
+	"fmt"
+	"strings"
+)
+
+// defaultHost is prepended to a bare owner/name source.
+const defaultHost = "github.com"
+
+// Source is a resolved planet location.
+type Source struct {
+	// Raw is what the user typed, and what the manifest records.
+	Raw string
+	// URL is what git is given.
+	URL string
+	// Alias is the default binding name derived from the source.
+	Alias string
+}
+
+// ParseSource turns what the user typed into a git URL and a default alias.
+//
+//	flipez/rocket-lang-utils   -> https://github.com/flipez/rocket-lang-utils
+//	codeberg.org/flipez/utils  -> https://codeberg.org/flipez/utils
+//	https://example.com/u.git   -> as written
+func ParseSource(raw string) (Source, error) {
+	raw = strings.TrimSuffix(strings.TrimSpace(raw), "/")
+
+	if raw == "" {
+		return Source{}, fmt.Errorf("empty planet source")
+	}
+
+	var url string
+
+	switch {
+	case strings.Contains(raw, "://"), strings.HasPrefix(raw, "git@"):
+		url = raw
+	case looksHostQualified(raw):
+		url = "https://" + raw
+	default:
+		parts := strings.Split(raw, "/")
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return Source{}, fmt.Errorf("cannot read %q as a planet source: expected owner/name, host/owner/name or a URL", raw)
+		}
+		url = "https://" + defaultHost + "/" + raw
+	}
+
+	alias, err := aliasFor(raw)
+	if err != nil {
+		return Source{}, err
+	}
+
+	return Source{Raw: raw, URL: url, Alias: alias}, nil
+}
+
+// looksHostQualified reports whether the first segment names a host. A dot in
+// the first segment is the signal, which is what distinguishes
+// codeberg.org/owner/name from owner/name.
+func looksHostQualified(raw string) bool {
+	parts := strings.SplitN(raw, "/", 2)
+
+	return len(parts) == 2 && strings.Contains(parts[0], ".")
+}
+
+// aliasFor derives a default alias from a source: the last path segment, with a
+// .git suffix and any rocket-lang prefix removed, since "rocket-lang-utils" as
+// an alias is redundant inside a RocketLang project.
+func aliasFor(raw string) (string, error) {
+	segments := strings.Split(strings.TrimSuffix(raw, ".git"), "/")
+	alias := segments[len(segments)-1]
+
+	for _, prefix := range []string{"rocket-lang-", "rocketlang-", "rl-"} {
+		if len(alias) > len(prefix) && strings.HasPrefix(alias, prefix) {
+			alias = strings.TrimPrefix(alias, prefix)
+			break
+		}
+	}
+
+	if !IsValidAlias(alias) {
+		return "", fmt.Errorf("cannot derive an alias from %q: %q is not usable as an identifier, pass one with --as", raw, alias)
+	}
+
+	return alias, nil
+}
+
+// IsValidAlias reports whether alias can be written in an import and used as a
+// binding. A hyphen is the common failure: "str-help.Foo" parses as
+// subtraction, so the binding would be unreachable.
+func IsValidAlias(alias string) bool {
+	if alias == "" {
+		return false
+	}
+
+	for i, r := range alias {
+		isLetter := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_'
+		isDigit := r >= '0' && r <= '9'
+
+		if !isLetter && !(isDigit && i > 0) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/planet/source_test.go
+++ b/planet/source_test.go
@@ -14,7 +14,7 @@ func TestParseSourceURL(t *testing.T) {
 		"codeberg.org/flipez/utils": "https://codeberg.org/flipez/utils",
 		"git.example.com/team/a/b":  "https://git.example.com/team/a/b",
 		// Explicit URLs and scp-style remotes pass through untouched.
-		"https://example.com/u/thing.git": "https://example.com/u/thing.git",
+		"https://example.com/u/thing.git":   "https://example.com/u/thing.git",
 		"git@github.com:flipez/helpers.git": "git@github.com:flipez/helpers.git",
 		// A trailing slash is tolerated.
 		"flipez/helpers/": "https://github.com/flipez/helpers",

--- a/planet/source_test.go
+++ b/planet/source_test.go
@@ -1,0 +1,67 @@
+package planet
+
+import "testing"
+
+func TestParseSource(t *testing.T) {
+	tests := []struct {
+		raw   string
+		url   string
+		alias string
+	}{
+		// A bare owner/name defaults to GitHub.
+		{"flipez/rocket-lang-utils", "https://github.com/flipez/rocket-lang-utils", "utils"},
+		{"flipez/helpers", "https://github.com/flipez/helpers", "helpers"},
+		// A dot in the first segment marks it as a host.
+		{"codeberg.org/flipez/utils", "https://codeberg.org/flipez/utils", "utils"},
+		{"git.example.com/team/tools", "https://git.example.com/team/tools", "tools"},
+		// Explicit URLs pass through untouched.
+		{"https://example.com/u/thing.git", "https://example.com/u/thing.git", "thing"},
+		{"git@github.com:flipez/helpers.git", "git@github.com:flipez/helpers.git", "helpers"},
+		// A trailing slash is tolerated.
+		{"flipez/helpers/", "https://github.com/flipez/helpers", "helpers"},
+		// Redundant rocket-lang prefixes are dropped from the default alias.
+		{"flipez/rocketlang-json", "https://github.com/flipez/rocketlang-json", "json"},
+		{"flipez/rl-http", "https://github.com/flipez/rl-http", "http"},
+	}
+
+	for _, tt := range tests {
+		got, err := ParseSource(tt.raw)
+		if err != nil {
+			t.Errorf("ParseSource(%q) errored: %s", tt.raw, err)
+			continue
+		}
+		if got.URL != tt.url {
+			t.Errorf("ParseSource(%q).URL = %q, want %q", tt.raw, got.URL, tt.url)
+		}
+		if got.Alias != tt.alias {
+			t.Errorf("ParseSource(%q).Alias = %q, want %q", tt.raw, got.Alias, tt.alias)
+		}
+	}
+}
+
+func TestParseSourceRejects(t *testing.T) {
+	// The last case is the one that matters: an alias with a hyphen left in it
+	// would produce an import binding that can never be referenced, because
+	// "my-lib.Foo" parses as subtraction.
+	for _, raw := range []string{"", "   ", "onlyone", "a/b/c/d/e/f", "flipez/my-lib"} {
+		if got, err := ParseSource(raw); err == nil {
+			t.Errorf("ParseSource(%q) succeeded with alias %q, want an error", raw, got.Alias)
+		}
+	}
+}
+
+func TestIsValidAlias(t *testing.T) {
+	valid := []string{"utils", "http2", "_private", "aB9", "a"}
+	invalid := []string{"", "my-lib", "1st", "has space", "dot.ted", "sla/sh"}
+
+	for _, alias := range valid {
+		if !IsValidAlias(alias) {
+			t.Errorf("IsValidAlias(%q) = false, want true", alias)
+		}
+	}
+	for _, alias := range invalid {
+		if IsValidAlias(alias) {
+			t.Errorf("IsValidAlias(%q) = true, want false", alias)
+		}
+	}
+}

--- a/planet/source_test.go
+++ b/planet/source_test.go
@@ -1,65 +1,104 @@
 package planet
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
-func TestParseSource(t *testing.T) {
-	tests := []struct {
-		raw   string
-		url   string
-		alias string
-	}{
+func TestParseSourceURL(t *testing.T) {
+	tests := map[string]string{
 		// A bare owner/name defaults to GitHub.
-		{"flipez/rocket-lang-utils", "https://github.com/flipez/rocket-lang-utils", "utils"},
-		{"flipez/helpers", "https://github.com/flipez/helpers", "helpers"},
+		"flipez/rocket-lang-utils": "https://github.com/flipez/rocket-lang-utils",
+		"flipez/helpers":           "https://github.com/flipez/helpers",
 		// A dot in the first segment marks it as a host.
-		{"codeberg.org/flipez/utils", "https://codeberg.org/flipez/utils", "utils"},
-		{"git.example.com/team/tools", "https://git.example.com/team/tools", "tools"},
-		// Explicit URLs pass through untouched.
-		{"https://example.com/u/thing.git", "https://example.com/u/thing.git", "thing"},
-		{"git@github.com:flipez/helpers.git", "git@github.com:flipez/helpers.git", "helpers"},
+		"codeberg.org/flipez/utils": "https://codeberg.org/flipez/utils",
+		"git.example.com/team/a/b":  "https://git.example.com/team/a/b",
+		// Explicit URLs and scp-style remotes pass through untouched.
+		"https://example.com/u/thing.git": "https://example.com/u/thing.git",
+		"git@github.com:flipez/helpers.git": "git@github.com:flipez/helpers.git",
 		// A trailing slash is tolerated.
-		{"flipez/helpers/", "https://github.com/flipez/helpers", "helpers"},
-		// Redundant rocket-lang prefixes are dropped from the default alias.
-		{"flipez/rocketlang-json", "https://github.com/flipez/rocketlang-json", "json"},
-		{"flipez/rl-http", "https://github.com/flipez/rl-http", "http"},
+		"flipez/helpers/": "https://github.com/flipez/helpers",
+		// Absolute local paths clone directly, which is what makes a planet in a
+		// monorepo or on a shared drive usable.
+		"/srv/planets/utils": "/srv/planets/utils",
 	}
 
-	for _, tt := range tests {
-		got, err := ParseSource(tt.raw)
+	for raw, want := range tests {
+		got, err := ParseSource(raw)
 		if err != nil {
-			t.Errorf("ParseSource(%q) errored: %s", tt.raw, err)
+			t.Errorf("ParseSource(%q) errored: %s", raw, err)
 			continue
 		}
-		if got.URL != tt.url {
-			t.Errorf("ParseSource(%q).URL = %q, want %q", tt.raw, got.URL, tt.url)
+		if got.URL != want {
+			t.Errorf("ParseSource(%q).URL = %q, want %q", raw, got.URL, want)
 		}
-		if got.Alias != tt.alias {
-			t.Errorf("ParseSource(%q).Alias = %q, want %q", tt.raw, got.Alias, tt.alias)
+		if got.Raw != raw {
+			t.Errorf("ParseSource(%q).Raw = %q, want it preserved verbatim", raw, got.Raw)
 		}
 	}
 }
 
+func TestParseSourceResolvesRelativePaths(t *testing.T) {
+	got, err := ParseSource("./sibling")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !filepath.IsAbs(got.URL) {
+		t.Errorf("ParseSource(\"./sibling\").URL = %q, want an absolute path", got.URL)
+	}
+}
+
 func TestParseSourceRejects(t *testing.T) {
-	// The last case is the one that matters: an alias with a hyphen left in it
-	// would produce an import binding that can never be referenced, because
-	// "my-lib.Foo" parses as subtraction.
-	for _, raw := range []string{"", "   ", "onlyone", "a/b/c/d/e/f", "flipez/my-lib"} {
+	for _, raw := range []string{"", "   ", "onlyone", "a/b/c"} {
 		if got, err := ParseSource(raw); err == nil {
-			t.Errorf("ParseSource(%q) succeeded with alias %q, want an error", raw, got.Alias)
+			t.Errorf("ParseSource(%q) succeeded with %q, want an error", raw, got.URL)
+		}
+	}
+}
+
+func TestDefaultAlias(t *testing.T) {
+	tests := map[string]string{
+		"flipez/rocket-lang-utils":          "utils",
+		"flipez/rocketlang-json":            "json",
+		"flipez/rl-http":                    "http",
+		"flipez/helpers":                    "helpers",
+		"codeberg.org/flipez/utils":         "utils",
+		"https://example.com/u/thing.git":   "thing",
+		"git@github.com:flipez/helpers.git": "helpers",
+		"/srv/planets/utils":                "utils",
+	}
+
+	for raw, want := range tests {
+		got, err := DefaultAlias(raw)
+		if err != nil {
+			t.Errorf("DefaultAlias(%q) errored: %s", raw, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("DefaultAlias(%q) = %q, want %q", raw, got, want)
+		}
+	}
+}
+
+func TestDefaultAliasRefusesUnusableNames(t *testing.T) {
+	// The first is the important one: my-lib cannot be referenced after import,
+	// because my-lib.Foo parses as subtraction. Failing here, with a pointer to
+	// --as, is better than installing something unusable.
+	for _, raw := range []string{"flipez/my-lib", "flipez/2fast", "/srv/planets/001"} {
+		if got, err := DefaultAlias(raw); err == nil {
+			t.Errorf("DefaultAlias(%q) = %q, want an error", raw, got)
 		}
 	}
 }
 
 func TestIsValidAlias(t *testing.T) {
-	valid := []string{"utils", "http2", "_private", "aB9", "a"}
-	invalid := []string{"", "my-lib", "1st", "has space", "dot.ted", "sla/sh"}
-
-	for _, alias := range valid {
+	for _, alias := range []string{"utils", "http2", "_private", "aB9", "a"} {
 		if !IsValidAlias(alias) {
 			t.Errorf("IsValidAlias(%q) = false, want true", alias)
 		}
 	}
-	for _, alias := range invalid {
+	for _, alias := range []string{"", "my-lib", "1st", "has space", "dot.ted", "sla/sh"} {
 		if IsValidAlias(alias) {
 			t.Errorf("IsValidAlias(%q) = true, want false", alias)
 		}

--- a/planet/stamp.go
+++ b/planet/stamp.go
@@ -1,0 +1,57 @@
+package planet
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Stamp records what an installed directory actually contains. It carries no
+// timestamp on purpose: the content is then a pure function of what was
+// installed, so it diffs cleanly if .planets is committed and can be compared
+// against the manifest without false positives.
+type Stamp struct {
+	Source  string `yaml:"source"`
+	Version string `yaml:"version"`
+	Commit  string `yaml:"commit"`
+}
+
+// WriteStamp records provenance inside an installed planet.
+func WriteStamp(dir string, stamp Stamp) error {
+	content, err := yaml.Marshal(stamp)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(dir, StampName), content, 0o644)
+}
+
+// ReadStamp reads the stamp from an installed planet. A missing stamp is
+// reported as not-ok rather than an error: an unstamped directory is something
+// to reinstall, not something to fail on.
+func ReadStamp(dir string) (Stamp, bool) {
+	content, err := os.ReadFile(filepath.Join(dir, StampName))
+	if err != nil {
+		return Stamp{}, false
+	}
+
+	var stamp Stamp
+	if err := yaml.Unmarshal(content, &stamp); err != nil {
+		return Stamp{}, false
+	}
+
+	return stamp, true
+}
+
+// Matches reports whether an installed directory already holds what the
+// manifest asks for, which is what makes planet install idempotent.
+func (s Stamp) Matches(entry Entry) bool {
+	if s.Source != entry.Source || s.Version != entry.Version {
+		return false
+	}
+
+	// A manifest with no recorded commit still matches on source and version;
+	// this covers a hand-written entry that has not been installed yet.
+	return entry.Commit == "" || s.Commit == entry.Commit
+}

--- a/utilities/utilities.go
+++ b/utilities/utilities.go
@@ -66,6 +66,14 @@ func canonicalize(path string) string {
 	return resolved
 }
 
+// InitSearchPaths builds the search path if it has not been built yet. Callers
+// that need to append to it -- the planet directory goes after the working
+// directory, not before it -- must force initialisation first, because
+// FindModule would otherwise build it lazily and put their entry at the front.
+func InitSearchPaths() {
+	once.Do(initSearchPaths)
+}
+
 func FindModule(name string) string {
 	once.Do(initSearchPaths)
 

--- a/utilities/utilities_test.go
+++ b/utilities/utilities_test.go
@@ -225,3 +225,42 @@ func TestSearchPathList(t *testing.T) {
 		}
 	}
 }
+
+// TestInitSearchPathsThenAddPathAppends covers the ordering the planet
+// directory depends on. FindModule builds the search path lazily, so a caller
+// that appends without forcing initialisation first would land at the front of
+// the list instead of the back — and an installed planet would then shadow the
+// project's own modules.
+func TestInitSearchPathsThenAddPathAppends(t *testing.T) {
+	before := len(SearchPaths)
+
+	InitSearchPaths()
+
+	built := len(SearchPaths)
+	if built == 0 {
+		t.Fatal("InitSearchPaths produced no search paths")
+	}
+
+	dir := t.TempDir()
+	if err := AddPath(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(SearchPaths) != built+1 {
+		t.Fatalf("AddPath added %d entries, want 1", len(SearchPaths)-built)
+	}
+
+	resolved, _ := filepath.EvalSymlinks(dir)
+	last, _ := filepath.EvalSymlinks(SearchPaths[len(SearchPaths)-1])
+	if last != resolved {
+		t.Errorf("AddPath put %q at position %d, want it last", resolved, before)
+	}
+
+	// InitSearchPaths is idempotent, so a second call must not rebuild and
+	// push the appended entry out of last place.
+	InitSearchPaths()
+	last, _ = filepath.EvalSymlinks(SearchPaths[len(SearchPaths)-1])
+	if last != resolved {
+		t.Errorf("a second InitSearchPaths call disturbed the appended entry")
+	}
+}


### PR DESCRIPTION
Implements `docs/design/planets.md`.

A **planet** is a reusable library: a git repository of `.rl` files. `planet get` clones it into `.planets/`, records it in `planets.yml`, and that directory joins the module search path.

```
$ rocket-lang planet init
created planets.yml
added .planets/ to .gitignore

$ rocket-lang planet get flipez/rocket-lang-utils
resolved flipez/rocket-lang-utils to v1.1.0
installed utils v1.1.0 (364d720) to .planets/utils
recorded in planets.yml

import it with:  import "utils/<module>"
```
```js
import "utils/strings" as strings
puts(strings.Snake("hello world"))   // hello_world
```

Seven commits, each independently testable. 34 tests in the new `planet` package, exercised against **real git repositories** built in temp dirs rather than mocks — so git's actual behaviour is what is covered, with no network.

## What is here

**Manifest and project root.** `planets.yml` records an alias against a source, the tag asked for, and the commit that tag resolved to. Its presence marks the project root, found by walking up.

**Search path.** The project's `.planets/` goes after `ROCKETLANGPATH` and the working directory, so local modules always win a clash. That ordering needed care: `FindModule` builds the path lazily through `sync.Once`, so appending without forcing initialisation first lands at the *front*. `utilities` gains an exported `InitSearchPaths`, and a test pins the order — getting it wrong would silently let a planet shadow local code.

**Sources.** `owner/name` (GitHub default), `host/owner/name`, a git URL, or a local path. A dot in the first segment is what distinguishes a host from an owner, so no list of known hosts is needed.

**Versions.** `git ls-remote --tags`, filtered to bare `major.minor.patch` and ordered numerically, so `v1.10.0` sorts above `v1.2.0` and a prerelease is never selected by a bare `get`.

**Fetch.** `git clone` at a tag, deliberately **without `--depth 1`** — shallow fetching is unsupported over git's dumb HTTP protocol, which is what would let a plain static file server act as a mirror later. `.git` is dropped afterwards; provenance lives in the stamp.

**Install.** Clones to a staging directory and swaps, so a failed fetch cannot leave a half-written planet where a working one was — tested by requesting a missing tag and checking the previous copy survived. `.planet` stamps each install with source, version and commit, with no timestamp, so `install` is idempotent and diffs cleanly if committed.

**Guards.** `get` refuses an alias a local module would shadow, and one that could not be referenced after import. `get` on an installed planet reports and stops; an explicit `@version` is required to move it.

**CLI.** `init`, `get`, `install`, `list`, `remove`. Hand-rolled with one `pflag.FlagSet` each — no new dependency. Routed ahead of filename handling, so `-v`, `-e`, a program file and the REPL are all untouched; a file named `planet` is reached as `./planet`.

## One pre-existing bug fixed along the way

An implicit binding taken from the path could contain characters that cannot be referenced. `my-lib` bound fine, but `my-lib.X` parses as *subtraction*, so the module was unreachable and the import reported nothing:

```js
import "./my-lib"
puts(my-lib.X)      // identifier not found: my
```

Now an error naming the fix. Rather than restate the lexer's identifier rules — which are defined negatively and admit `?` and `!`, so `include?` and `strip!` work as method names — the check asks the lexer whether the name lexes to exactly one identifier. That stays correct if those rules change.

This predates planets, but planet names routinely contain hyphens, which turns it from exotic into common.

## Two gaps my own tests exposed

Worth flagging because both changed the design slightly:

- **A local filesystem path was not a valid source**, though git clones one happily. Now supported, which also makes a planet in a monorepo usable.
- **Alias derivation could fail source parsing.** Splitting `DefaultAlias` out means an odd directory name no longer makes a repository uncloneable; only `get` without `--as` needs a derivable name.

## Deliberately not here

Transitive dependencies (a planet that needs one vendors it and imports with `./`, which works today), the universe mirror, version ranges, a lockfile, and planets in the wasm playground — `planet` is build-tagged out there, since there is no filesystem to install into.

## Verified

`go test ./...` green. `GOOS=js GOARCH=wasm go build` succeeds. Docs added, with every example run against a build — including the three claims easiest to get wrong: a planet directory is not importable on its own, imports carry no `.rl` extension, and a planet's own dependency resolves through a `./` import. `yarn build` succeeds.