### PR TITLE
fix(function): check the arity of a user-defined function call

### DIFF
--- a/docs/docs/specification/functions.md
+++ b/docs/docs/specification/functions.md
@@ -65,3 +65,29 @@ The returned array can be unpacked into multiple variables (see [Multiple Assign
 x, y, z = get_coordinates()
 // x = 10, y = 20, z = 30
 ```
+
+## Arguments
+
+A call has to supply exactly as many arguments as the function has parameters.
+Too few or too many is an error:
+
+```js
+def add(a, b)
+  return a + b
+end
+
+add(1, 2)     // 3
+add(1)        // ERROR: add: to few arguments: got=1, want=2
+add(1, 2, 3)  // ERROR: add: to many arguments: got=3, want=2
+```
+
+A named function reports its own name, which helps when the call is into a
+module rather than a function on screen. Like any other error it can be caught:
+
+```js
+begin
+  add(1)
+rescue e
+  puts(e.msg())   // add: to few arguments: got=1, want=2
+end
+```

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -156,6 +156,14 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 func applyFunction(def object.Object, args []object.Object, env *object.Environment) object.Object {
 	switch def := def.(type) {
 	case *object.Function:
+		// extendFunctionEnv indexes the arguments by parameter position, so a
+		// short call would read past the end of the slice and panic. Builtins
+		// validate arity through MethodLayout; this is the equivalent for
+		// functions written in RocketLang, and uses the same wording.
+		if err := checkArity(def, args); err != nil {
+			return err
+		}
+
 		extendedEnv := extendFunctionEnv(def, args)
 		evaluated := Eval(def.Body, extendedEnv)
 		return unwrapReturnValue(evaluated)
@@ -166,6 +174,28 @@ func applyFunction(def object.Object, args []object.Object, env *object.Environm
 	default:
 		return object.NewErrorFormat("not a function: %s", def.Type())
 	}
+}
+
+// checkArity reports a call that does not match the function's parameter list.
+// A named function names itself, which matters when the call is into a library
+// rather than a function the reader has on screen.
+func checkArity(def *object.Function, args []object.Object) object.Object {
+	given, want := len(args), len(def.Parameters)
+
+	if given == want {
+		return nil
+	}
+
+	problem := "to many arguments"
+	if given < want {
+		problem = "to few arguments"
+	}
+
+	if def.Name != "" {
+		return object.NewErrorFormat("%s: %s: got=%d, want=%d", def.Name, problem, given, want)
+	}
+
+	return object.NewErrorFormat("%s: got=%d, want=%d", problem, given, want)
 }
 
 func extendFunctionEnv(def *object.Function, args []object.Object) *object.Environment {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -1259,3 +1259,49 @@ func TestImportRejectsUnusableImplicitBinding(t *testing.T) {
 func TestImportWithAsAcceptsAnyPath(t *testing.T) {
 	testIntegerObject(t, testEval(`import "../fixtures/hyphen-name" as hyphen; hyphen.Value`), 7)
 }
+
+// TestFunctionArityIsChecked covers a crash: extendFunctionEnv iterated the
+// parameters and indexed into the arguments, so calling a function with fewer
+// arguments than it has parameters ran off the end of the slice and panicked,
+// killing the process. Too many arguments were silently discarded. Builtins
+// validated both cases already; user-defined functions validated neither.
+func TestFunctionArityIsChecked(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// The panic.
+		{`def f(a, b) return a end f(1)`, "to few arguments: got=1, want=2"},
+		{`def f(a, b) return a end f()`, "to few arguments: got=0, want=2"},
+		// The quiet half: these used to return a value and say nothing.
+		{`def f(a) return a end f(1, 2, 3)`, "to many arguments: got=3, want=1"},
+		{`def f() return 1 end f(1)`, "to many arguments: got=1, want=0"},
+		// A named function says which one, which matters when the call is into
+		// a library rather than a function on screen.
+		{`def named(a) return a end named()`, "named: to few arguments"},
+		// An anonymous function has no name to report.
+		{`f = def(a) return a end f()`, "to few arguments: got=0, want=1"},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+
+		err, ok := evaluated.(*object.Error)
+		if !ok {
+			t.Errorf("input %q: expected an error, got=%T (%+v)", tt.input, evaluated, evaluated)
+			continue
+		}
+
+		if !strings.Contains(err.Message, tt.expected) {
+			t.Errorf("input %q: expected %q, got=%q", tt.input, tt.expected, err.Message)
+		}
+	}
+}
+
+// TestFunctionArityAcceptsExactMatch guards the other direction: the check must
+// not reject a correct call.
+func TestFunctionArityAcceptsExactMatch(t *testing.T) {
+	testIntegerObject(t, testEval(`def add(a, b) return a + b end add(2, 3)`), 5)
+	testIntegerObject(t, testEval(`def none() return 7 end none()`), 7)
+	testIntegerObject(t, testEval(`f = def(a) return a end f(9)`), 9)
+}


### PR DESCRIPTION
Closes #291.

`extendFunctionEnv` iterated the **parameters** and indexed into the **arguments**, so a short call read past the end of the slice and panicked, taking the process with it:

```js
def f(a, b) return a end
f(1)
→ panic: runtime error: index out of range [1] with length 1
```

Too many arguments were silently discarded, which is the quieter half of the same gap:

```js
def g(a) return a end
g(1, 2, 3)   // returned 1 and said nothing
```

Builtins already validated both cases via `MethodLayout.validateArgs`. User-defined functions validated neither.

## After

```
f: to few arguments: got=1, want=2
g: to many arguments: got=3, want=1
```

A **named** function reports its own name. That matters most in the case that prompted the report — a call into a planet module, where the function is not on screen:

```
» stats.min()
» ERROR: min: to few arguments: got=0, want=1
» REPL survived
```

Previously that killed the whole REPL session.

The result is an ordinary error object, so it is rescuable and execution continues:

```js
begin
  add(1)
rescue e
  puts(e.msg())   // add: to few arguments: got=1, want=2
end
puts("continued")
```

## On the breaking half

Rejecting *too many* arguments is technically breaking, and I went with it for consistency — builtins already reject it, so accepting it for user functions would leave the language inconsistent with itself.

Nothing in the repository relied on the old behaviour: the suite passed **without a single expectation change**, and every tracked `.rl` file produces byte-identical output, checked by md5 against a pre-change binary. Happy to make it warn instead if you would rather not break it.

## A wart I propagated deliberately

The wording is copied from the builtin validator, `to few` / `to many` typo included, rather than introducing a second phrasing for the same error. Fixing it in both places is worth doing, but it appears in 13 test expectations and is a separate change — flagging rather than bundling.

## Also

Docs gained an `## Arguments` section on the functions page, with all four outputs run against a build. `yarn build` succeeds.

Position information is not included, matching the builtin errors, which also report none. The function name seemed the more useful identifier for a library call; adding positions to both would be a follow-up.