### PR TITLE
docs: refresh the landing page, and fix the examples it pointed at

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -3,52 +3,81 @@ sidebar_position: 0
 ---
 # Getting Started
 
-RocketLang as of version 0.9.5 is the full (as in the book was worked through) version of [MonkeyLang](https://monkeylang.org/) and
-is then being extended with various useful and not so useful features.
+RocketLang started as a complete implementation of
+[MonkeyLang](https://monkeylang.org/) — the language built in
+*Writing an Interpreter in Go* — and has been extended since with features both
+useful and not so useful.
 
 # Latest Version
 
 [![GitHub release](https://img.shields.io/github/release/flipez/rocket-lang.svg)](https://github.com/flipez/rocket-lang/releases/)
 
 # Quick Start
+
 ```js
-input = open("examples/aoc/2021/day-1/input").lines()
+// Values carry methods.
+name = "rocket-lang"
+puts(name.upcase())          // ROCKET-LANG
+puts(name.split("-").size()) // 2
 
+// Arrays and hashes, both with methods of their own.
+crew = ["ada", "grace", "alan"]
+puts(crew.size())            // 3
+puts(crew.include?("ada"))   // true
 
-a = []
-foreach i, number in input
-  a.push(number.strip().to_i())
+ages = {"ada": 36, "grace": 45}
+puts(ages["grace"])          // 45
+
+// Functions are values, so they can be passed around.
+double = def(n)
+  return n * 2
 end
-input = a
+puts(double(21))             // 42
 
-increase = 0
-foreach i, number in input
-  if (number > input[i-1])
-    increase = increase + 1
+// Blocks close with `end`, and parentheses around a condition are optional.
+foreach i, member in crew
+  if i > 0
+    puts(i.to_s() + ": " + member)
   end
 end
-puts(increase + 1)
 
-increase = 0
-foreach i, number in input
-  sum = number + input[i+1] + input[i+2]
-  sum_two = input[i+1] + input[i+2] + input[i+3]
-
-  if (sum_two > sum)
-    increase = increase + 1
-  end
+// Errors are values you can catch.
+begin
+  puts(1 / 0)
+rescue e
+  puts("caught: " + e.msg())
 end
-puts(increase + 1)
 ```
 
+Split a program across files with [modules](./language/modules), and pull in
+someone else's with [planets](./language/planets):
+
+```js
+import "./helpers" as helpers
+```
+
+For longer programs, the [examples
+directory](https://github.com/flipez/rocket-lang/tree/main/examples) has
+solutions to several Advent of Code puzzles.
+
 # Help
-You can launch RocketLang with `-h` or `--help` to get an overview about the cli capabilities.
+
+Launch RocketLang with `-h` or `--help` for an overview of the CLI.
 
 ```zsh
 $ rocket-lang -h
 Usage: rocket-lang [flags] [program file] [arguments]
+       rocket-lang planet <command>
 
 Available flags:
   -e, --exec string   Runs the given code.
   -v, --version       Prints the version and build date.
+```
+
+Run a file, evaluate a snippet, or start a REPL with no arguments at all:
+
+```zsh
+$ rocket-lang program.rl
+$ rocket-lang -e 'puts("hi")'
+$ rocket-lang
 ```

--- a/examples/aoc/2015/day1.rl
+++ b/examples/aoc/2015/day1.rl
@@ -37,7 +37,7 @@ if (part_one(")())())") != -3)
 end
 
 "// We can now read data from files so using 'real' input data is much easier"
-real_input = IO.open("examples/aoc/2015/day1.input").content().strip()
+real_input = IO.open("day1.input").content().strip()
 
 puts("Solution Day 1 Part 1: ")
 puts(part_one(real_input))

--- a/examples/aoc/2021/day-1/complete.rl
+++ b/examples/aoc/2021/day-1/complete.rl
@@ -1,4 +1,4 @@
-input = IO.open("examples/aoc/2021/day-1/input").lines()
+input = IO.open("input").lines()
 
 // Part 1
 
@@ -24,12 +24,14 @@ puts(increase)
 
 increase = 0
 
+// A three-wide window rises exactly when the value entering it is larger than
+// the one leaving, so the sums need not be computed. Reading past the end used
+// to work only because nil.to_i() was 0.
 foreach i, number in input
-  sum = number + input[i+1].to_i() + input[i+2].to_i()
-  sum_two = input[i+1].to_i() + input[i+2].to_i() + input[i+3].to_i()
-  
-  if (sum_two > sum)
-    increase = increase + 1
+  if (i + 3 < input.size())
+    if (input[i+3] > number)
+      increase = increase + 1
+    end
   end
 end
 

--- a/examples/aoc/2021/day-2/complete.rl
+++ b/examples/aoc/2021/day-2/complete.rl
@@ -1,4 +1,4 @@
-input = IO.open("examples/aoc/2021/day-2/input").lines()
+input = IO.open("input").lines()
 
 depth = 0
 hor = 0


### PR DESCRIPTION
The Quick Start on `docs/docs/index.md` could not run, and finding out why turned up a regression of mine.

## The landing page was broken

It opened its input with `open()`, a builtin that no longer exists:

```
» open("go.mod")
» ERROR: identifier not found: open
```

`IO.open` replaced it, so the first line failed and nothing below it ran.

**Its logic was also wrong.** It dropped the `input[i-1] != nil` guard that the maintained example has, and added `1` to compensate:

```js
foreach i, number in input
  if (number > input[i-1])     // at i=0 this wraps to the last element
    increase = increase + 1
  end
end
puts(increase + 1)             // 1689
```

Negative indexing wraps, so the `i=0` comparison is spurious and the `+1` is a fudge. It produces **1689** where the correct answer is **1688**.

## Replaced with a self-contained tour

No input file, no working-directory assumption. Covers methods on values, arrays and hashes, functions as values, blocks, and rescuing an error — about 30 lines. Extracted from the page and run verbatim; every commented output matches.

One thing I caught while writing it: an earlier draft called `crew.sort()` before iterating `crew`, and the loop then printed in sorted order because `sort()` mutates in place. That is #231 leaking onto the landing page by accident, so the example avoids it.

The `-h` block is regenerated from the binary and now mentions the `planet` subcommand.

## A regression of mine, and why I missed it

`examples/aoc/2021/day-1/complete.rl` part 2 read past the end of the array and worked only because `nil.to_i()` returned `0`. Since #285 it returns `nil`, so:

```
before #285: 1728
after:       ERROR: type mismatch: INTEGER + NIL
```

Fixed by comparing the value entering the three-wide window with the one leaving, which needs no padding. Same answer, 1728.

**Why my verification missed it.** In #285 I reported that every tracked `.rl` file produced byte-identical output. That check ran each file from *its own directory* — and three examples opened their input relative to the repository root, so they failed on line 1 under both binaries. Identical early errors, matching md5, "no change". The check was structurally blind to anything below the first line.

Re-run properly from the repository root, exactly one unintended regression showed up, this one. The other two differences were changes I made deliberately in #289.

Those three examples are now directory-relative like the other six, so every example runs from where it lives — which removes the blind spot as well as the inconsistency. All nine AoC examples verified: day-1 gives 1688 and 1728, day-2 gives 1320534480, 2015 day1 gives 129.

`yarn build` succeeds.