### PR TITLE
feat(object): consistent ! convention, and fill in String's Ruby methods (#231)

### DIFF
--- a/docs/docs/language/methods.md
+++ b/docs/docs/language/methods.md
@@ -1,0 +1,168 @@
+# Methods
+
+> 👉 The `!` convention became consistent across all types in `0.24`
+
+Every value in RocketLang is an object, and objects are used by calling methods
+on them. `methods()` lists what a value responds to, and `wat()` lists the same
+names with their arguments:
+
+```js
+🚀 > [1, 2, 3].methods()
+=> ["first", "include?", "index", "join", "last", "pop", "push", "reverse", "reverse!", "size", "slices", "sort", "sort!", "sum", "to_m", "uniq", "uniq!"]
+```
+
+Both are sorted by name. Before `0.24` they came out in a different order on
+every run.
+
+## Methods ending in `!`
+
+A method whose name ends in `!` changes the value it is called on. The plain
+method of the same name leaves it alone and returns a new value instead:
+
+```js
+🚀 > a = [3, 1, 2]
+=> [3, 1, 2]
+🚀 > a.sort()
+=> [1, 2, 3]
+🚀 > a
+=> [3, 1, 2]
+🚀 > a.sort!()
+=> [1, 2, 3]
+🚀 > a
+=> [1, 2, 3]
+```
+
+`sort()` handed back a sorted copy and left `a` as it was. `sort!()` sorted `a`
+itself.
+
+The pairs are:
+
+| Pure | In place | Type |
+| ---- | -------- | ---- |
+| `reverse` | `reverse!` | `ARRAY`, `STRING` |
+| `compact` | `compact!` | `ARRAY`, `HASH` |
+| `flatten` | `flatten!` | `ARRAY` |
+| `rotate` | `rotate!` | `ARRAY` |
+| `sort` | `sort!` | `ARRAY` |
+| `uniq` | `uniq!` | `ARRAY` |
+| `merge` | `merge!` | `HASH` |
+| `capitalize` | `capitalize!` | `STRING` |
+| `chomp` | `chomp!` | `STRING` |
+| `chop` | `chop!` | `STRING` |
+| `downcase` | `downcase!` | `STRING` |
+| `lstrip` | `lstrip!` | `STRING` |
+| `replace` | `replace!` | `STRING` |
+| `rstrip` | `rstrip!` | `STRING` |
+| `strip` | `strip!` | `STRING` |
+| `swapcase` | `swapcase!` | `STRING` |
+| `upcase` | `upcase!` | `STRING` |
+
+A method that cannot sensibly be done in place has no `!` form. `size()` and
+`split()` return something other than a string, so there is nothing for a
+`size!()` to mean. Neither do the predicates, which answer a question rather
+than change anything: `empty?`, `include?`, `start_with?`, `end_with?`,
+`even?`, `odd?`, `zero?`, `positive?`, `negative?`, `nan?`, `finite?` and
+`nil?`.
+
+### A `!` method returns the value it changed
+
+Since `0.24` every `!` method returns the object it just modified, rather than
+`nil`. That makes them chainable:
+
+```js
+🚀 > "hello world".upcase!().reverse!()
+=> "DLROW OLLEH"
+```
+
+Before `0.24` these returned `nil`, so the second call in that chain failed with
+`undefined method '.reverse!()' for NIL`.
+
+This is a deliberate difference from Ruby. Ruby's `String#upcase!` is documented
+as returning "`self` if any changes were made, `nil` otherwise", which means the
+same chain raises there:
+
+```ruby
+# Ruby
+"ABC".upcase!            #=> nil
+"ABC".upcase!.reverse!   #=> NoMethodError: undefined method 'reverse!' for nil
+```
+
+RocketLang returns the receiver whether or not anything changed, so a chain
+never depends on whether the string happened to already be uppercase. The cost
+is that you cannot use the return value to ask "did this change anything".
+
+### A failed `!` method changes nothing
+
+`sort!` needs the elements to be all strings, all integers or all floats. When
+they are not, it returns an error and leaves the array as it was, rather than
+half-ordered:
+
+```js
+🚀 > a = [1, "x", 2]
+=> [1, "x", 2]
+🚀 > a.sort!()
+=> ERROR: Array does contain either an object not INTEGER, FLOAT or STRING or is mixed
+🚀 > a
+=> [1, "x", 2]
+```
+
+## Mutating methods without a `!`
+
+A few methods change the object without a `!`, because they have no pure
+counterpart — the name would mean nothing else:
+
+```js
+🚀 > a = [1]
+=> [1]
+🚀 > a.push(2).push(3)
+=> [1, 2, 3]
+🚀 > a.pop()
+=> 3
+🚀 > a
+=> [1, 2]
+```
+
+`push` returns the array, so pushes chain. `pop` returns the element it removed,
+since that is the only thing worth having back. `set` on a `MATRIX` behaves like
+`push`:
+
+```js
+🚀 > m = [[1, 2], [3, 4]].to_m()
+🚀 > m.set(0, 0, 9).set(1, 1, 9).to_a()
+=> [[9.0, 2.0], [3.0, 9.0]]
+```
+
+The rule these follow is what the method has to give back. One that puts
+something in returns the receiver, so it chains; one that takes something out
+returns what it took, so nothing is lost:
+
+| Returns the receiver | Returns what it removed |
+| -------------------- | ----------------------- |
+| `push`, `unshift`, `insert`, `concat`, `clear` (`ARRAY`) | `pop`, `shift`, `delete`, `delete_at` (`ARRAY`) |
+| `clear` (`HASH`) | `delete` (`HASH`) |
+| `set` (`MATRIX`) | |
+
+A method that removes something answers `nil` when there was nothing to remove,
+so a removal can be told from a miss:
+
+```js
+🚀 > a = [1, 2, 1]
+🚀 > a.delete(1)
+=> 1
+🚀 > a
+=> [2]
+🚀 > a.delete(9)
+=> nil
+```
+
+## Ordering
+
+`uniq` keeps the order in which elements first appear:
+
+```js
+🚀 > [5, 3, 1, 4, 2, 3].uniq()
+=> [5, 3, 1, 4, 2]
+```
+
+The `keys()` and `values()` methods of a `HASH` are the exception: their order
+is not defined and can differ between runs.

--- a/docs/docs/literals/array.md
+++ b/docs/docs/literals/array.md
@@ -27,14 +27,181 @@ puts(a[1:-2])
 
 ## Literal Specific Methods
 
-### first()
-> Returns `STRING|ARRAY|HASH|BOOLEAN|INTEGER|NIL|FUNCTION|FILE`
+### clear()
+> Returns `ARRAY`
+
+Removes every element and returns the array, so calls can be chained.
+
+
+<CodeBlockSimple input='a = [1, 2]
+a.clear()
+a
+' output='[1, 2]
+[]
+[]
+' />
+
+
+### compact()
+> Returns `ARRAY|ERROR`
+
+Returns a copy with every `nil` removed. The array itself is unchanged; use `compact!` to remove them in place.
+
+
+<CodeBlockSimple input='a = [1, nil, 2, nil]
+a.compact()
+a
+' output='[1, nil, 2, nil]
+[1, 2]
+[1, nil, 2, nil]
+' />
+
+
+### compact!()
+> Returns `ARRAY|ERROR`
+
+Removes every `nil` in place and returns the array, so calls can be chained.
+
+
+<CodeBlockSimple input='a = [1, nil, 2, nil]
+a.compact!()
+a
+' output='[1, nil, 2, nil]
+[1, 2]
+[1, 2]
+' />
+
+
+### concat(ARRAY)
+> Returns `ARRAY`
+
+Appends every element of the given array and returns the array, so calls can be chained.
+
+
+<CodeBlockSimple input='a = [1]
+a.concat([2, 3])
+a
+' output='[1]
+[1, 2, 3]
+[1, 2, 3]
+' />
+
+
+### count(INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL)
+> Returns `INTEGER`
+
+Without an argument this is `size`. With one it counts how often that element occurs, which is what `index` cannot tell you.
+
+
+<CodeBlockSimple input='[1, 2, 2, 3].count()
+[1, 2, 2, 3].count(2)
+[1, 2, 2, 3].count(9)
+' output='4
+2
+0
+' />
+
+
+### delete(INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL)
+> Returns `INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL`
+
+Removes every element equal to the argument and returns that argument, or `nil` when there was nothing to remove, so a removal can be told from a miss.
+
+
+<CodeBlockSimple input='a = [1, 2, 1]
+a.delete(1)
+a
+a.delete(9)
+' output='[1, 2, 1]
+1
+[2]
+nil
+' />
+
+
+### delete_at(INTEGER)
+> Returns `INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL`
+
+Removes the element at the given index and returns it. A negative index counts back from the end. An index that is not there gives `nil`, the same answer `first` gives for an empty array.
+
+
+<CodeBlockSimple input='a = [1, 2, 3]
+a.delete_at(1)
+a
+a.delete_at(9)
+' output='[1, 2, 3]
+2
+[1, 3]
+nil
+' />
+
+
+### drop(INTEGER)
+> Returns `ARRAY|ERROR`
+
+Returns everything after the first n elements as a new array. Dropping more than there are gives an empty array.
+
+
+<CodeBlockSimple input='[1, 2, 3].drop(2)
+[1, 2, 3].drop(9)
+' output='[3]
+[]
+' />
+
+
+### empty?()
+> Returns `BOOLEAN`
+
+Returns `true` when the array has no elements.
+
+
+<CodeBlockSimple input='[].empty?()
+[1].empty?()
+' output='true
+false
+' />
+
+
+### first(INTEGER)
+> Returns `INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL`
 
 Returns the first element of the array. Shorthand for `array[0]`
 
 
 <CodeBlockSimple input='["a", "b", 1, 2].first()
 ' output='"a"
+' />
+
+
+### flatten(INTEGER)
+> Returns `ARRAY|ERROR`
+
+Returns a copy with nested arrays inlined, all the way down by default or to the given depth. The array itself is unchanged; use `flatten!` to inline in place.
+
+
+<CodeBlockSimple input='a = [1, [2, [3]]]
+a.flatten()
+a.flatten(1)
+a
+' output='[1, [2, [3]]]
+[1, 2, 3]
+[1, 2, [3]]
+[1, [2, [3]]]
+' />
+
+
+### flatten!(INTEGER)
+> Returns `ARRAY|ERROR`
+
+Inlines nested arrays in place and returns the array, so calls can be chained. Takes the same optional depth as `flatten`.
+
+
+<CodeBlockSimple input='a = [1, [2, [3]]]
+a.flatten!()
+a
+' output='[1, [2, [3]]]
+[1, 2, 3]
+[1, 2, 3]
 ' />
 
 
@@ -62,23 +229,72 @@ Returns the index of the given element in the array if found. Otherwise return `
 ' />
 
 
+### insert(INTEGER, INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL)
+> Returns `ARRAY|ERROR`
+
+Inserts an element at the given index and returns the array. A negative index counts back from the end, so `-1` appends. An index past the end is an error rather than a silent padding with `nil`.
+
+
+<CodeBlockSimple input='a = [1, 2]
+a.insert(1, 9)
+a.insert(0 - 1, 8)
+a
+' output='[1, 2]
+[1, 9, 2]
+[1, 9, 2, 8]
+[1, 9, 2, 8]
+' />
+
+
 ### join(STRING)
 > Returns `STRING`
 
+Joins the elements into a string, with an optional separator between them. Every element has to have a string form; a function does not.
 
 
+<CodeBlockSimple input='[1, 2, 3].join()
+[1, 2, 3].join("-")
+' output='"123"
+"1-2-3"
+' />
 
 
-
-
-### last()
-> Returns `STRING|ARRAY|HASH|BOOLEAN|INTEGER|NIL|FUNCTION|FILE`
+### last(INTEGER)
+> Returns `INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL`
 
 Returns the last element of the array.
 
 
 <CodeBlockSimple input='["a", "b", 1, 2].last()
 ' output='2
+' />
+
+
+### max()
+> Returns `INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL`
+
+Returns the largest element, or `nil` for an empty array. Takes the same elements as `min`.
+
+
+<CodeBlockSimple input='[3, 1, 2].max()
+[].max()
+' output='3
+nil
+' />
+
+
+### min()
+> Returns `INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL`
+
+Returns the smallest element, or `nil` for an empty array. The elements have to be all strings, all integers or all floats, exactly as `sort` requires.
+
+
+<CodeBlockSimple input='[3, 1, 2].min()
+["b", "a"].min()
+[].min()
+' output='1
+"a"
+nil
 ' />
 
 
@@ -98,16 +314,16 @@ a
 
 
 ### push(STRING|ARRAY|HASH|BOOLEAN|INTEGER|NIL|FUNCTION|FILE)
-> Returns `NIL`
+> Returns `ARRAY`
 
-Adds the given object as last element to the array.
+Adds the given object as the last element and returns the array, so calls can be chained.
 
 
-<CodeBlockSimple input='a = [1,2,3]
-a.push("a")
-a
+<CodeBlockSimple input='d = [1,2,3]
+d.push("a")
+d
 ' output='[1, 2, 3]
-nil
+[1, 2, 3, "a"]
 [1, 2, 3, "a"]
 ' />
 
@@ -115,11 +331,92 @@ nil
 ### reverse()
 > Returns `ARRAY`
 
-Reverses the elements of the array
+Returns a new array with the elements in reverse order. The array itself is unchanged; use `reverse!` to reverse it in place.
 
 
-<CodeBlockSimple input='["a", "b", 1, 2].reverse()
-' output='[2, 1, "b", "a"]
+<CodeBlockSimple input='a = ["a", "b", 1, 2]
+a.reverse()
+a
+' output='["a", "b", 1, 2]
+[2, 1, "b", "a"]
+["a", "b", 1, 2]
+' />
+
+
+### reverse!()
+> Returns `ARRAY`
+
+Reverses the array in place and returns it, so calls can be chained.
+
+
+<CodeBlockSimple input='a = ["a", "b", 1, 2]
+a.reverse!()
+a
+' output='["a", "b", 1, 2]
+[2, 1, "b", "a"]
+[2, 1, "b", "a"]
+' />
+
+
+### rindex(INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL)
+> Returns `INTEGER`
+
+Returns the index of the last matching element, or `-1` when there is none. The mirror of `index`.
+
+
+<CodeBlockSimple input='[1, 2, 2, 3].rindex(2)
+[1, 2, 3].rindex(9)
+' output='2
+-1
+' />
+
+
+### rotate(INTEGER)
+> Returns `ARRAY|ERROR`
+
+Returns a copy with the first elements moved to the end, one by default. A negative count rotates the other way, and the count wraps. The array itself is unchanged; use `rotate!` to rotate in place.
+
+
+<CodeBlockSimple input='a = [1, 2, 3]
+a.rotate()
+a.rotate(2)
+a.rotate(0 - 1)
+a
+' output='[1, 2, 3]
+[2, 3, 1]
+[3, 1, 2]
+[3, 1, 2]
+[1, 2, 3]
+' />
+
+
+### rotate!(INTEGER)
+> Returns `ARRAY|ERROR`
+
+Rotates the array in place and returns it, so calls can be chained. Takes the same optional count as `rotate`.
+
+
+<CodeBlockSimple input='a = [1, 2, 3]
+a.rotate!()
+a
+' output='[1, 2, 3]
+[2, 3, 1]
+[2, 3, 1]
+' />
+
+
+### shift()
+> Returns `INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL`
+
+Removes the first element and returns it, or `nil` for an empty array. The mirror of `pop`, and like `pop` it changes the array without a `!`, because there is no pure version of taking something out.
+
+
+<CodeBlockSimple input='a = [1, 2, 3]
+a.shift()
+a
+' output='[1, 2, 3]
+1
+[2, 3]
 ' />
 
 
@@ -146,23 +443,59 @@ Returns the elements of the array in slices with the size of the given integer
 
 
 ### sort()
-> Returns `ARRAY`
+> Returns `ARRAY|ERROR`
 
-Sorts the array if it contains only one type of STRING, INTEGER or FLOAT
+Returns a new sorted array. The elements must all be STRING, all INTEGER or all FLOAT, otherwise an error is returned and the array is left untouched. Use `sort!` to sort in place.
 
 
-<CodeBlockSimple input='[3.4, 3.1, 2.0].sort()
-' output='[2.0, 3.1, 3.4]
+<CodeBlockSimple input='b = [3.4, 3.1, 2.0]
+b.sort()
+b
+' output='[3.4, 3.1, 2.0]
+[2.0, 3.1, 3.4]
+[3.4, 3.1, 2.0]
+' />
+
+
+### sort!()
+> Returns `ARRAY|ERROR`
+
+Sorts the array in place and returns it. A sort that cannot compare its elements returns an error and leaves the array unchanged rather than half-ordered.
+
+
+<CodeBlockSimple input='b = [3.4, 3.1, 2.0]
+b.sort!()
+b
+' output='[3.4, 3.1, 2.0]
+[2.0, 3.1, 3.4]
+[2.0, 3.1, 3.4]
 ' />
 
 
 ### sum()
 > Returns `INTEGER`
 
+Adds the elements up. They all have to be numbers.
 
 
+<CodeBlockSimple input='[1, 2, 3].sum()
+[1.5, 2.5].sum()
+' output='6
+3
+' />
 
 
+### take(INTEGER)
+> Returns `ARRAY|ERROR`
+
+Returns the first n elements as a new array. Asking for more than there are gives all of them. The result is a copy, so changing the original does not change it.
+
+
+<CodeBlockSimple input='[1, 2, 3].take(2)
+[1, 2, 3].take(9)
+' output='[1, 2]
+[1, 2, 3]
+' />
 
 
 ### to_m()
@@ -183,11 +516,45 @@ Converts a nested array (2D array) to a Matrix object.
 ### uniq()
 > Returns `ARRAY|ERROR`
 
-Returns a copy of the array with deduplicated elements. Raises an error if a element is not hashable.
+Returns a new array with duplicates removed, keeping the order of first appearance. Returns an error if an element is not hashable. Use `uniq!` to deduplicate in place.
 
 
-<CodeBlockSimple input='["a", 1, 1, 2].uniq()
-' output='[1, 2, "a"]
+<CodeBlockSimple input='c = ["a", 1, 1, 2]
+c.uniq()
+c
+' output='["a", 1, 1, 2]
+["a", 1, 2]
+["a", 1, 1, 2]
+' />
+
+
+### uniq!()
+> Returns `ARRAY|ERROR`
+
+Removes duplicates from the array in place and returns it, keeping the order of first appearance.
+
+
+<CodeBlockSimple input='c = ["a", 1, 1, 2]
+c.uniq!()
+c
+' output='["a", 1, 1, 2]
+["a", 1, 2]
+["a", 1, 2]
+' />
+
+
+### unshift(INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL)
+> Returns `ARRAY`
+
+Adds an element to the front and returns the array, so calls can be chained. The mirror of `push`.
+
+
+<CodeBlockSimple input='a = [2, 3]
+a.unshift(1)
+a
+' output='[2, 3]
+[1, 2, 3]
+[1, 2, 3]
 ' />
 
 
@@ -197,13 +564,30 @@ Returns a copy of the array with deduplicated elements. Raises an error if a ele
 ### methods()
 > Returns `ARRAY`
 
-Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array.
+Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The names are sorted, so the result is the same on every run. A type with no methods of its own returns an empty array.
 
 
-<CodeBlockSimple input='"test".methods().sort()
+<CodeBlockSimple input='1.0.methods().include?("round")
 true.methods()
-' output='["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+' output='true
 []
+' />
+
+
+### nil?()
+> Returns `BOOLEAN`
+
+Returns `true` only for `nil`. Reads better than comparing against `nil` at the end of a chain, and every type answers it.
+
+
+<CodeBlockSimple input='nil.nil?()
+1.nil?()
+"".nil?()
+[].first().nil?()
+' output='true
+false
+false
+true
 ' />
 
 
@@ -299,7 +683,7 @@ Returns the type of the object.
 ### wat()
 > Returns `STRING`
 
-Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none.
+Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none.
 
 
 <CodeBlockSimple input='true.wat()

--- a/docs/docs/literals/boolean.md
+++ b/docs/docs/literals/boolean.md
@@ -27,13 +27,30 @@ is_true = a != b;
 ### methods()
 > Returns `ARRAY`
 
-Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array.
+Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The names are sorted, so the result is the same on every run. A type with no methods of its own returns an empty array.
 
 
-<CodeBlockSimple input='"test".methods().sort()
+<CodeBlockSimple input='1.0.methods().include?("round")
 true.methods()
-' output='["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+' output='true
 []
+' />
+
+
+### nil?()
+> Returns `BOOLEAN`
+
+Returns `true` only for `nil`. Reads better than comparing against `nil` at the end of a chain, and every type answers it.
+
+
+<CodeBlockSimple input='nil.nil?()
+1.nil?()
+"".nil?()
+[].first().nil?()
+' output='true
+false
+false
+true
 ' />
 
 
@@ -129,7 +146,7 @@ Returns the type of the object.
 ### wat()
 > Returns `STRING`
 
-Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none.
+Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none.
 
 
 <CodeBlockSimple input='true.wat()

--- a/docs/docs/literals/error.md
+++ b/docs/docs/literals/error.md
@@ -62,13 +62,30 @@ Please note that performing `.msg()` on a ERROR object does result in a STRING o
 ### methods()
 > Returns `ARRAY`
 
-Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array.
+Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The names are sorted, so the result is the same on every run. A type with no methods of its own returns an empty array.
 
 
-<CodeBlockSimple input='"test".methods().sort()
+<CodeBlockSimple input='1.0.methods().include?("round")
 true.methods()
-' output='["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+' output='true
 []
+' />
+
+
+### nil?()
+> Returns `BOOLEAN`
+
+Returns `true` only for `nil`. Reads better than comparing against `nil` at the end of a chain, and every type answers it.
+
+
+<CodeBlockSimple input='nil.nil?()
+1.nil?()
+"".nil?()
+[].first().nil?()
+' output='true
+false
+false
+true
 ' />
 
 
@@ -164,7 +181,7 @@ Returns the type of the object.
 ### wat()
 > Returns `STRING`
 
-Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none.
+Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none.
 
 
 <CodeBlockSimple input='true.wat()

--- a/docs/docs/literals/file.md
+++ b/docs/docs/literals/file.md
@@ -81,13 +81,30 @@ Writes the given string to the file. Returns number of written bytes on success.
 ### methods()
 > Returns `ARRAY`
 
-Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array.
+Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The names are sorted, so the result is the same on every run. A type with no methods of its own returns an empty array.
 
 
-<CodeBlockSimple input='"test".methods().sort()
+<CodeBlockSimple input='1.0.methods().include?("round")
 true.methods()
-' output='["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+' output='true
 []
+' />
+
+
+### nil?()
+> Returns `BOOLEAN`
+
+Returns `true` only for `nil`. Reads better than comparing against `nil` at the end of a chain, and every type answers it.
+
+
+<CodeBlockSimple input='nil.nil?()
+1.nil?()
+"".nil?()
+[].first().nil?()
+' output='true
+false
+false
+true
 ' />
 
 
@@ -183,7 +200,7 @@ Returns the type of the object.
 ### wat()
 > Returns `STRING`
 
-Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none.
+Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none.
 
 
 <CodeBlockSimple input='true.wat()

--- a/docs/docs/literals/float.md
+++ b/docs/docs/literals/float.md
@@ -20,46 +20,148 @@ Returns the absolute value, as a float.
 ' />
 
 
-### ceil()
+### ceil(INTEGER)
 > Returns `FLOAT`
 
-Rounds up to the nearest whole number, as a float.
+Returns the smallest float that is not less than the number. An optional digit count says how many decimal places to keep; a negative count rounds to a power of ten. The result stays a `FLOAT` -- in Ruby it would be an `INTEGER`.
 
 
-<CodeBlockSimple input='3.14.ceil()
-(0.0 - 3.7).ceil()
-' output='4.0
--3.0
+<CodeBlockSimple input='1.5.ceil()
+1.561.ceil(2)
+555.5.ceil(0 - 1)
+' output='2.0
+1.57
+560.0
 ' />
 
 
-### floor()
-> Returns `FLOAT`
+### divmod(FLOAT)
+> Returns `ARRAY|ERROR`
 
-Rounds down to the nearest whole number, as a float.
+Returns the quotient and the remainder as a two-element array. Truncated toward zero, so it agrees with `Integer#divmod` and with `/`.
 
 
-<CodeBlockSimple input='3.14.floor()
-(0.0 - 3.2).floor()
-' output='3.0
--4.0
+<CodeBlockSimple input='11.0.divmod(4.0)
+11.0.divmod(0.0 - 4.0)
+' output='[2.0, 3.0]
+[-2.0, 3.0]
 ' />
 
 
-### round()
+### finite?()
+> Returns `BOOLEAN`
+
+Returns `true` when the number is neither infinite nor not-a-number.
+
+
+<CodeBlockSimple input='1.5.finite?()
+' output='true
+' />
+
+
+### floor(INTEGER)
 > Returns `FLOAT`
 
-Rounds to the nearest whole number, as a float. Halves round away from zero. The result stays a float, matching `Math.round`; chain `to_i` for an integer.
+Returns the largest float that is not greater than the number. Takes the same optional digit count as `ceil`.
 
 
-<CodeBlockSimple input='3.14.round()
-2.5.round()
-(0.0 - 2.5).round()
-3.7.round().to_i()
-' output='3.0
-3.0
--3.0
-4
+<CodeBlockSimple input='1.5.floor()
+1.567.floor(2)
+(0.0 - 1.5).floor()
+' output='1.0
+1.56
+-2.0
+' />
+
+
+### infinite?()
+> Returns `INTEGER|NIL`
+
+Returns `1` for positive infinity, `-1` for negative infinity and `nil` otherwise, so the direction is not lost. Use `finite?` for the plain yes-or-no question.
+
+
+<CodeBlockSimple input='1.5.infinite?()
+' output='nil
+' />
+
+
+### nan?()
+> Returns `BOOLEAN`
+
+Returns `true` when the number is not a number.
+
+
+<CodeBlockSimple input='1.5.nan?()
+' output='false
+' />
+
+
+### negative?()
+> Returns `BOOLEAN`
+
+Returns `true` when the number is less than zero.
+
+
+<CodeBlockSimple input='(0.0 - 1.5).negative?()
+0.0.negative?()
+' output='true
+false
+' />
+
+
+### positive?()
+> Returns `BOOLEAN`
+
+Returns `true` when the number is greater than zero.
+
+
+<CodeBlockSimple input='1.5.positive?()
+0.0.positive?()
+' output='true
+false
+' />
+
+
+### round(INTEGER)
+> Returns `FLOAT`
+
+Returns the number rounded to the nearest value, halves away from zero. Takes the same optional digit count as `ceil`.
+
+
+<CodeBlockSimple input='1.5.round()
+1.567.round(2)
+555.5.round(0 - 1)
+' output='2.0
+1.57
+560.0
+' />
+
+
+### truncate(INTEGER)
+> Returns `FLOAT`
+
+Returns the number with its fractional part dropped, rounding toward zero. Unlike `floor` this moves a negative number up. Takes the same optional digit count as `ceil`.
+
+
+<CodeBlockSimple input='1.567.truncate()
+(0.0 - 1.5).truncate()
+1.567.truncate(2)
+' output='1.0
+-1.0
+1.56
+' />
+
+
+### zero?()
+> Returns `BOOLEAN`
+
+Returns `true` when the number is zero.
+
+
+<CodeBlockSimple input='0.0.zero?()
+1.5.zero?()
+' output='true
+false
 ' />
 
 
@@ -69,13 +171,30 @@ Rounds to the nearest whole number, as a float. Halves round away from zero. The
 ### methods()
 > Returns `ARRAY`
 
-Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array.
+Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The names are sorted, so the result is the same on every run. A type with no methods of its own returns an empty array.
 
 
-<CodeBlockSimple input='"test".methods().sort()
+<CodeBlockSimple input='1.0.methods().include?("round")
 true.methods()
-' output='["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+' output='true
 []
+' />
+
+
+### nil?()
+> Returns `BOOLEAN`
+
+Returns `true` only for `nil`. Reads better than comparing against `nil` at the end of a chain, and every type answers it.
+
+
+<CodeBlockSimple input='nil.nil?()
+1.nil?()
+"".nil?()
+[].first().nil?()
+' output='true
+false
+false
+true
 ' />
 
 
@@ -171,7 +290,7 @@ Returns the type of the object.
 ### wat()
 > Returns `STRING`
 
-Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none.
+Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none.
 
 
 <CodeBlockSimple input='true.wat()

--- a/docs/docs/literals/hash.md
+++ b/docs/docs/literals/hash.md
@@ -52,6 +52,96 @@ true
 
 ## Literal Specific Methods
 
+### clear()
+> Returns `HASH`
+
+Removes every entry and returns the hash, so calls can be chained.
+
+
+<CodeBlockSimple input='h = {"a": 1}
+h.clear()
+h.size()
+' output='{"a": 1}
+{}
+0
+' />
+
+
+### compact()
+> Returns `HASH|ERROR`
+
+Returns a new hash without the entries whose value is `nil`. The hash itself is unchanged; use `compact!` to remove them in place.
+
+
+<CodeBlockSimple input='h = {"a": nil}
+h.compact().size()
+h.size()
+' output='{"a": nil}
+0
+1
+' />
+
+
+### compact!()
+> Returns `HASH|ERROR`
+
+Removes the entries whose value is `nil` in place and returns the hash, so calls can be chained.
+
+
+<CodeBlockSimple input='h = {"a": nil}
+h.compact!().size()
+h.size()
+' output='{"a": nil}
+0
+0
+' />
+
+
+### delete(INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL)
+> Returns `INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL`
+
+Removes the entry for a key and returns its value, or `nil` when the key was not there, so a removal can be told from a miss.
+
+
+<CodeBlockSimple input='h = {"a": 1}
+h.delete("a")
+h.size()
+h.delete("a")
+' output='{"a": 1}
+1
+0
+nil
+' />
+
+
+### empty?()
+> Returns `BOOLEAN`
+
+Returns `true` when the hash has no entries.
+
+
+<CodeBlockSimple input='{}.empty?()
+{"a": 1}.empty?()
+' output='true
+false
+' />
+
+
+### fetch(INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL, INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL)
+> Returns `INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL`
+
+Returns the value for a key. Without a fallback a missing key is an error, which is the difference from `get`, where a fallback is required.
+
+
+<CodeBlockSimple input='h = {"a": 1}
+h.fetch("a")
+h.fetch("z", 0)
+' output='{"a": 1}
+1
+0
+' />
+
+
 ### get(INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL, INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL)
 > Returns `INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL`
 
@@ -60,7 +150,7 @@ Returns the value of the given key or the default
 
 <CodeBlockSimple input='{"a": "1", "b": "2"}.get("a", 10)
 {"a": "1", "b": "2"}.get("c", 10)
-' output='1
+' output='"1"
 10
 ' />
 
@@ -73,28 +163,94 @@ Returns true or false wether the hash contains the given object as key
 
 <CodeBlockSimple input='{"a": 1, 1: "b"}.include?(1)
 {"a": 1, 1: "b"}.include?("c")
-' output='true false' />
+' output='true
+false
+' />
+
+
+### invert()
+> Returns `HASH|ERROR`
+
+Returns a new hash with keys and values swapped. Values that repeat collapse into one entry, and which one survives is not defined. A value that cannot be a key is an error.
+
+
+<CodeBlockSimple input='h = {"a": 1}
+h.invert().get(1, "missing")
+' output='{"a": 1}
+"a"
+' />
 
 
 ### keys()
 > Returns `ARRAY`
 
-Returns the keys of the hash.
+Returns the keys of the hash. The order is **not** defined and can differ between runs of the same program, so sort the result if you need it stable.
 
 
-<CodeBlockSimple input='{"a": "1", "b": "2"}.keys()
-' output='["a", "b"]
+<CodeBlockSimple input='{"a": "1"}.keys()
+{"a": "1", "b": "2"}.keys().sort()
+' output='["a"]
+["a", "b"]
+' />
+
+
+### merge(HASH)
+> Returns `HASH|ERROR`
+
+Returns a new hash with the entries of both. The argument wins where a key is in both. The hash itself is unchanged; use `merge!` to merge in place.
+
+
+<CodeBlockSimple input='h = {"a": 1}
+h.merge({"b": 2}).size()
+h.size()
+h.merge({"a": 9}).get("a", 0)
+' output='{"a": 1}
+2
+1
+9
+' />
+
+
+### merge!(HASH)
+> Returns `HASH|ERROR`
+
+Merges the given hash in place and returns the hash, so calls can be chained.
+
+
+<CodeBlockSimple input='h = {"a": 1}
+h.merge!({"b": 2}).size()
+h.size()
+' output='{"a": 1}
+2
+2
+' />
+
+
+### size()
+> Returns `INTEGER`
+
+Returns the number of entries.
+
+
+<CodeBlockSimple input='h = {"a": 1}
+h.size()
+{}.size()
+' output='{"a": 1}
+1
+0
 ' />
 
 
 ### values()
 > Returns `ARRAY`
 
-Returns the values of the hash.
+Returns the values of the hash, in the same unspecified order as `keys`.
 
 
-<CodeBlockSimple input='{"a": "1", "b": "2"}.values()
-' output='["1", "2"]
+<CodeBlockSimple input='{"a": "1"}.values()
+{"a": "1", "b": "2"}.values().sort()
+' output='["1"]
+["1", "2"]
 ' />
 
 
@@ -104,13 +260,30 @@ Returns the values of the hash.
 ### methods()
 > Returns `ARRAY`
 
-Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array.
+Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The names are sorted, so the result is the same on every run. A type with no methods of its own returns an empty array.
 
 
-<CodeBlockSimple input='"test".methods().sort()
+<CodeBlockSimple input='1.0.methods().include?("round")
 true.methods()
-' output='["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+' output='true
 []
+' />
+
+
+### nil?()
+> Returns `BOOLEAN`
+
+Returns `true` only for `nil`. Reads better than comparing against `nil` at the end of a chain, and every type answers it.
+
+
+<CodeBlockSimple input='nil.nil?()
+1.nil?()
+"".nil?()
+[].first().nil?()
+' output='true
+false
+false
+true
 ' />
 
 
@@ -206,7 +379,7 @@ Returns the type of the object.
 ### wat()
 > Returns `STRING`
 
-Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none.
+Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none.
 
 
 <CodeBlockSimple input='true.wat()

--- a/docs/docs/literals/http.md
+++ b/docs/docs/literals/http.md
@@ -61,13 +61,30 @@ Starts a blocking webserver on the given port.
 ### methods()
 > Returns `ARRAY`
 
-Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array.
+Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The names are sorted, so the result is the same on every run. A type with no methods of its own returns an empty array.
 
 
-<CodeBlockSimple input='"test".methods().sort()
+<CodeBlockSimple input='1.0.methods().include?("round")
 true.methods()
-' output='["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+' output='true
 []
+' />
+
+
+### nil?()
+> Returns `BOOLEAN`
+
+Returns `true` only for `nil`. Reads better than comparing against `nil` at the end of a chain, and every type answers it.
+
+
+<CodeBlockSimple input='nil.nil?()
+1.nil?()
+"".nil?()
+[].first().nil?()
+' output='true
+false
+false
+true
 ' />
 
 
@@ -163,7 +180,7 @@ Returns the type of the object.
 ### wat()
 > Returns `STRING`
 
-Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none.
+Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none.
 
 
 <CodeBlockSimple input='true.wat()

--- a/docs/docs/literals/integer.md
+++ b/docs/docs/literals/integer.md
@@ -42,7 +42,218 @@ Returns the base of the integer.
 
 
 <CodeBlockSimple input='"0b1010".to_i().base()
-' output='2' />
+' output='2
+' />
+
+
+### bit_length()
+> Returns `INTEGER`
+
+Returns how many bits are needed to represent the number, not counting the sign. A negative number needs as many as its complement, so `-256` is 8 bits just like `255`.
+
+
+<CodeBlockSimple input='255.bit_length()
+256.bit_length()
+0.bit_length()
+' output='8
+9
+0
+' />
+
+
+### ceil(INTEGER)
+> Returns `INTEGER`
+
+Rounds up to a multiple of ten, given a negative digit count. An integer is already exact, so no argument, or a count of zero or more, returns it unchanged.
+
+
+<CodeBlockSimple input='555.ceil(0 - 1)
+555.ceil(0 - 2)
+555.ceil()
+' output='560
+600
+555
+' />
+
+
+### chr()
+> Returns `STRING|ERROR`
+
+Returns the character with this code point, as a string. The inverse of a single entry of `string.ascii()`. A value outside the range of a character is an error.
+
+
+<CodeBlockSimple input='65.chr()
+' output='"A"
+' />
+
+
+### digits(INTEGER)
+> Returns `ARRAY|ERROR`
+
+Returns the digits of the number, least significant first, in base 10 or in a given base. A negative number has no digits and gives an error.
+
+
+<CodeBlockSimple input='12345.digits()
+12345.digits(7)
+0.digits()
+' output='[5, 4, 3, 2, 1]
+[4, 6, 6, 0, 5]
+[0]
+' />
+
+
+### divmod(INTEGER)
+> Returns `ARRAY|ERROR`
+
+Returns the quotient and the remainder as a two-element array. Both follow the `/` and `%` operators, which truncate toward zero. Ruby floors instead, so it answers `[-3, -1]` for the second example below.
+
+
+<CodeBlockSimple input='11.divmod(4)
+11.divmod(0 - 4)
+' output='[2, 3]
+[-2, 3]
+' />
+
+
+### even?()
+> Returns `BOOLEAN`
+
+Returns `true` when the number divides by two exactly.
+
+
+<CodeBlockSimple input='4.even?()
+5.even?()
+' output='true
+false
+' />
+
+
+### floor(INTEGER)
+> Returns `INTEGER`
+
+Rounds down to a multiple of ten, given a negative digit count. No argument, or a count of zero or more, returns the number unchanged.
+
+
+<CodeBlockSimple input='555.floor(0 - 1)
+555.floor(0 - 2)
+' output='550
+500
+' />
+
+
+### gcd(INTEGER)
+> Returns `INTEGER|ERROR`
+
+Returns the greatest common divisor of the two numbers, always positive. Like the infix operators, it refuses two integers of different bases.
+
+
+<CodeBlockSimple input='36.gcd(60)
+3.gcd(0 - 7)
+' output='12
+1
+' />
+
+
+### lcm(INTEGER)
+> Returns `INTEGER|ERROR`
+
+Returns the least common multiple of the two numbers, always positive.
+
+
+<CodeBlockSimple input='36.lcm(60)
+3.lcm(0 - 7)
+' output='180
+21
+' />
+
+
+### negative?()
+> Returns `BOOLEAN`
+
+Returns `true` when the number is less than zero.
+
+
+<CodeBlockSimple input='(0 - 1).negative?()
+0.negative?()
+' output='true
+false
+' />
+
+
+### odd?()
+> Returns `BOOLEAN`
+
+Returns `true` when the number does not divide by two exactly.
+
+
+<CodeBlockSimple input='5.odd?()
+4.odd?()
+' output='true
+false
+' />
+
+
+### positive?()
+> Returns `BOOLEAN`
+
+Returns `true` when the number is greater than zero.
+
+
+<CodeBlockSimple input='1.positive?()
+0.positive?()
+' output='true
+false
+' />
+
+
+### pow(INTEGER, INTEGER)
+> Returns `INTEGER|ERROR`
+
+Returns the number raised to the given power. A second argument takes the result modulo it, which keeps large exponents workable. A negative exponent is an error, since the result would not be an integer.
+
+
+<CodeBlockSimple input='2.pow(3)
+2.pow(3, 5)
+' output='8
+3
+' />
+
+
+### pred()
+> Returns `INTEGER`
+
+Returns the previous integer, keeping the base of the receiver.
+
+
+<CodeBlockSimple input='1.pred()
+0.pred()
+' output='0
+-1
+' />
+
+
+### round(INTEGER)
+> Returns `INTEGER`
+
+Rounds to the nearest multiple of ten, halves away from zero, given a negative digit count. No argument, or a count of zero or more, returns the number unchanged.
+
+
+<CodeBlockSimple input='555.round(0 - 1)
+554.round(0 - 1)
+' output='560
+550
+' />
+
+
+### succ()
+> Returns `INTEGER`
+
+Returns the next integer, keeping the base of the receiver.
+
+
+<CodeBlockSimple input='1.succ()
+' output='2
+' />
 
 
 ### to_base(INTEGER)
@@ -56,19 +267,62 @@ Converts the integer into a integer with the given base
 ' />
 
 
+### truncate(INTEGER)
+> Returns `INTEGER`
+
+Drops the last digits, rounding toward zero, given a negative digit count. No argument, or a count of zero or more, returns the number unchanged.
+
+
+<CodeBlockSimple input='555.truncate(0 - 1)
+(0 - 555).truncate(0 - 1)
+' output='550
+-550
+' />
+
+
+### zero?()
+> Returns `BOOLEAN`
+
+Returns `true` when the number is zero.
+
+
+<CodeBlockSimple input='0.zero?()
+1.zero?()
+' output='true
+false
+' />
+
+
 
 ## Generic Literal Methods
 
 ### methods()
 > Returns `ARRAY`
 
-Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array.
+Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The names are sorted, so the result is the same on every run. A type with no methods of its own returns an empty array.
 
 
-<CodeBlockSimple input='"test".methods().sort()
+<CodeBlockSimple input='1.0.methods().include?("round")
 true.methods()
-' output='["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+' output='true
 []
+' />
+
+
+### nil?()
+> Returns `BOOLEAN`
+
+Returns `true` only for `nil`. Reads better than comparing against `nil` at the end of a chain, and every type answers it.
+
+
+<CodeBlockSimple input='nil.nil?()
+1.nil?()
+"".nil?()
+[].first().nil?()
+' output='true
+false
+false
+true
 ' />
 
 
@@ -164,7 +418,7 @@ Returns the type of the object.
 ### wat()
 > Returns `STRING`
 
-Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none.
+Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none.
 
 
 <CodeBlockSimple input='true.wat()

--- a/docs/docs/literals/matrix.md
+++ b/docs/docs/literals/matrix.md
@@ -101,7 +101,7 @@ m.rows()
 ### set(INTEGER, INTEGER, FLOAT|INTEGER)
 > Returns `NIL|ERROR`
 
-Sets the element at the specified row and column (0-indexed).
+Sets the element at the specified row and column (0-indexed) and returns the matrix, so calls can be chained.
 
 
 <CodeBlockSimple input='m = [[1, 2, 3], [4, 5, 6]].to_m()
@@ -112,11 +112,15 @@ m
 │ 1.0  2.0  3.0 │
 │ 4.0  5.0  6.0 │
 └               ┘
-nil
 2x3 matrix
 ┌                ┐
-│ 1.0   2.0  99.0 │
-│ 4.0   5.0   6.0 │
+│ 1.0  2.0  99.0 │
+│ 4.0  5.0   6.0 │
+└                ┘
+2x3 matrix
+┌                ┐
+│ 1.0  2.0  99.0 │
+│ 4.0  5.0   6.0 │
 └                ┘
 ' />
 
@@ -196,13 +200,30 @@ m.transpose()
 ### methods()
 > Returns `ARRAY`
 
-Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array.
+Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The names are sorted, so the result is the same on every run. A type with no methods of its own returns an empty array.
 
 
-<CodeBlockSimple input='"test".methods().sort()
+<CodeBlockSimple input='1.0.methods().include?("round")
 true.methods()
-' output='["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+' output='true
 []
+' />
+
+
+### nil?()
+> Returns `BOOLEAN`
+
+Returns `true` only for `nil`. Reads better than comparing against `nil` at the end of a chain, and every type answers it.
+
+
+<CodeBlockSimple input='nil.nil?()
+1.nil?()
+"".nil?()
+[].first().nil?()
+' output='true
+false
+false
+true
 ' />
 
 
@@ -298,7 +319,7 @@ Returns the type of the object.
 ### wat()
 > Returns `STRING`
 
-Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none.
+Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none.
 
 
 <CodeBlockSimple input='true.wat()

--- a/docs/docs/literals/nil.md
+++ b/docs/docs/literals/nil.md
@@ -15,13 +15,30 @@ It will be returned if something returns nothing (eg. puts or an empty break/nex
 ### methods()
 > Returns `ARRAY`
 
-Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array.
+Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The names are sorted, so the result is the same on every run. A type with no methods of its own returns an empty array.
 
 
-<CodeBlockSimple input='"test".methods().sort()
+<CodeBlockSimple input='1.0.methods().include?("round")
 true.methods()
-' output='["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+' output='true
 []
+' />
+
+
+### nil?()
+> Returns `BOOLEAN`
+
+Returns `true` only for `nil`. Reads better than comparing against `nil` at the end of a chain, and every type answers it.
+
+
+<CodeBlockSimple input='nil.nil?()
+1.nil?()
+"".nil?()
+[].first().nil?()
+' output='true
+false
+false
+true
 ' />
 
 
@@ -117,7 +134,7 @@ Returns the type of the object.
 ### wat()
 > Returns `STRING`
 
-Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none.
+Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none.
 
 
 <CodeBlockSimple input='true.wat()

--- a/docs/docs/literals/string.md
+++ b/docs/docs/literals/string.md
@@ -84,31 +84,169 @@ Returns the character codes of the string, always as an array with one entry per
 ' />
 
 
+### capitalize()
+> Returns `STRING`
+
+Returns a copy with the first character upcased and every following character downcased, as Ruby's `capitalize` does. A capital in the middle of the string is therefore lost.
+
+
+<CodeBlockSimple input='a = "hello World!"
+a.capitalize()
+a
+' output='"hello World!"
+"Hello world!"
+"hello World!"
+' />
+
+
+### capitalize!()
+> Returns `STRING`
+
+Upcases the first character and downcases the rest in place, and returns the string, so calls can be chained.
+
+
+<CodeBlockSimple input='a = "hello World!"
+a.capitalize!()
+a
+' output='"hello World!"
+"Hello world!"
+"Hello world!"
+' />
+
+
+### chomp(STRING)
+> Returns `STRING`
+
+Returns a copy with one trailing line ending removed: `\r\n`, `\n` or `\r`. Given a string it removes one trailing occurrence of that string instead. Given `""` it removes every trailing `\n` and `\r\n`, which is the way to drop blank lines at the end of a file.
+
+
+<CodeBlockSimple input='a = "line\n"
+a.chomp()
+a.chomp() == "line"
+"abcdd".chomp("d")
+"a\n\n\n".chomp("")
+' output='"line\n"
+"line"
+true
+"abcd"
+"a"
+' />
+
+
+### chomp!(STRING)
+> Returns `STRING`
+
+Removes one trailing line ending in place and returns the string, so calls can be chained. Takes the same optional separator as `chomp`.
+
+
+<CodeBlockSimple input='a = "line\n"
+a.chomp!()
+a
+' output='"line\n"
+"line"
+"line"
+' />
+
+
+### chop()
+> Returns `STRING`
+
+Returns a copy with the last character removed. A trailing `\r\n` is removed as a unit so a line ending is never left half there. Chopping an empty string gives an empty string rather than an error.
+
+
+<CodeBlockSimple input='a = "abcd"
+a.chop()
+a
+"".chop()
+' output='"abcd"
+"abc"
+"abcd"
+""
+' />
+
+
+### chop!()
+> Returns `STRING`
+
+Removes the last character in place and returns the string, so calls can be chained.
+
+
+<CodeBlockSimple input='a = "abcd"
+a.chop!()
+a
+' output='"abcd"
+"abc"
+"abc"
+' />
+
+
 ### count(STRING)
 > Returns `INTEGER`
 
 Counts how often a given substring occurs in the string.
 
 
-
+<CodeBlockSimple input='"test".count("t")
+' output='2
+' />
 
 
 ### downcase()
 > Returns `STRING`
 
-Returns the string with all uppercase letters replaced with lowercase counterparts.
+Returns a copy with all uppercase letters replaced by their lowercase counterparts.
 
 
-
+<CodeBlockSimple input='a = "TEST"
+a.downcase()
+a
+' output='"TEST"
+"test"
+"TEST"
+' />
 
 
 ### downcase!()
-> Returns `NIL`
+> Returns `STRING`
 
-Replaces all upcase characters with lowercase counterparts.
+Replaces uppercase characters with their lowercase counterparts in place and returns the string, so calls can be chained.
 
 
+<CodeBlockSimple input='a = "TEST"
+a.downcase!()
+a
+' output='"TEST"
+"test"
+"test"
+' />
 
+
+### empty?()
+> Returns `BOOLEAN`
+
+Returns `true` when the string has no characters.
+
+
+<CodeBlockSimple input='"".empty?()
+" ".empty?()
+' output='true
+false
+' />
+
+
+### end_with?(STRING)
+> Returns `BOOLEAN`
+
+Returns `true` when the string ends with any of the given strings.
+
+
+<CodeBlockSimple input='"test.rl".end_with?(".rl")
+"test.rl".end_with?(".go")
+"test.rl".end_with?(".go", ".rl")
+' output='true
+false
+true
+' />
 
 
 ### find(STRING)
@@ -117,7 +255,9 @@ Replaces all upcase characters with lowercase counterparts.
 Returns the character index of a given string if found. Otherwise returns `-1`
 
 
-
+<CodeBlockSimple input='"test".find("e")
+' output='1
+' />
 
 
 ### format(STRING|INTEGER|FLOAT|BOOLEAN|ARRAY|HASH)
@@ -126,7 +266,22 @@ Returns the character index of a given string if found. Otherwise returns `-1`
 Formats according to a format specifier and returns the resulting string
 
 
+<CodeBlockSimple input='"%s is %d".format("a", 1)
+' output='"a is 1"
+' />
 
+
+### include?(STRING)
+> Returns `BOOLEAN`
+
+Returns `true` when the string contains the given substring.
+
+
+<CodeBlockSimple input='"test".include?("es")
+"test".include?("xy")
+' output='true
+false
+' />
 
 
 ### lines()
@@ -135,16 +290,69 @@ Formats according to a format specifier and returns the resulting string
 Splits the string at newline escape sequence and return all chunks in an array. Shorthand for `string.split("\n")`.
 
 
+<CodeBlockSimple input='"a\nb".lines()
+' output='["a", "b"]
+' />
 
+
+### lstrip()
+> Returns `STRING`
+
+Returns a copy with leading whitespace removed. See `rstrip` for the trailing end and `strip` for both.
+
+
+<CodeBlockSimple input='a = "  test  "
+a.lstrip()
+a
+' output='"  test  "
+"test  "
+"  test  "
+' />
+
+
+### lstrip!()
+> Returns `STRING`
+
+Removes leading whitespace in place and returns the string, so calls can be chained.
+
+
+<CodeBlockSimple input='a = "  test  "
+a.lstrip!()
+a
+' output='"  test  "
+"test  "
+"test  "
+' />
 
 
 ### replace(STRING, STRING)
 > Returns `STRING`
 
-Replaces the first string with the second string in the given string.
+Returns a copy with every occurrence of the first string replaced by the second. This is Ruby's `gsub` with plain strings rather than Ruby's `replace`.
 
 
+<CodeBlockSimple input='a = "test"
+a.replace("t", "f")
+a
+' output='"test"
+"fesf"
+"test"
+' />
 
+
+### replace!(STRING, STRING)
+> Returns `STRING`
+
+Replaces every occurrence of the first string with the second in place and returns the string, so calls can be chained.
+
+
+<CodeBlockSimple input='a = "test"
+a.replace!("t", "f")
+a
+' output='"test"
+"fesf"
+"fesf"
+' />
 
 
 ### reverse()
@@ -153,16 +361,58 @@ Replaces the first string with the second string in the given string.
 Returns a copy of the string with all characters reversed.
 
 
-
+<CodeBlockSimple input='a = "stressed"
+a.reverse()
+a
+' output='"stressed"
+"desserts"
+"stressed"
+' />
 
 
 ### reverse!()
-> Returns `NIL`
+> Returns `STRING`
 
-Replaces all the characters in a string in reverse order.
+Reverses the characters in place and returns the string, so calls can be chained.
 
 
+<CodeBlockSimple input='a = "stressed"
+a.reverse!()
+a
+' output='"stressed"
+"desserts"
+"desserts"
+' />
 
+
+### rstrip()
+> Returns `STRING`
+
+Returns a copy with trailing whitespace removed. See `lstrip` for the leading end and `strip` for both.
+
+
+<CodeBlockSimple input='a = "  test  "
+a.rstrip()
+a
+' output='"  test  "
+"  test"
+"  test  "
+' />
+
+
+### rstrip!()
+> Returns `STRING`
+
+Removes trailing whitespace in place and returns the string, so calls can be chained.
+
+
+<CodeBlockSimple input='a = "  test  "
+a.rstrip!()
+a
+' output='"  test  "
+"  test"
+"  test"
+' />
 
 
 ### size()
@@ -171,7 +421,9 @@ Replaces all the characters in a string in reverse order.
 Returns the amount of characters in the string.
 
 
-
+<CodeBlockSimple input='"test".size()
+' output='4
+' />
 
 
 ### split(STRING)
@@ -180,43 +432,116 @@ Returns the amount of characters in the string.
 Splits the string on a given seperator and returns all the chunks in an array. Default seperator is `" "`
 
 
+<CodeBlockSimple input='"a b".split()
+"a-b".split("-")
+' output='["a", "b"]
+["a", "b"]
+' />
 
+
+### start_with?(STRING)
+> Returns `BOOLEAN`
+
+Returns `true` when the string starts with any of the given strings.
+
+
+<CodeBlockSimple input='"test.rl".start_with?("test")
+"test.rl".start_with?("prod")
+"test.rl".start_with?("prod", "test")
+' output='true
+false
+true
+' />
 
 
 ### strip()
 > Returns `STRING`
 
-Returns a copy of the string with all leading and trailing whitespaces removed.
+Returns a copy with leading and trailing whitespace removed.
 
 
-
+<CodeBlockSimple input='a = "  test  "
+a.strip()
+a
+' output='"  test  "
+"test"
+"  test  "
+' />
 
 
 ### strip!()
-> Returns `NIL`
+> Returns `STRING`
 
-Removes all leading and trailing whitespaces in the string.
+Removes leading and trailing whitespace in place and returns the string, so calls can be chained.
 
 
+<CodeBlockSimple input='a = "  test  "
+a.strip!()
+a
+' output='"  test  "
+"test"
+"test"
+' />
 
+
+### swapcase()
+> Returns `STRING`
+
+Returns a copy with every uppercase character downcased and every lowercase character upcased.
+
+
+<CodeBlockSimple input='a = "Hello World"
+a.swapcase()
+a
+' output='"Hello World"
+"hELLO wORLD"
+"Hello World"
+' />
+
+
+### swapcase!()
+> Returns `STRING`
+
+Swaps the case of every character in place and returns the string, so calls can be chained.
+
+
+<CodeBlockSimple input='a = "Hello World"
+a.swapcase!()
+a
+' output='"Hello World"
+"hELLO wORLD"
+"hELLO wORLD"
+' />
 
 
 ### upcase()
 > Returns `STRING`
 
-Returns the string with all lowercase letters replaced with uppercase counterparts.
+Returns a copy with all lowercase letters replaced by their uppercase counterparts.
 
 
-
+<CodeBlockSimple input='a = "test"
+a.upcase()
+a
+' output='"test"
+"TEST"
+"test"
+' />
 
 
 ### upcase!()
-> Returns `NIL`
+> Returns `STRING`
 
-Replaces all lowercase characters with upcase counterparts.
+Replaces lowercase characters with their uppercase counterparts in place and returns the string, so calls can be chained.
 
 
-
+<CodeBlockSimple input='a = "test"
+a.upcase!()
+a
+' output='"test"
+"TEST"
+"TEST"
+' />
 
 
 
@@ -225,13 +550,30 @@ Replaces all lowercase characters with upcase counterparts.
 ### methods()
 > Returns `ARRAY`
 
-Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array.
+Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The names are sorted, so the result is the same on every run. A type with no methods of its own returns an empty array.
 
 
-<CodeBlockSimple input='"test".methods().sort()
+<CodeBlockSimple input='1.0.methods().include?("round")
 true.methods()
-' output='["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
+' output='true
 []
+' />
+
+
+### nil?()
+> Returns `BOOLEAN`
+
+Returns `true` only for `nil`. Reads better than comparing against `nil` at the end of a chain, and every type answers it.
+
+
+<CodeBlockSimple input='nil.nil?()
+1.nil?()
+"".nil?()
+[].first().nil?()
+' output='true
+false
+false
+true
 ' />
 
 
@@ -327,7 +669,7 @@ Returns the type of the object.
 ### wat()
 > Returns `STRING`
 
-Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none.
+Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none.
 
 
 <CodeBlockSimple input='true.wat()

--- a/docs/literals/array.yml
+++ b/docs/literals/array.yml
@@ -1,5 +1,4 @@
 title: "Array"
-description:
 example: |
   a = [1, 2, 3, 4, 5]
   puts(a[2])
@@ -18,30 +17,124 @@ example: |
   [2, 3]
   [1, 2, 8, 9, 5]
 methods:
-  reverse:
-    description: "Reverses the elements of the array"
+  clear:
+    description: "Removes every element and returns the array, so calls can be chained."
     input: |
-      ["a", "b", 1, 2].reverse()
+      a = [1, 2]
+      a.clear()
+      a
     output: |
-      [2, 1, "b", "a"]
-  size:
-    description: "Returns the amount of elements in the array."
+      [1, 2]
+      []
+      []
+  compact:
+    description: "Returns a copy with every `nil` removed. The array itself is unchanged; use `compact!` to remove them in place."
     input: |
-      ["a", "b", 1, 2].size()
+      a = [1, nil, 2, nil]
+      a.compact()
+      a
+    output: |
+      [1, nil, 2, nil]
+      [1, 2]
+      [1, nil, 2, nil]
+  compact!:
+    description: "Removes every `nil` in place and returns the array, so calls can be chained."
+    input: |
+      a = [1, nil, 2, nil]
+      a.compact!()
+      a
+    output: |
+      [1, nil, 2, nil]
+      [1, 2]
+      [1, 2]
+  concat:
+    description: "Appends every element of the given array and returns the array, so calls can be chained."
+    input: |
+      a = [1]
+      a.concat([2, 3])
+      a
+    output: |
+      [1]
+      [1, 2, 3]
+      [1, 2, 3]
+  count:
+    description: "Without an argument this is `size`. With one it counts how often that element occurs, which is what `index` cannot tell you."
+    input: |
+      [1, 2, 2, 3].count()
+      [1, 2, 2, 3].count(2)
+      [1, 2, 2, 3].count(9)
     output: |
       4
-  sort:
-    description: "Sorts the array if it contains only one type of STRING, INTEGER or FLOAT"
+      2
+      0
+  delete:
+    description: "Removes every element equal to the argument and returns that argument, or `nil` when there was nothing to remove, so a removal can be told from a miss."
     input: |
-      [3.4, 3.1, 2.0].sort()
+      a = [1, 2, 1]
+      a.delete(1)
+      a
+      a.delete(9)
     output: |
-      [2.0, 3.1, 3.4]
-  uniq:
-    description: "Returns a copy of the array with deduplicated elements. Raises an error if a element is not hashable."
+      [1, 2, 1]
+      1
+      [2]
+      nil
+  delete_at:
+    description: "Removes the element at the given index and returns it. A negative index counts back from the end. An index that is not there gives `nil`, the same answer `first` gives for an empty array."
     input: |
-      ["a", 1, 1, 2].uniq()
+      a = [1, 2, 3]
+      a.delete_at(1)
+      a
+      a.delete_at(9)
     output: |
-      [1, 2, "a"]
+      [1, 2, 3]
+      2
+      [1, 3]
+      nil
+  drop:
+    description: "Returns everything after the first n elements as a new array. Dropping more than there are gives an empty array."
+    input: |
+      [1, 2, 3].drop(2)
+      [1, 2, 3].drop(9)
+    output: |
+      [3]
+      []
+  empty?:
+    description: "Returns `true` when the array has no elements."
+    input: |
+      [].empty?()
+      [1].empty?()
+    output: |
+      true
+      false
+  first:
+    description: "Returns the first element of the array. Shorthand for `array[0]`"
+    input: |
+      ["a", "b", 1, 2].first()
+    output: |
+      "a"
+  flatten:
+    description: "Returns a copy with nested arrays inlined, all the way down by default or to the given depth. The array itself is unchanged; use `flatten!` to inline in place."
+    input: |
+      a = [1, [2, [3]]]
+      a.flatten()
+      a.flatten(1)
+      a
+    output: |
+      [1, [2, [3]]]
+      [1, 2, 3]
+      [1, 2, [3]]
+      [1, [2, [3]]]
+  flatten!:
+    description: "Inlines nested arrays in place and returns the array, so calls can be chained. Takes the same optional depth as `flatten`."
+    input: |
+      a = [1, [2, [3]]]
+      a.flatten!()
+      a
+    output: |
+      [1, [2, [3]]]
+      [1, 2, 3]
+      [1, 2, 3]
   include?:
     description: "Returns true or false wether the array contains the given element"
     input: |
@@ -56,24 +149,50 @@ methods:
       ["a", "b", 1, 2].index(1)
     output: |
       2
-  first:
-    description: "Returns the first element of the array. Shorthand for `array[0]`"
+  insert:
+    description: "Inserts an element at the given index and returns the array. A negative index counts back from the end, so `-1` appends. An index past the end is an error rather than a silent padding with `nil`."
     input: |
-      ["a", "b", 1, 2].first()
+      a = [1, 2]
+      a.insert(1, 9)
+      a.insert(0 - 1, 8)
+      a
     output: |
-      "a"
+      [1, 2]
+      [1, 9, 2]
+      [1, 9, 2, 8]
+      [1, 9, 2, 8]
+  join:
+    description: "Joins the elements into a string, with an optional separator between them. Every element has to have a string form; a function does not."
+    input: |
+      [1, 2, 3].join()
+      [1, 2, 3].join("-")
+    output: |
+      "123"
+      "1-2-3"
   last:
     description: "Returns the last element of the array."
     input: |
       ["a", "b", 1, 2].last()
     output: |
       2
-  slices:
-    description: "Returns the elements of the array in slices with the size of the given integer"
+  max:
+    description: "Returns the largest element, or `nil` for an empty array. Takes the same elements as `min`."
     input: |
-      [1,2,3,4,5,6,7,8].slices(3)
+      [3, 1, 2].max()
+      [].max()
     output: |
-      [[1, 2, 3], [4, 5, 6], [7, 8]]
+      3
+      nil
+  min:
+    description: "Returns the smallest element, or `nil` for an empty array. The elements have to be all strings, all integers or all floats, exactly as `sort` requires."
+    input: |
+      [3, 1, 2].min()
+      ["b", "a"].min()
+      [].min()
+    output: |
+      1
+      "a"
+      nil
   pop:
     description: "Removes the last element of the array and returns it."
     input: |
@@ -85,15 +204,125 @@ methods:
       3
       [1, 2]
   push:
-    description: "Adds the given object as last element to the array."
+    description: "Adds the given object as the last element and returns the array, so calls can be chained."
     input: |
-      a = [1,2,3]
-      a.push("a")
+      d = [1,2,3]
+      d.push("a")
+      d
+    output: |
+      [1, 2, 3]
+      [1, 2, 3, "a"]
+      [1, 2, 3, "a"]
+  reverse:
+    description: "Returns a new array with the elements in reverse order. The array itself is unchanged; use `reverse!` to reverse it in place."
+    input: |
+      a = ["a", "b", 1, 2]
+      a.reverse()
+      a
+    output: |
+      ["a", "b", 1, 2]
+      [2, 1, "b", "a"]
+      ["a", "b", 1, 2]
+  reverse!:
+    description: "Reverses the array in place and returns it, so calls can be chained."
+    input: |
+      a = ["a", "b", 1, 2]
+      a.reverse!()
+      a
+    output: |
+      ["a", "b", 1, 2]
+      [2, 1, "b", "a"]
+      [2, 1, "b", "a"]
+  rindex:
+    description: "Returns the index of the last matching element, or `-1` when there is none. The mirror of `index`."
+    input: |
+      [1, 2, 2, 3].rindex(2)
+      [1, 2, 3].rindex(9)
+    output: |
+      2
+      -1
+  rotate:
+    description: "Returns a copy with the first elements moved to the end, one by default. A negative count rotates the other way, and the count wraps. The array itself is unchanged; use `rotate!` to rotate in place."
+    input: |
+      a = [1, 2, 3]
+      a.rotate()
+      a.rotate(2)
+      a.rotate(0 - 1)
       a
     output: |
       [1, 2, 3]
-      nil
-      [1, 2, 3, "a"]
+      [2, 3, 1]
+      [3, 1, 2]
+      [3, 1, 2]
+      [1, 2, 3]
+  rotate!:
+    description: "Rotates the array in place and returns it, so calls can be chained. Takes the same optional count as `rotate`."
+    input: |
+      a = [1, 2, 3]
+      a.rotate!()
+      a
+    output: |
+      [1, 2, 3]
+      [2, 3, 1]
+      [2, 3, 1]
+  shift:
+    description: "Removes the first element and returns it, or `nil` for an empty array. The mirror of `pop`, and like `pop` it changes the array without a `!`, because there is no pure version of taking something out."
+    input: |
+      a = [1, 2, 3]
+      a.shift()
+      a
+    output: |
+      [1, 2, 3]
+      1
+      [2, 3]
+  size:
+    description: "Returns the amount of elements in the array."
+    input: |
+      ["a", "b", 1, 2].size()
+    output: |
+      4
+  slices:
+    description: "Returns the elements of the array in slices with the size of the given integer"
+    input: |
+      [1,2,3,4,5,6,7,8].slices(3)
+    output: |
+      [[1, 2, 3], [4, 5, 6], [7, 8]]
+  sort:
+    description: "Returns a new sorted array. The elements must all be STRING, all INTEGER or all FLOAT, otherwise an error is returned and the array is left untouched. Use `sort!` to sort in place."
+    input: |
+      b = [3.4, 3.1, 2.0]
+      b.sort()
+      b
+    output: |
+      [3.4, 3.1, 2.0]
+      [2.0, 3.1, 3.4]
+      [3.4, 3.1, 2.0]
+  sort!:
+    description: "Sorts the array in place and returns it. A sort that cannot compare its elements returns an error and leaves the array unchanged rather than half-ordered."
+    input: |
+      b = [3.4, 3.1, 2.0]
+      b.sort!()
+      b
+    output: |
+      [3.4, 3.1, 2.0]
+      [2.0, 3.1, 3.4]
+      [2.0, 3.1, 3.4]
+  sum:
+    description: "Adds the elements up. They all have to be numbers."
+    input: |
+      [1, 2, 3].sum()
+      [1.5, 2.5].sum()
+    output: |
+      6
+      3
+  take:
+    description: "Returns the first n elements as a new array. Asking for more than there are gives all of them. The result is a copy, so changing the original does not change it."
+    input: |
+      [1, 2, 3].take(2)
+      [1, 2, 3].take(9)
+    output: |
+      [1, 2]
+      [1, 2, 3]
   to_m:
     description: "Converts a nested array (2D array) to a Matrix object."
     input: |
@@ -104,3 +333,33 @@ methods:
       │ 1.0  2.0 │
       │ 3.0  4.0 │
       └          ┘
+  uniq:
+    description: "Returns a new array with duplicates removed, keeping the order of first appearance. Returns an error if an element is not hashable. Use `uniq!` to deduplicate in place."
+    input: |
+      c = ["a", 1, 1, 2]
+      c.uniq()
+      c
+    output: |
+      ["a", 1, 1, 2]
+      ["a", 1, 2]
+      ["a", 1, 1, 2]
+  uniq!:
+    description: "Removes duplicates from the array in place and returns it, keeping the order of first appearance."
+    input: |
+      c = ["a", 1, 1, 2]
+      c.uniq!()
+      c
+    output: |
+      ["a", 1, 1, 2]
+      ["a", 1, 2]
+      ["a", 1, 2]
+  unshift:
+    description: "Adds an element to the front and returns the array, so calls can be chained. The mirror of `push`."
+    input: |
+      a = [2, 3]
+      a.unshift(1)
+      a
+    output: |
+      [2, 3]
+      [1, 2, 3]
+      [1, 2, 3]

--- a/docs/literals/float.yml
+++ b/docs/literals/float.yml
@@ -9,48 +9,92 @@ methods:
       3.14
       3.14
   ceil:
-    description: "Rounds up to the nearest whole number, as a float."
+    description: "Returns the smallest float that is not less than the number. An optional digit count says how many decimal places to keep; a negative count rounds to a power of ten. The result stays a `FLOAT` -- in Ruby it would be an `INTEGER`."
     input: |
-      3.14.ceil()
-      (0.0 - 3.7).ceil()
+      1.5.ceil()
+      1.561.ceil(2)
+      555.5.ceil(0 - 1)
     output: |
-      4.0
-      -3.0
+      2.0
+      1.57
+      560.0
+  divmod:
+    description: "Returns the quotient and the remainder as a two-element array. Truncated toward zero, so it agrees with `Integer#divmod` and with `/`."
+    input: |
+      11.0.divmod(4.0)
+      11.0.divmod(0.0 - 4.0)
+    output: |
+      [2.0, 3.0]
+      [-2.0, 3.0]
+  finite?:
+    description: "Returns `true` when the number is neither infinite nor not-a-number."
+    input: |
+      1.5.finite?()
+    output: |
+      true
   floor:
-    description: "Rounds down to the nearest whole number, as a float."
+    description: "Returns the largest float that is not greater than the number. Takes the same optional digit count as `ceil`."
     input: |
-      3.14.floor()
-      (0.0 - 3.2).floor()
+      1.5.floor()
+      1.567.floor(2)
+      (0.0 - 1.5).floor()
     output: |
-      3.0
-      -4.0
+      1.0
+      1.56
+      -2.0
+  infinite?:
+    description: "Returns `1` for positive infinity, `-1` for negative infinity and `nil` otherwise, so the direction is not lost. Use `finite?` for the plain yes-or-no question."
+    input: |
+      1.5.infinite?()
+    output: |
+      nil
+  nan?:
+    description: "Returns `true` when the number is not a number."
+    input: |
+      1.5.nan?()
+    output: |
+      false
+  negative?:
+    description: "Returns `true` when the number is less than zero."
+    input: |
+      (0.0 - 1.5).negative?()
+      0.0.negative?()
+    output: |
+      true
+      false
+  positive?:
+    description: "Returns `true` when the number is greater than zero."
+    input: |
+      1.5.positive?()
+      0.0.positive?()
+    output: |
+      true
+      false
   round:
-    description: "Rounds to the nearest whole number, as a float. Halves round away from zero. The result stays a float, matching `Math.round`; chain `to_i` for an integer."
+    description: "Returns the number rounded to the nearest value, halves away from zero. Takes the same optional digit count as `ceil`."
     input: |
-      3.14.round()
-      2.5.round()
-      (0.0 - 2.5).round()
-      3.7.round().to_i()
+      1.5.round()
+      1.567.round(2)
+      555.5.round(0 - 1)
     output: |
-      3.0
-      3.0
-      -3.0
-      4
-  to_f:
-    description: "Returns self"
+      2.0
+      1.57
+      560.0
+  truncate:
+    description: "Returns the number with its fractional part dropped, rounding toward zero. Unlike `floor` this moves a negative number up. Takes the same optional digit count as `ceil`."
     input: |
-      123.456.to_f()
+      1.567.truncate()
+      (0.0 - 1.5).truncate()
+      1.567.truncate(2)
     output: |
-      123.456
-  to_s:
-    description: "Returns a string representation of the float."
+      1.0
+      -1.0
+      1.56
+  zero?:
+    description: "Returns `true` when the number is zero."
     input: |
-      123.456.to_s()
+      0.0.zero?()
+      1.5.zero?()
     output: |
-      "123.456"
-  to_i:
-    description: "Converts the float into an integer."
-    input: |
-      123.456.to_i()
-    output: |
-      123
+      true
+      false

--- a/docs/literals/hash.yml
+++ b/docs/literals/hash.yml
@@ -43,31 +43,135 @@ example: |
   "moo"
   true
 methods:
-  include?:
-    description: "Returns true or false wether the hash contains the given object as key"
+  clear:
+    description: "Removes every entry and returns the hash, so calls can be chained."
     input: |
-      {"a": 1, 1: "b"}.include?(1)
-      {"a": 1, 1: "b"}.include?("c")
-    output:
+      h = {"a": 1}
+      h.clear()
+      h.size()
+    output: |
+      {"a": 1}
+      {}
+      0
+  compact:
+    description: "Returns a new hash without the entries whose value is `nil`. The hash itself is unchanged; use `compact!` to remove them in place."
+    input: |
+      h = {"a": nil}
+      h.compact().size()
+      h.size()
+    output: |
+      {"a": nil}
+      0
+      1
+  compact!:
+    description: "Removes the entries whose value is `nil` in place and returns the hash, so calls can be chained."
+    input: |
+      h = {"a": nil}
+      h.compact!().size()
+      h.size()
+    output: |
+      {"a": nil}
+      0
+      0
+  delete:
+    description: "Removes the entry for a key and returns its value, or `nil` when the key was not there, so a removal can be told from a miss."
+    input: |
+      h = {"a": 1}
+      h.delete("a")
+      h.size()
+      h.delete("a")
+    output: |
+      {"a": 1}
+      1
+      0
+      nil
+  empty?:
+    description: "Returns `true` when the hash has no entries."
+    input: |
+      {}.empty?()
+      {"a": 1}.empty?()
+    output: |
       true
       false
-  keys:
-    description: "Returns the keys of the hash."
+  fetch:
+    description: "Returns the value for a key. Without a fallback a missing key is an error, which is the difference from `get`, where a fallback is required."
     input: |
-      {"a": "1", "b": "2"}.keys()
+      h = {"a": 1}
+      h.fetch("a")
+      h.fetch("z", 0)
     output: |
-      ["a", "b"]
-  values:
-    description: "Returns the values of the hash."
-    input: |
-      {"a": "1", "b": "2"}.values()
-    output: |
-      ["1", "2"]
+      {"a": 1}
+      1
+      0
   get:
     description: "Returns the value of the given key or the default"
     input: |
       {"a": "1", "b": "2"}.get("a", 10)
       {"a": "1", "b": "2"}.get("c", 10)
     output: |
-      1
+      "1"
       10
+  include?:
+    description: "Returns true or false wether the hash contains the given object as key"
+    input: |
+      {"a": 1, 1: "b"}.include?(1)
+      {"a": 1, 1: "b"}.include?("c")
+    output: |
+      true
+      false
+  invert:
+    description: "Returns a new hash with keys and values swapped. Values that repeat collapse into one entry, and which one survives is not defined. A value that cannot be a key is an error."
+    input: |
+      h = {"a": 1}
+      h.invert().get(1, "missing")
+    output: |
+      {"a": 1}
+      "a"
+  keys:
+    description: "Returns the keys of the hash. The order is **not** defined and can differ between runs of the same program, so sort the result if you need it stable."
+    input: |
+      {"a": "1"}.keys()
+      {"a": "1", "b": "2"}.keys().sort()
+    output: |
+      ["a"]
+      ["a", "b"]
+  merge:
+    description: "Returns a new hash with the entries of both. The argument wins where a key is in both. The hash itself is unchanged; use `merge!` to merge in place."
+    input: |
+      h = {"a": 1}
+      h.merge({"b": 2}).size()
+      h.size()
+      h.merge({"a": 9}).get("a", 0)
+    output: |
+      {"a": 1}
+      2
+      1
+      9
+  merge!:
+    description: "Merges the given hash in place and returns the hash, so calls can be chained."
+    input: |
+      h = {"a": 1}
+      h.merge!({"b": 2}).size()
+      h.size()
+    output: |
+      {"a": 1}
+      2
+      2
+  size:
+    description: "Returns the number of entries."
+    input: |
+      h = {"a": 1}
+      h.size()
+      {}.size()
+    output: |
+      {"a": 1}
+      1
+      0
+  values:
+    description: "Returns the values of the hash, in the same unspecified order as `keys`."
+    input: |
+      {"a": "1"}.values()
+      {"a": "1", "b": "2"}.values().sort()
+    output: |
+      ["1"]
+      ["1", "2"]

--- a/docs/literals/integer.yml
+++ b/docs/literals/integer.yml
@@ -25,7 +25,137 @@ methods:
     description: "Returns the base of the integer."
     input: |
       "0b1010".to_i().base()
-    output:
+    output: |
+      2
+  bit_length:
+    description: "Returns how many bits are needed to represent the number, not counting the sign. A negative number needs as many as its complement, so `-256` is 8 bits just like `255`."
+    input: |
+      255.bit_length()
+      256.bit_length()
+      0.bit_length()
+    output: |
+      8
+      9
+      0
+  ceil:
+    description: "Rounds up to a multiple of ten, given a negative digit count. An integer is already exact, so no argument, or a count of zero or more, returns it unchanged."
+    input: |
+      555.ceil(0 - 1)
+      555.ceil(0 - 2)
+      555.ceil()
+    output: |
+      560
+      600
+      555
+  chr:
+    description: "Returns the character with this code point, as a string. The inverse of a single entry of `string.ascii()`. A value outside the range of a character is an error."
+    input: |
+      65.chr()
+    output: |
+      "A"
+  digits:
+    description: "Returns the digits of the number, least significant first, in base 10 or in a given base. A negative number has no digits and gives an error."
+    input: |
+      12345.digits()
+      12345.digits(7)
+      0.digits()
+    output: |
+      [5, 4, 3, 2, 1]
+      [4, 6, 6, 0, 5]
+      [0]
+  divmod:
+    description: "Returns the quotient and the remainder as a two-element array. Both follow the `/` and `%` operators, which truncate toward zero. Ruby floors instead, so it answers `[-3, -1]` for the second example below."
+    input: |
+      11.divmod(4)
+      11.divmod(0 - 4)
+    output: |
+      [2, 3]
+      [-2, 3]
+  even?:
+    description: "Returns `true` when the number divides by two exactly."
+    input: |
+      4.even?()
+      5.even?()
+    output: |
+      true
+      false
+  floor:
+    description: "Rounds down to a multiple of ten, given a negative digit count. No argument, or a count of zero or more, returns the number unchanged."
+    input: |
+      555.floor(0 - 1)
+      555.floor(0 - 2)
+    output: |
+      550
+      500
+  gcd:
+    description: "Returns the greatest common divisor of the two numbers, always positive. Like the infix operators, it refuses two integers of different bases."
+    input: |
+      36.gcd(60)
+      3.gcd(0 - 7)
+    output: |
+      12
+      1
+  lcm:
+    description: "Returns the least common multiple of the two numbers, always positive."
+    input: |
+      36.lcm(60)
+      3.lcm(0 - 7)
+    output: |
+      180
+      21
+  negative?:
+    description: "Returns `true` when the number is less than zero."
+    input: |
+      (0 - 1).negative?()
+      0.negative?()
+    output: |
+      true
+      false
+  odd?:
+    description: "Returns `true` when the number does not divide by two exactly."
+    input: |
+      5.odd?()
+      4.odd?()
+    output: |
+      true
+      false
+  positive?:
+    description: "Returns `true` when the number is greater than zero."
+    input: |
+      1.positive?()
+      0.positive?()
+    output: |
+      true
+      false
+  pow:
+    description: "Returns the number raised to the given power. A second argument takes the result modulo it, which keeps large exponents workable. A negative exponent is an error, since the result would not be an integer."
+    input: |
+      2.pow(3)
+      2.pow(3, 5)
+    output: |
+      8
+      3
+  pred:
+    description: "Returns the previous integer, keeping the base of the receiver."
+    input: |
+      1.pred()
+      0.pred()
+    output: |
+      0
+      -1
+  round:
+    description: "Rounds to the nearest multiple of ten, halves away from zero, given a negative digit count. No argument, or a count of zero or more, returns the number unchanged."
+    input: |
+      555.round(0 - 1)
+      554.round(0 - 1)
+    output: |
+      560
+      550
+  succ:
+    description: "Returns the next integer, keeping the base of the receiver."
+    input: |
+      1.succ()
+    output: |
       2
   to_base:
     description: "Converts the integer into a integer with the given base"
@@ -33,21 +163,19 @@ methods:
       "0b1010".to_i().to_base(8)
     output: |
       0o12
-  to_s:
-    description: "Returns a string representation of the integer, rendered in the integer's own base."
+  truncate:
+    description: "Drops the last digits, rounding toward zero, given a negative digit count. No argument, or a count of zero or more, returns the number unchanged."
     input: |
-      1234.to_s()
+      555.truncate(0 - 1)
+      (0 - 555).truncate(0 - 1)
     output: |
-      "1234"
-  to_i:
-    description: "Returns self"
+      550
+      -550
+  zero?:
+    description: "Returns `true` when the number is zero."
     input: |
-      1234.to_i()
+      0.zero?()
+      1.zero?()
     output: |
-      1234
-  to_f:
-    description: "Converts the integer into a float."
-    input: |
-      1234.to_f()
-    output: |
-      1234.0
+      true
+      false

--- a/docs/literals/matrix.yml
+++ b/docs/literals/matrix.yml
@@ -102,7 +102,7 @@ methods:
     output: |
       3.0
   set:
-    description: "Sets the element at the specified row and column (0-indexed)."
+    description: "Sets the element at the specified row and column (0-indexed) and returns the matrix, so calls can be chained."
     input: |
       m = [[1, 2, 3], [4, 5, 6]].to_m()
       m.set(0, 2, 99)
@@ -113,11 +113,15 @@ methods:
       │ 1.0  2.0  3.0 │
       │ 4.0  5.0  6.0 │
       └               ┘
-      nil
       2x3 matrix
       ┌                ┐
-      │ 1.0   2.0  99.0 │
-      │ 4.0   5.0   6.0 │
+      │ 1.0  2.0  99.0 │
+      │ 4.0  5.0   6.0 │
+      └                ┘
+      2x3 matrix
+      ┌                ┐
+      │ 1.0  2.0  99.0 │
+      │ 4.0  5.0   6.0 │
       └                ┘
   row:
     description: "Returns the specified row as an array (0-indexed)."

--- a/docs/literals/nil.yml
+++ b/docs/literals/nil.yml
@@ -2,22 +2,3 @@ title: "Nil"
 description: |
   Nil is the representation of "nothing".
   It will be returned if something returns nothing (eg. puts or an empty break/next) and can also be generated with 'nil'.
-methods:
-  to_s:
-    description: "Returns empty string."
-    input: |
-      nil.to_s()
-    output: |
-      ""
-  to_i:
-    description: "Returns zero integer."
-    input: |
-      nil.to_i()
-    output: |
-      0
-  to_f:
-    description: "Returns zero float."
-    input: |
-      nil.to_f()
-    output: |
-      0.0

--- a/docs/literals/object.yml
+++ b/docs/literals/object.yml
@@ -1,20 +1,36 @@
 methods:
-  to_s:
-    description: "Converts an object to its string representation, or the empty string when it has none. Takes no arguments; an integer renders in its own base, so use `to_base` first to change it."
+  methods:
+    description: "Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The names are sorted, so the result is the same on every run. A type with no methods of its own returns an empty array."
     input: |
-      true.to_s()
-      1234.to_s()
-      "test".to_s()
-      1.4.to_s()
-      nil.to_s()
-      "0b1010".to_i().to_s()
+      1.0.methods().include?("round")
+      true.methods()
     output: |
-      "true"
-      "1234"
-      "test"
-      "1.4"
-      ""
-      "0b1010"
+      true
+      []
+  nil?:
+    description: "Returns `true` only for `nil`. Reads better than comparing against `nil` at the end of a chain, and every type answers it."
+    input: |
+      nil.nil?()
+      1.nil?()
+      "".nil?()
+      [].first().nil?()
+    output: |
+      true
+      false
+      false
+      true
+  to_f:
+    description: "Converts an object to its float representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0.0`."
+    input: |
+      1.to_f()
+      "1.4".to_f()
+      "abc".to_f()
+      nil.to_f()
+    output: |
+      1.0
+      1.4
+      nil
+      nil
   to_i:
     description: "Converts an object to its integer representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0`. For strings a `0b`, `0o` or `0x` prefix selects binary, octal or hexadecimal and is matched case insensitively, a leading zero followed only by octal digits is octal, and anything else is decimal. The resulting integer keeps the base it was parsed with, and integers of differing bases cannot be combined directly."
     input: |
@@ -37,18 +53,6 @@ methods:
       0x2322
       0b1010
       nil
-  to_f:
-    description: "Converts an object to its float representation, or `nil` when it cannot. A `nil` result is what distinguishes a failed conversion from a genuine `0.0`."
-    input: |
-      1.to_f()
-      "1.4".to_f()
-      "abc".to_f()
-      nil.to_f()
-    output: |
-      1.0
-      1.4
-      nil
-      nil
   to_json:
     description: "Returns the object as json notation."
     input: |
@@ -57,23 +61,31 @@ methods:
     output: |
       {"test": 1234}
       "{\"test\":1234}"
-  methods:
-    description: "Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The order is unspecified, so sort the result if you need it stable. A type with no methods of its own returns an empty array."
+  to_s:
+    description: "Converts an object to its string representation, or the empty string when it has none. Takes no arguments; an integer renders in its own base, so use `to_base` first to change it."
     input: |
-      "test".methods().sort()
-      true.methods()
+      true.to_s()
+      1234.to_s()
+      "test".to_s()
+      1.4.to_s()
+      nil.to_s()
+      "0b1010".to_i().to_s()
     output: |
-      ["ascii", "count", "downcase", "downcase!", "find", "format", "lines", "replace", "reverse", "reverse!", "size", "split", "strip", "strip!", "upcase", "upcase!"]
-      []
-  wat:
-    description: "Returns the type's literal-specific methods with their usage information, as a single string. Types with no methods of their own list none."
-    input: |
-      true.wat()
-    output: |
-      "BOOLEAN supports the following methods:\n"
+      "true"
+      "1234"
+      "test"
+      "1.4"
+      ""
+      "0b1010"
   type:
     description: "Returns the type of the object."
     input: |
       "test".type()
     output: |
       "STRING"
+  wat:
+    description: "Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none."
+    input: |
+      true.wat()
+    output: |
+      "BOOLEAN supports the following methods:\n"

--- a/docs/literals/string.yml
+++ b/docs/literals/string.yml
@@ -70,104 +70,303 @@ methods:
       []
       [97]
       [97, 98, 99]
+  capitalize:
+    description: "Returns a copy with the first character upcased and every following character downcased, as Ruby's `capitalize` does. A capital in the middle of the string is therefore lost."
+    input: |
+      a = "hello World!"
+      a.capitalize()
+      a
+    output: |
+      "hello World!"
+      "Hello world!"
+      "hello World!"
+  capitalize!:
+    description: "Upcases the first character and downcases the rest in place, and returns the string, so calls can be chained."
+    input: |
+      a = "hello World!"
+      a.capitalize!()
+      a
+    output: |
+      "hello World!"
+      "Hello world!"
+      "Hello world!"
+  chomp:
+    description: "Returns a copy with one trailing line ending removed: `\\r\\n`, `\\n` or `\\r`. Given a string it removes one trailing occurrence of that string instead. Given `\"\"` it removes every trailing `\\n` and `\\r\\n`, which is the way to drop blank lines at the end of a file."
+    input: |
+      a = "line\n"
+      a.chomp()
+      a.chomp() == "line"
+      "abcdd".chomp("d")
+      "a\n\n\n".chomp("")
+    output: |
+      "line\n"
+      "line"
+      true
+      "abcd"
+      "a"
+  chomp!:
+    description: "Removes one trailing line ending in place and returns the string, so calls can be chained. Takes the same optional separator as `chomp`."
+    input: |
+      a = "line\n"
+      a.chomp!()
+      a
+    output: |
+      "line\n"
+      "line"
+      "line"
+  chop:
+    description: "Returns a copy with the last character removed. A trailing `\\r\\n` is removed as a unit so a line ending is never left half there. Chopping an empty string gives an empty string rather than an error."
+    input: |
+      a = "abcd"
+      a.chop()
+      a
+      "".chop()
+    output: |
+      "abcd"
+      "abc"
+      "abcd"
+      ""
+  chop!:
+    description: "Removes the last character in place and returns the string, so calls can be chained."
+    input: |
+      a = "abcd"
+      a.chop!()
+      a
+    output: |
+      "abcd"
+      "abc"
+      "abc"
   count:
     description: "Counts how often a given substring occurs in the string."
-    example: |
-      🚀 » "test".count("t")
-      » 2
-      🚀 » "test".count("f")
-      » 0
+    input: |
+      "test".count("t")
+    output: |
+      2
+  downcase:
+    description: "Returns a copy with all uppercase letters replaced by their lowercase counterparts."
+    input: |
+      a = "TEST"
+      a.downcase()
+      a
+    output: |
+      "TEST"
+      "test"
+      "TEST"
+  downcase!:
+    description: "Replaces uppercase characters with their lowercase counterparts in place and returns the string, so calls can be chained."
+    input: |
+      a = "TEST"
+      a.downcase!()
+      a
+    output: |
+      "TEST"
+      "test"
+      "test"
+  empty?:
+    description: "Returns `true` when the string has no characters."
+    input: |
+      "".empty?()
+      " ".empty?()
+    output: |
+      true
+      false
+  end_with?:
+    description: "Returns `true` when the string ends with any of the given strings."
+    input: |
+      "test.rl".end_with?(".rl")
+      "test.rl".end_with?(".go")
+      "test.rl".end_with?(".go", ".rl")
+    output: |
+      true
+      false
+      true
   find:
     description: "Returns the character index of a given string if found. Otherwise returns `-1`"
-    example: |
-      🚀 » "test".find("e")
-      » 1
-      🚀 » "test".find("f")
-      » -1
+    input: |
+      "test".find("e")
+    output: |
+      1
   format:
     description: "Formats according to a format specifier and returns the resulting string"
-    example: |
-      🚀 » "test%9d".format(1)
-      » "test        1"
-      🚀 » "test%1.2f".format(1.5)
-      » "test1.50"
-      🚀 » "test%s".format("test")
-      » "testtest"
-  size:
-    description: "Returns the amount of characters in the string."
-    example: |
-      🚀 » "test".size()
-      » 4
-  replace:
-    description: "Replaces the first string with the second string in the given string."
-    example: |
-      🚀 » "test".replace("t", "f")
-      » "fesf"
-  reverse:
-    description: "Returns a copy of the string with all characters reversed."
-    example: |
-      🚀 » "stressed".reverse()
-      » "desserts"
-  reverse!:
-    description: "Replaces all the characters in a string in reverse order."
-    example: |
-      🚀 » a = "stressed"
-      » "stressed"
-      🚀 » a.reverse!()
-      » nil
-      🚀 » a
-      » "desserts"
-  split:
-    description: "Splits the string on a given seperator and returns all the chunks in an array. Default seperator is `\" \"`"
-    example: |
-      🚀 » "a,b,c,d".split(",")
-      » ["a", "b", "c", "d"]
-      🚀 » "test and another test".split()
-      » ["test", "and", "another", "test"]
+    input: |
+      "%s is %d".format("a", 1)
+    output: |
+      "a is 1"
+  include?:
+    description: "Returns `true` when the string contains the given substring."
+    input: |
+      "test".include?("es")
+      "test".include?("xy")
+    output: |
+      true
+      false
   lines:
     description: "Splits the string at newline escape sequence and return all chunks in an array. Shorthand for `string.split(\"\\n\")`."
-    example: |
-      🚀 » "test\ntest2".lines()
-      » ["test\ntest2"]
+    input: |
+      "a\nb".lines()
+    output: |
+      ["a", "b"]
+  lstrip:
+    description: "Returns a copy with leading whitespace removed. See `rstrip` for the trailing end and `strip` for both."
+    input: |
+      a = "  test  "
+      a.lstrip()
+      a
+    output: |
+      "  test  "
+      "test  "
+      "  test  "
+  lstrip!:
+    description: "Removes leading whitespace in place and returns the string, so calls can be chained."
+    input: |
+      a = "  test  "
+      a.lstrip!()
+      a
+    output: |
+      "  test  "
+      "test  "
+      "test  "
+  replace:
+    description: "Returns a copy with every occurrence of the first string replaced by the second. This is Ruby's `gsub` with plain strings rather than Ruby's `replace`."
+    input: |
+      a = "test"
+      a.replace("t", "f")
+      a
+    output: |
+      "test"
+      "fesf"
+      "test"
+  replace!:
+    description: "Replaces every occurrence of the first string with the second in place and returns the string, so calls can be chained."
+    input: |
+      a = "test"
+      a.replace!("t", "f")
+      a
+    output: |
+      "test"
+      "fesf"
+      "fesf"
+  reverse:
+    description: "Returns a copy of the string with all characters reversed."
+    input: |
+      a = "stressed"
+      a.reverse()
+      a
+    output: |
+      "stressed"
+      "desserts"
+      "stressed"
+  reverse!:
+    description: "Reverses the characters in place and returns the string, so calls can be chained."
+    input: |
+      a = "stressed"
+      a.reverse!()
+      a
+    output: |
+      "stressed"
+      "desserts"
+      "desserts"
+  rstrip:
+    description: "Returns a copy with trailing whitespace removed. See `lstrip` for the leading end and `strip` for both."
+    input: |
+      a = "  test  "
+      a.rstrip()
+      a
+    output: |
+      "  test  "
+      "  test"
+      "  test  "
+  rstrip!:
+    description: "Removes trailing whitespace in place and returns the string, so calls can be chained."
+    input: |
+      a = "  test  "
+      a.rstrip!()
+      a
+    output: |
+      "  test  "
+      "  test"
+      "  test"
+  size:
+    description: "Returns the amount of characters in the string."
+    input: |
+      "test".size()
+    output: |
+      4
+  split:
+    description: "Splits the string on a given seperator and returns all the chunks in an array. Default seperator is `\" \"`"
+    input: |
+      "a b".split()
+      "a-b".split("-")
+    output: |
+      ["a", "b"]
+      ["a", "b"]
+  start_with?:
+    description: "Returns `true` when the string starts with any of the given strings."
+    input: |
+      "test.rl".start_with?("test")
+      "test.rl".start_with?("prod")
+      "test.rl".start_with?("prod", "test")
+    output: |
+      true
+      false
+      true
   strip:
-    description: "Returns a copy of the string with all leading and trailing whitespaces removed."
-    example: |
-      🚀 » " test ".strip()
-      » "test"
+    description: "Returns a copy with leading and trailing whitespace removed."
+    input: |
+      a = "  test  "
+      a.strip()
+      a
+    output: |
+      "  test  "
+      "test"
+      "  test  "
   strip!:
-    description: "Removes all leading and trailing whitespaces in the string."
-    example: |
-      🚀 » a = " test "
-      » " test "
-      🚀 » a.strip!()
-      » nil
-      🚀 » a
-      » "test"
-  downcase:
-    description: "Returns the string with all uppercase letters replaced with lowercase counterparts."
-    example: |
-      🚀 » "TeST".downcase()
-      » "test"
-  downcase!:
-    description: "Replaces all upcase characters with lowercase counterparts."
-    example: |
-      🚀 » a = "TeST"
-      » "TeST"
-      🚀 » a.downcase!()
-      » nil
-      🚀 » a
-      » "test"
+    description: "Removes leading and trailing whitespace in place and returns the string, so calls can be chained."
+    input: |
+      a = "  test  "
+      a.strip!()
+      a
+    output: |
+      "  test  "
+      "test"
+      "test"
+  swapcase:
+    description: "Returns a copy with every uppercase character downcased and every lowercase character upcased."
+    input: |
+      a = "Hello World"
+      a.swapcase()
+      a
+    output: |
+      "Hello World"
+      "hELLO wORLD"
+      "Hello World"
+  swapcase!:
+    description: "Swaps the case of every character in place and returns the string, so calls can be chained."
+    input: |
+      a = "Hello World"
+      a.swapcase!()
+      a
+    output: |
+      "Hello World"
+      "hELLO wORLD"
+      "hELLO wORLD"
   upcase:
-    description: "Returns the string with all lowercase letters replaced with uppercase counterparts."
-    example: |
-      🚀 » "test".upcase()
-      » "TEST"
+    description: "Returns a copy with all lowercase letters replaced by their uppercase counterparts."
+    input: |
+      a = "test"
+      a.upcase()
+      a
+    output: |
+      "test"
+      "TEST"
+      "test"
   upcase!:
-    description: "Replaces all lowercase characters with upcase counterparts."
-    example: |
-      🚀 » a = "test"
-      » "test"
-      🚀 » a.upcase!()
-      » nil
-      🚀 » a
-      » "TEST"
+    description: "Replaces lowercase characters with their uppercase counterparts in place and returns the string, so calls can be chained."
+    input: |
+      a = "test"
+      a.upcase!()
+      a
+    output: |
+      "test"
+      "TEST"
+      "TEST"

--- a/examples/len_out_of_range.rl
+++ b/examples/len_out_of_range.rl
@@ -38,7 +38,7 @@ foreach instruction in instructions
   foreach i in amount
     temp_stack.push(stacks2[from - 1].pop())
   end
-  temp_stack.reverse()
+  temp_stack.reverse!()
   foreach item in temp_stack
     stacks2[to - 1].push(item)
   end

--- a/object/array.go
+++ b/object/array.go
@@ -103,11 +103,19 @@ func init() {
 				),
 			},
 			method: func(o Object, _ []Object, _ Environment) Object {
+				return NewArray(reversedElements(o.(*Array).Elements))
+			},
+		},
+		"reverse!": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(ARRAY_OBJ),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
 				ao := o.(*Array)
+				ao.Elements = reversedElements(ao.Elements)
 
-				for i, j := 0, len(ao.Elements)-1; i < j; i, j = i+1, j-1 {
-					ao.Elements[i], ao.Elements[j] = ao.Elements[j], ao.Elements[i]
-				}
 				return ao
 			},
 		},
@@ -123,76 +131,31 @@ func init() {
 			},
 		},
 		"sort": ObjectMethod{
-			// Can be refactored to generics once
-			// https://github.com/golang/go/issues/48522
-			// is fixed
 			Layout: MethodLayout{
-				ReturnPattern: Args(Arg(ARRAY_OBJ)),
+				ReturnPattern: Args(Arg(ARRAY_OBJ, ERROR_OBJ)),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				sorted, err := sortedElements(o.(*Array).Elements)
+				if err != nil {
+					return err
+				}
+
+				return NewArray(sorted)
+			},
+		},
+		"sort!": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(Arg(ARRAY_OBJ, ERROR_OBJ)),
 			},
 			method: func(o Object, _ []Object, _ Environment) Object {
 				ao := o.(*Array)
-				sortError := false
 
-				if len(ao.Elements) == 0 {
-					return ao
+				sorted, err := sortedElements(ao.Elements)
+				if err != nil {
+					return err
 				}
+				ao.Elements = sorted
 
-				switch ao.Elements[0].(type) {
-				case *Float:
-					sort.SliceStable(ao.Elements, func(i, j int) bool {
-						leftElement, ok := ao.Elements[i].(*Float)
-						if !ok {
-							sortError = true
-							return false
-						}
-
-						rightElement, ok := ao.Elements[j].(*Float)
-						if !ok {
-							sortError = true
-							return false
-						}
-
-						return leftElement.Value < rightElement.Value
-					})
-				case *Integer:
-					sort.SliceStable(ao.Elements, func(i, j int) bool {
-						leftElement, ok := ao.Elements[i].(*Integer)
-						if !ok {
-							sortError = true
-							return false
-						}
-
-						rightElement, ok := ao.Elements[j].(*Integer)
-						if !ok {
-							sortError = true
-							return false
-						}
-
-						return leftElement.Value < rightElement.Value
-					})
-				case *String:
-					sort.SliceStable(ao.Elements, func(i, j int) bool {
-						leftElement, ok := ao.Elements[i].(*String)
-						if !ok {
-							sortError = true
-							return false
-						}
-
-						rightElement, ok := ao.Elements[j].(*String)
-						if !ok {
-							sortError = true
-							return false
-						}
-
-						return leftElement.Value < rightElement.Value
-					})
-				default:
-					sortError = true
-				}
-
-				if sortError {
-					return NewError("Array does contain either an object not INTEGER, FLOAT or STRING or is mixed")
-				}
 				return ao
 			},
 		},
@@ -231,26 +194,30 @@ func init() {
 				),
 			},
 			method: func(o Object, _ []Object, _ Environment) Object {
+				unique, err := uniqueElements(o.(*Array).Elements)
+				if err != nil {
+					return err
+				}
+
+				return NewArray(unique)
+			},
+		},
+		"uniq!": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(ARRAY_OBJ, ERROR_OBJ),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
 				ao := o.(*Array)
 
-				items := make(map[HashKey]Object)
-				for _, element := range ao.Elements {
-					helper, ok := element.(Hashable)
-					if !ok {
-						return NewErrorFormat("failed because element %s is not hashable", element.Type())
-					}
-					items[helper.HashKey()] = element
+				unique, err := uniqueElements(ao.Elements)
+				if err != nil {
+					return err
 				}
+				ao.Elements = unique
 
-				length := len(items)
-				newElements := make([]Object, length)
-				var idx int
-				for _, item := range items {
-					newElements[idx] = item
-					idx++
-				}
-
-				return NewArray(newElements)
+				return ao
 			},
 		},
 		"index": ObjectMethod{
@@ -269,29 +236,67 @@ func init() {
 		},
 		"first": ObjectMethod{
 			Layout: MethodLayout{
+				ArgPattern: Args(
+					OptArg(INTEGER_OBJ),
+				),
 				ReturnPattern: Args(
-					Arg(STRING_OBJ, ARRAY_OBJ, HASH_OBJ, BOOLEAN_OBJ, INTEGER_OBJ, NIL_OBJ, FUNCTION_OBJ, FILE_OBJ),
+					Arg(ANY_OBJ...),
 				),
 			},
-			method: func(o Object, _ []Object, _ Environment) Object {
+			method: func(o Object, args []Object, _ Environment) Object {
 				ao := o.(*Array)
+
+				if len(args) > 0 {
+					count := args[0].(*Integer).Value
+					if count < 0 {
+						return NewErrorFormat("negative count %d", count)
+					}
+
+					elements := ao.Elements
+					if count > len(elements) {
+						count = len(elements)
+					}
+
+					return NewArray(copyElements(elements[:count]))
+				}
+
 				if len(ao.Elements) == 0 {
 					return NIL
 				}
+
 				return ao.Elements[0]
 			},
 		},
 		"last": ObjectMethod{
 			Layout: MethodLayout{
+				ArgPattern: Args(
+					OptArg(INTEGER_OBJ),
+				),
 				ReturnPattern: Args(
-					Arg(STRING_OBJ, ARRAY_OBJ, HASH_OBJ, BOOLEAN_OBJ, INTEGER_OBJ, NIL_OBJ, FUNCTION_OBJ, FILE_OBJ),
+					Arg(ANY_OBJ...),
 				),
 			},
-			method: func(o Object, _ []Object, _ Environment) Object {
+			method: func(o Object, args []Object, _ Environment) Object {
 				ao := o.(*Array)
+
+				if len(args) > 0 {
+					count := args[0].(*Integer).Value
+					if count < 0 {
+						return NewErrorFormat("negative count %d", count)
+					}
+
+					elements := ao.Elements
+					if count > len(elements) {
+						count = len(elements)
+					}
+
+					return NewArray(copyElements(elements[len(elements)-count:]))
+				}
+
 				if len(ao.Elements) == 0 {
 					return NIL
 				}
+
 				return ao.Elements[len(ao.Elements)-1]
 			},
 		},
@@ -322,7 +327,7 @@ func init() {
 		"push": ObjectMethod{
 			Layout: MethodLayout{
 				ReturnPattern: Args(
-					Arg(NIL_OBJ),
+					Arg(ARRAY_OBJ),
 				),
 				ArgPattern: Args(
 					Arg(STRING_OBJ, ARRAY_OBJ, HASH_OBJ, BOOLEAN_OBJ, INTEGER_OBJ, NIL_OBJ, FUNCTION_OBJ, FILE_OBJ),
@@ -331,7 +336,8 @@ func init() {
 			method: func(o Object, args []Object, _ Environment) Object {
 				ao := o.(*Array)
 				ao.Elements = append(ao.Elements, args[0])
-				return NIL
+
+				return ao
 			},
 		},
 		"include?": ObjectMethod{
@@ -396,7 +402,442 @@ func init() {
 				return matrix
 			},
 		},
+		"empty?": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(BOOLEAN_OBJ),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				if len(o.(*Array).Elements) == 0 {
+					return TRUE
+				}
+
+				return FALSE
+			},
+		},
+		"count": ObjectMethod{
+			Layout: MethodLayout{
+				ArgPattern: Args(
+					OptArg(ANY_OBJ...),
+				),
+				ReturnPattern: Args(
+					Arg(INTEGER_OBJ),
+				),
+			},
+			method: func(o Object, args []Object, _ Environment) Object {
+				ao := o.(*Array)
+
+				// Without an argument this is size(). With one it counts how
+				// often that element occurs, which is what index() cannot tell
+				// you.
+				if len(args) == 0 {
+					return NewInteger(len(ao.Elements))
+				}
+
+				count := 0
+				for _, element := range ao.Elements {
+					if CompareObjects(element, args[0]) {
+						count++
+					}
+				}
+
+				return NewInteger(count)
+			},
+		},
+		"rindex": ObjectMethod{
+			Layout: MethodLayout{
+				ArgPattern: Args(
+					Arg(ANY_OBJ...),
+				),
+				ReturnPattern: Args(
+					Arg(INTEGER_OBJ),
+				),
+			},
+			method: func(o Object, args []Object, _ Environment) Object {
+				ao := o.(*Array)
+
+				// -1 when absent, the same answer index() gives.
+				for i := len(ao.Elements) - 1; i >= 0; i-- {
+					if CompareObjects(ao.Elements[i], args[0]) {
+						return NewInteger(i)
+					}
+				}
+
+				return NewInteger(-1)
+			},
+		},
+		"min": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(ANY_OBJ...),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				return extremeElement(o.(*Array).Elements, true)
+			},
+		},
+		"max": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(ANY_OBJ...),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				return extremeElement(o.(*Array).Elements, false)
+			},
+		},
+		"shift": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(ANY_OBJ...),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				ao := o.(*Array)
+
+				// The mirror of pop: it changes the array and hands back the
+				// element, so it has no ! either.
+				if len(ao.Elements) == 0 {
+					return NIL
+				}
+
+				first := ao.Elements[0]
+				ao.Elements = copyElements(ao.Elements[1:])
+
+				return first
+			},
+		},
+		"unshift": ObjectMethod{
+			Layout: MethodLayout{
+				ArgPattern: Args(
+					Arg(ANY_OBJ...),
+				),
+				ReturnPattern: Args(
+					Arg(ARRAY_OBJ),
+				),
+			},
+			method: func(o Object, args []Object, _ Environment) Object {
+				ao := o.(*Array)
+				ao.Elements = append([]Object{args[0]}, ao.Elements...)
+
+				return ao
+			},
+		},
+		"insert": ObjectMethod{
+			Layout: MethodLayout{
+				ArgPattern: Args(
+					Arg(INTEGER_OBJ),
+					Arg(ANY_OBJ...),
+				),
+				ReturnPattern: Args(
+					Arg(ARRAY_OBJ, ERROR_OBJ),
+				),
+			},
+			method: func(o Object, args []Object, _ Environment) Object {
+				ao := o.(*Array)
+				length := len(ao.Elements)
+
+				at := args[0].(*Integer).Value
+				if at < 0 {
+					at = length + at + 1
+				}
+				// Inserting at length appends. Anything past that would need
+				// the array padded with nils, which is a surprise rather than a
+				// convenience.
+				if at < 0 || at > length {
+					return NewErrorFormat("index out of range, got %d but array has only %d elements", args[0].(*Integer).Value, length)
+				}
+
+				elements := make([]Object, 0, length+1)
+				elements = append(elements, ao.Elements[:at]...)
+				elements = append(elements, args[1])
+				elements = append(elements, ao.Elements[at:]...)
+				ao.Elements = elements
+
+				return ao
+			},
+		},
+		"delete": ObjectMethod{
+			Layout: MethodLayout{
+				ArgPattern: Args(
+					Arg(ANY_OBJ...),
+				),
+				ReturnPattern: Args(
+					Arg(ANY_OBJ...),
+				),
+			},
+			method: func(o Object, args []Object, _ Environment) Object {
+				ao := o.(*Array)
+
+				kept := make([]Object, 0, len(ao.Elements))
+				found := false
+				for _, element := range ao.Elements {
+					if CompareObjects(element, args[0]) {
+						found = true
+						continue
+					}
+					kept = append(kept, element)
+				}
+				ao.Elements = kept
+
+				// The element when something went, nil when nothing did, so the
+				// caller can tell the two apart.
+				if !found {
+					return NIL
+				}
+
+				return args[0]
+			},
+		},
+		"delete_at": ObjectMethod{
+			Layout: MethodLayout{
+				ArgPattern: Args(
+					Arg(INTEGER_OBJ),
+				),
+				ReturnPattern: Args(
+					Arg(ANY_OBJ...),
+				),
+			},
+			method: func(o Object, args []Object, _ Environment) Object {
+				ao := o.(*Array)
+				length := len(ao.Elements)
+
+				at := args[0].(*Integer).Value
+				if at < 0 {
+					at = length + at
+				}
+				// nil rather than an error for a position that is not there,
+				// the same answer first() and pop() give for an empty array.
+				if at < 0 || at >= length {
+					return NIL
+				}
+
+				removed := ao.Elements[at]
+				elements := make([]Object, 0, length-1)
+				elements = append(elements, ao.Elements[:at]...)
+				elements = append(elements, ao.Elements[at+1:]...)
+				ao.Elements = elements
+
+				return removed
+			},
+		},
+		"clear": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(ARRAY_OBJ),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				ao := o.(*Array)
+				ao.Elements = make([]Object, 0)
+
+				return ao
+			},
+		},
+		"concat": ObjectMethod{
+			Layout: MethodLayout{
+				ArgPattern: Args(
+					Arg(ARRAY_OBJ),
+				),
+				ReturnPattern: Args(
+					Arg(ARRAY_OBJ),
+				),
+			},
+			method: func(o Object, args []Object, _ Environment) Object {
+				ao := o.(*Array)
+				ao.Elements = append(ao.Elements, args[0].(*Array).Elements...)
+
+				return ao
+			},
+		},
+		"take": ObjectMethod{
+			Layout: MethodLayout{
+				ArgPattern: Args(
+					Arg(INTEGER_OBJ),
+				),
+				ReturnPattern: Args(
+					Arg(ARRAY_OBJ, ERROR_OBJ),
+				),
+			},
+			method: func(o Object, args []Object, _ Environment) Object {
+				ao := o.(*Array)
+
+				count := args[0].(*Integer).Value
+				if count < 0 {
+					return NewErrorFormat("negative count %d", count)
+				}
+				if count > len(ao.Elements) {
+					count = len(ao.Elements)
+				}
+
+				return NewArray(copyElements(ao.Elements[:count]))
+			},
+		},
+		"drop": ObjectMethod{
+			Layout: MethodLayout{
+				ArgPattern: Args(
+					Arg(INTEGER_OBJ),
+				),
+				ReturnPattern: Args(
+					Arg(ARRAY_OBJ, ERROR_OBJ),
+				),
+			},
+			method: func(o Object, args []Object, _ Environment) Object {
+				ao := o.(*Array)
+
+				count := args[0].(*Integer).Value
+				if count < 0 {
+					return NewErrorFormat("negative count %d", count)
+				}
+				if count > len(ao.Elements) {
+					count = len(ao.Elements)
+				}
+
+				return NewArray(copyElements(ao.Elements[count:]))
+			},
+		},
 	}
+
+	// Pure method and ! counterpart from one transformation each, the same way
+	// string.go registers its pairs.
+	arrayPair("compact", nil, func(elements []Object, _ []Object) ([]Object, Object) {
+		return compactElements(elements), nil
+	})
+	arrayPair("flatten", Args(OptArg(INTEGER_OBJ)), func(elements []Object, args []Object) ([]Object, Object) {
+		depth := -1
+		if len(args) > 0 {
+			depth = args[0].(*Integer).Value
+			if depth < 0 {
+				return nil, NewErrorFormat("negative depth %d", depth)
+			}
+		}
+
+		return flattenElements(elements, depth), nil
+	})
+	arrayPair("rotate", Args(OptArg(INTEGER_OBJ)), func(elements []Object, args []Object) ([]Object, Object) {
+		by := 1
+		if len(args) > 0 {
+			by = args[0].(*Integer).Value
+		}
+
+		return rotatedElements(elements, by), nil
+	})
+}
+
+// arrayPair registers a method and its in-place counterpart from one
+// transformation, so the two halves cannot drift apart. See stringPair in
+// string.go for why this is not written out twice.
+func arrayPair(name string, argPattern []Argument, transform func(elements []Object, args []Object) ([]Object, Object)) {
+	layout := MethodLayout{
+		ArgPattern:    argPattern,
+		ReturnPattern: Args(Arg(ARRAY_OBJ, ERROR_OBJ)),
+	}
+
+	objectMethods[ARRAY_OBJ][name] = ObjectMethod{
+		Layout: layout,
+		method: func(o Object, args []Object, _ Environment) Object {
+			elements, err := transform(o.(*Array).Elements, args)
+			if err != nil {
+				return err
+			}
+
+			return NewArray(elements)
+		},
+	}
+
+	objectMethods[ARRAY_OBJ][name+"!"] = ObjectMethod{
+		Layout: layout,
+		method: func(o Object, args []Object, _ Environment) Object {
+			ao := o.(*Array)
+
+			elements, err := transform(ao.Elements, args)
+			if err != nil {
+				return err
+			}
+			ao.Elements = elements
+
+			return ao
+		},
+	}
+}
+
+// copyElements returns a fresh slice, so a method handing back a sub-slice
+// cannot be written through to the array it came from.
+func copyElements(src []Object) []Object {
+	out := make([]Object, len(src))
+	copy(out, src)
+
+	return out
+}
+
+func compactElements(src []Object) []Object {
+	out := make([]Object, 0, len(src))
+	for _, element := range src {
+		if element.Type() == NIL_OBJ {
+			continue
+		}
+		out = append(out, element)
+	}
+
+	return out
+}
+
+// flattenElements inlines nested arrays. A depth below zero means all the way
+// down; zero means leave them alone.
+func flattenElements(src []Object, depth int) []Object {
+	out := make([]Object, 0, len(src))
+	for _, element := range src {
+		nested, ok := element.(*Array)
+		if !ok || depth == 0 {
+			out = append(out, element)
+			continue
+		}
+
+		next := depth - 1
+		if depth < 0 {
+			next = depth
+		}
+		out = append(out, flattenElements(nested.Elements, next)...)
+	}
+
+	return out
+}
+
+// rotatedElements moves the first by elements to the end. A negative count
+// rotates the other way, and the count wraps, so rotating a 3-element array by
+// 4 is the same as by 1.
+func rotatedElements(src []Object, by int) []Object {
+	if len(src) == 0 {
+		return copyElements(src)
+	}
+
+	at := by % len(src)
+	if at < 0 {
+		at += len(src)
+	}
+
+	return append(copyElements(src[at:]), src[:at]...)
+}
+
+// extremeElement returns the smallest or largest element. It sorts a copy so
+// that the rule about what can be compared, and the error when it cannot, are
+// exactly sort's.
+func extremeElement(src []Object, min bool) Object {
+	if len(src) == 0 {
+		return NIL
+	}
+
+	sorted, err := sortedElements(src)
+	if err != nil {
+		return err
+	}
+
+	if min {
+		return sorted[0]
+	}
+
+	return sorted[len(sorted)-1]
 }
 
 func (ao *Array) InvokeMethod(method string, env Environment, args ...Object) Object {
@@ -405,6 +846,13 @@ func (ao *Array) InvokeMethod(method string, env Environment, args ...Object) Ob
 
 func (ao *Array) GetIterator(start, step int, _ bool) Iterator {
 	return &arrayIterator{items: ao.Elements, index: start, step: step}
+}
+
+// ToStringObj renders the array the way Inspect does, which is what Ruby's
+// Array#to_s does too. Without it the generic to_s fell through to an empty
+// string, so [1,2].to_s() was "" while to_json() worked.
+func (ao *Array) ToStringObj() *String {
+	return NewString(ao.Inspect())
 }
 
 func (ao *Array) MarshalJSON() ([]byte, error) {
@@ -425,4 +873,101 @@ func (a *arrayIterator) Next() (Object, Object, bool) {
 		return val, idx, true
 	}
 	return nil, NewInteger(0), false
+}
+
+// reversedElements returns a reversed copy, leaving src untouched.
+func reversedElements(src []Object) []Object {
+	out := make([]Object, len(src))
+	for i, element := range src {
+		out[len(src)-1-i] = element
+	}
+
+	return out
+}
+
+// sortedElements returns a sorted copy of src. The second value is an error
+// object when the elements are not a single sortable type, in which case the
+// copy must not be used -- working on a copy means a failed sort cannot leave a
+// half-ordered array behind.
+//
+// Can be refactored to generics once
+// https://github.com/golang/go/issues/48522 is fixed.
+func sortedElements(src []Object) ([]Object, Object) {
+	out := make([]Object, len(src))
+	copy(out, src)
+
+	if len(out) == 0 {
+		return out, nil
+	}
+
+	sortError := false
+
+	switch out[0].(type) {
+	case *Float:
+		sort.SliceStable(out, func(i, j int) bool {
+			left, leftOk := out[i].(*Float)
+			right, rightOk := out[j].(*Float)
+			if !leftOk || !rightOk {
+				sortError = true
+				return false
+			}
+
+			return left.Value < right.Value
+		})
+	case *Integer:
+		sort.SliceStable(out, func(i, j int) bool {
+			left, leftOk := out[i].(*Integer)
+			right, rightOk := out[j].(*Integer)
+			if !leftOk || !rightOk {
+				sortError = true
+				return false
+			}
+
+			return left.Value < right.Value
+		})
+	case *String:
+		sort.SliceStable(out, func(i, j int) bool {
+			left, leftOk := out[i].(*String)
+			right, rightOk := out[j].(*String)
+			if !leftOk || !rightOk {
+				sortError = true
+				return false
+			}
+
+			return left.Value < right.Value
+		})
+	default:
+		sortError = true
+	}
+
+	if sortError {
+		return nil, NewError("Array does contain either an object not INTEGER, FLOAT or STRING or is mixed")
+	}
+
+	return out, nil
+}
+
+// uniqueElements returns a copy with duplicates removed, keeping the order of
+// first appearance. Building the result from a map, as this once did, made the
+// order depend on Go's map iteration and therefore vary between runs.
+func uniqueElements(src []Object) ([]Object, Object) {
+	seen := make(map[HashKey]struct{}, len(src))
+	out := make([]Object, 0, len(src))
+
+	for _, element := range src {
+		hashable, ok := element.(Hashable)
+		if !ok {
+			return nil, NewErrorFormat("failed because element %s is not hashable", element.Type())
+		}
+
+		key := hashable.HashKey()
+		if _, duplicate := seen[key]; duplicate {
+			continue
+		}
+
+		seen[key] = struct{}{}
+		out = append(out, element)
+	}
+
+	return out, nil
 }

--- a/object/array_test.go
+++ b/object/array_test.go
@@ -45,10 +45,12 @@ func TestArrayObjectMethods(t *testing.T) {
 		{`[1,1,2].uniq().size()`, 2},
 		{`[true,true,2].uniq().size()`, 2},
 		{`["test","test",2].uniq().size()`, 2},
-		{`["12".reverse!()].uniq()`, "failed because element NIL is not hashable"},
-		{"[].first()", "NIL"},
+		// nil is not hashable, so it cannot be de-duplicated. Written with a
+		// literal rather than relying on what a !-method hands back.
+		{`[nil].uniq()`, "failed because element NIL is not hashable"},
+		{"[].first()", nil},
 		{"[1,2,3].first()", 1},
-		{"[].last()", "NIL"},
+		{"[].last()", nil},
 		{"[1,2,3].last()", 3},
 		{"[1,2,3].to_json()", "[1,2,3]"},
 		{`["test",true,3].to_json()`, `["test",true,3]`},
@@ -69,7 +71,12 @@ func TestArrayObjectMethods(t *testing.T) {
 		{`[1,2,3,4,5,6,7,8].slices(3)`, `[[1, 2, 3], [4, 5, 6], [7, 8]]`},
 		{`[1,2].slices(3)`, `[[1, 2]]`},
 		{`[1,2].slices(0)`, `invalid slice size, needs to be > 0`},
-		{"[1,2,3,{}].join()", "Found non stringable element HASH on index 3"},
+		// A hash used to be rejected here because Hash had no to_s. Now it
+		// renders like it does everywhere else, and only a type that genuinely
+		// has no string form -- a function -- is refused.
+		{"[1,2,3,{}].join()", "123{}"},
+		{"[1,2,3,[4]].join()", "123[4]"},
+		{"[def() end].join()", "Found non stringable element FUNCTION on index 0"},
 		{"[1,2,3].join()", "123"},
 		{"[1,2,3].join('-')", "1-2-3"},
 		{"['1',2, 2.5,{}].sum()", "Found non number element HASH on index 3"},
@@ -129,4 +136,178 @@ func TestArrayAdd(t *testing.T) {
 	if len(array.Elements) != 4 || array.Elements[3].Type() != object.INTEGER_OBJ {
 		t.Errorf("expected array to have an integer value on index 3")
 	}
+}
+
+// TestArrayBangConvention covers the mutation convention #231 introduced: a
+// plain method leaves the receiver alone and returns a new array, a !-method
+// changes the receiver and hands it back so calls chain. Before this, reverse
+// and sort mutated without a bang while uniq did not, so the same name meant
+// different things on Array and String.
+func TestArrayBangConvention(t *testing.T) {
+	tests := []inputTestCase{
+		// Plain methods are pure: the original is untouched.
+		{`a = [3,1,2]; a.reverse(); a.to_json()`, "[3,1,2]"},
+		{`a = [3,1,2]; a.sort(); a.to_json()`, "[3,1,2]"},
+		{`a = [1,1,2]; a.uniq(); a.to_json()`, "[1,1,2]"},
+		{`[3,1,2].reverse().to_json()`, "[2,1,3]"},
+		{`[3,1,2].sort().to_json()`, "[1,2,3]"},
+		{`[1,1,2].uniq().to_json()`, "[1,2]"},
+
+		// !-methods change the receiver.
+		{`a = [3,1,2]; a.reverse!(); a.to_json()`, "[2,1,3]"},
+		{`a = [3,1,2]; a.sort!(); a.to_json()`, "[1,2,3]"},
+		{`a = [1,1,2]; a.uniq!(); a.to_json()`, "[1,2]"},
+
+		// ...and hand it back, so they chain.
+		{`[3,1,2].sort!().reverse!().to_json()`, "[3,2,1]"},
+		{`[1].push(2).push(3).to_json()`, "[1,2,3]"},
+
+		// uniq keeps the order of first appearance. Building the result from a
+		// map made this vary between runs.
+		{`[5,3,1,4,2,3].uniq().to_json()`, "[5,3,1,4,2]"},
+		{`[5,3,1,4,2,3].uniq!().to_json()`, "[5,3,1,4,2]"},
+
+		// pop still mutates and hands back the element, as in Ruby: a pure pop
+		// would just be last().
+		{`a = [1,2,3]; a.pop()`, 3},
+		{`a = [1,2,3]; a.pop(); a.to_json()`, "[1,2]"},
+
+		// A sort that cannot compare its elements errors...
+		{`[1,"a"].sort()`, "Array does contain either an object not INTEGER, FLOAT or STRING or is mixed"},
+		// ...and leaves the array alone rather than half-ordered. The error has
+		// to be caught, or it would propagate before to_json runs and the
+		// assertion would pass without checking anything.
+		{`a = [1,"a"]
+		  begin
+		    a.sort!()
+		  rescue e
+		  end
+		  a.to_json()`, `[1,"a"]`},
+	}
+
+	testInput(t, tests)
+}
+
+// TestArrayRubyMethods covers the methods added to close the gap with Ruby's
+// Array. Only the ones that need no user-supplied function are here; map,
+// select and reject are not possible until an object method can call one.
+func TestArrayRubyMethods(t *testing.T) {
+	tests := []inputTestCase{
+		{`[].empty?()`, true},
+		{`[1].empty?()`, false},
+
+		// count() is size(); count(x) is how often x occurs, which index()
+		// cannot tell you.
+		{`[1,2,2,3].count()`, 4},
+		{`[1,2,2,3].count(2)`, 2},
+		{`[1,2,2,3].count(9)`, 0},
+
+		// -1 when absent, the answer index() already gave.
+		{`[1,2,2,3].rindex(2)`, 2},
+		{`[1,2,3].rindex(9)`, -1},
+
+		{`[3,1,2].min()`, 1},
+		{`[3,1,2].max()`, 3},
+		{`["b","a"].min()`, "a"},
+		{`[2.5,1.5].max()`, 2.5},
+		{`[].min()`, nil},
+		{`[].max()`, nil},
+		// min and max borrow sort's rule about what can be compared, so they
+		// fail the same way and with the same words.
+		{`[1,"a"].min()`, "Array does contain either an object not INTEGER, FLOAT or STRING or is mixed"},
+
+		{`[1,2,3].first(2)`, "[1, 2]"},
+		{`[1,2,3].first(9)`, "[1, 2, 3]"},
+		{`[1,2,3].first(0)`, "[]"},
+		{`[1,2,3].last(2)`, "[2, 3]"},
+		{`[1,2,3].first(0 - 1)`, "negative count -1"},
+		// Without a count they still answer the element, not a one-item array.
+		{`[1,2,3].first()`, 1},
+		{`[1,2,3].last()`, 3},
+
+		{`[1,2,3].take(2)`, "[1, 2]"},
+		{`[1,2,3].drop(2)`, "[3]"},
+		{`[1,2,3].take(9)`, "[1, 2, 3]"},
+		{`[1,2,3].drop(9)`, "[]"},
+		{`[1,2,3].take(0 - 1)`, "negative count -1"},
+
+		{`[1,nil,2,nil].compact()`, "[1, 2]"},
+		{`[1,[2,[3]]].flatten()`, "[1, 2, 3]"},
+		{`[1,[2,[3]]].flatten(1)`, "[1, 2, [3]]"},
+		{`[1,[2,[3]]].flatten(0)`, "[1, [2, [3]]]"},
+		{`[1,2,3].rotate()`, "[2, 3, 1]"},
+		{`[1,2,3].rotate(2)`, "[3, 1, 2]"},
+		{`[1,2,3].rotate(0 - 1)`, "[3, 1, 2]"},
+		// The count wraps, so rotating three elements by four is by one.
+		{`[1,2,3].rotate(4)`, "[2, 3, 1]"},
+		{`[].rotate()`, "[]"},
+
+		// shift mirrors pop: it changes the array and hands back the element.
+		{`a = [1,2,3]; a.shift()`, 1},
+		{`a = [1,2,3]; a.shift(); a.to_json()`, "[2,3]"},
+		{`[].shift()`, nil},
+		{`a = [2,3]; a.unshift(1).to_json()`, "[1,2,3]"},
+
+		{`a = [1,2]; a.insert(1, 9).to_json()`, "[1,9,2]"},
+		{`a = [1,2]; a.insert(0, 9).to_json()`, "[9,1,2]"},
+		{`a = [1,2]; a.insert(2, 9).to_json()`, "[1,2,9]"},
+		// A negative index counts back from the end, so -1 appends.
+		{`a = [1,2]; a.insert(0 - 1, 9).to_json()`, "[1,2,9]"},
+		{`a = [1,2]; a.insert(3, 9)`, "index out of range, got 3 but array has only 2 elements"},
+
+		// delete takes out every occurrence and reports the element, or nil
+		// when there was nothing to take out.
+		{`a = [1,2,1]; a.delete(1)`, 1},
+		{`a = [1,2,1]; a.delete(1); a.to_json()`, "[2]"},
+		{`a = [1,2]; a.delete(9)`, nil},
+		{`a = [1,2]; a.delete(9); a.to_json()`, "[1,2]"},
+
+		{`a = [1,2,3]; a.delete_at(1)`, 2},
+		{`a = [1,2,3]; a.delete_at(1); a.to_json()`, "[1,3]"},
+		{`a = [1,2,3]; a.delete_at(0 - 1)`, 3},
+		// A position that is not there gives nil, as first() and pop() do on an
+		// empty array.
+		{`[1,2].delete_at(9)`, nil},
+
+		{`a = [1,2]; a.clear().to_json()`, "[]"},
+		{`a = [1]; a.concat([2,3]).to_json()`, "[1,2,3]"},
+		{`a = [1]; a.concat([]).to_json()`, "[1]"},
+
+		// A method handing back part of an array must hand back a copy. Without
+		// one the result shares memory with the original, and writing to the
+		// original changes the result underneath the caller.
+		{`a = [1,2,3]; b = a.drop(1); a[1] = 9; b.to_json()`, "[2,3]"},
+		{`a = [1,2,3]; b = a.take(2); a[0] = 9; b.to_json()`, "[1,2]"},
+		{`a = [1,2,3]; b = a.first(2); a[0] = 9; b.to_json()`, "[1,2]"},
+		{`a = [1,2,3]; b = a.last(2); a[2] = 9; b.to_json()`, "[2,3]"},
+	}
+	testInput(t, tests)
+}
+
+// TestArrayBangPairsAreComplete checks that the new pairs follow the same rule
+// as the old ones: the plain method leaves the receiver alone, the ! method
+// changes it and hands it back so calls chain.
+func TestArrayBangPairsAreComplete(t *testing.T) {
+	tests := []inputTestCase{
+		// Pure.
+		{`a = [1,nil,2]; a.compact(); a.to_json()`, "[1,null,2]"},
+		{`a = [1,[2]]; a.flatten(); a.to_json()`, "[1,[2]]"},
+		{`a = [1,2,3]; a.rotate(); a.to_json()`, "[1,2,3]"},
+
+		// In place.
+		{`a = [1,nil,2]; a.compact!(); a.to_json()`, "[1,2]"},
+		{`a = [1,[2]]; a.flatten!(); a.to_json()`, "[1,2]"},
+		{`a = [1,2,3]; a.rotate!(); a.to_json()`, "[2,3,1]"},
+
+		// ...and they chain, because each returns the array.
+		{`[1,nil,[2,nil]].flatten!().compact!().to_json()`, "[1,2]"},
+		{`[1,2,3].rotate!().rotate!().to_json()`, "[3,1,2]"},
+		{`[1,2].compact!().type()`, "ARRAY"},
+
+		// A ! method takes the same arguments as its plain counterpart.
+		{`[1,[2,[3]]].flatten!(1).to_json()`, "[1,2,[3]]"},
+		{`[1,2,3].rotate!(2).to_json()`, "[3,1,2]"},
+		{`[1,2].flatten!(0 - 1)`, "negative depth -1"},
+	}
+	testInput(t, tests)
 }

--- a/object/error.go
+++ b/object/error.go
@@ -16,6 +16,12 @@ func NewErrorFormat(format string, a ...interface{}) *Error {
 
 func (e *Error) Type() ObjectType { return ERROR_OBJ }
 func (e *Error) Inspect() string  { return "ERROR: " + e.Message }
+
+// ToStringObj gives the message without the "ERROR: " prefix Inspect adds, so
+// to_s() matches msg(). Ruby's Exception#to_s does the same.
+func (e *Error) ToStringObj() *String {
+	return NewString(e.Message)
+}
 func (e *Error) InvokeMethod(method string, env Environment, args ...Object) Object {
 	return objectMethodLookup(e, method, env, args)
 }

--- a/object/file.go
+++ b/object/file.go
@@ -211,6 +211,10 @@ func init() {
 	}
 }
 
+func (f *File) ToStringObj() *String {
+	return NewString(f.Inspect())
+}
+
 func (f *File) InvokeMethod(method string, env Environment, args ...Object) Object {
 	return objectMethodLookup(f, method, env, args)
 }

--- a/object/float.go
+++ b/object/float.go
@@ -37,35 +37,113 @@ func init() {
 				return NewFloat(math.Abs(o.(*Float).Value))
 			},
 		},
-		"ceil": ObjectMethod{
+		"divmod": ObjectMethod{
 			Layout: MethodLayout{
-				ReturnPattern: Args(
+				ArgPattern: Args(
 					Arg(FLOAT_OBJ),
 				),
+				ReturnPattern: Args(
+					Arg(ARRAY_OBJ, ERROR_OBJ),
+				),
 			},
-			method: func(o Object, _ []Object, _ Environment) Object {
-				return NewFloat(math.Ceil(o.(*Float).Value))
+			method: func(o Object, args []Object, _ Environment) Object {
+				value := o.(*Float).Value
+				divisor := args[0].(*Float).Value
+
+				if divisor == 0 {
+					return NewError("division by zero not allowed")
+				}
+
+				// Truncated, so that this agrees with Integer#divmod and with
+				// the / operator. Ruby floors instead.
+				quotient := math.Trunc(value / divisor)
+
+				return NewArrayWithObjects(
+					NewFloat(quotient),
+					NewFloat(value-quotient*divisor),
+				)
 			},
 		},
-		"floor": ObjectMethod{
+		"infinite?": ObjectMethod{
 			Layout: MethodLayout{
 				ReturnPattern: Args(
-					Arg(FLOAT_OBJ),
+					Arg(INTEGER_OBJ, NIL_OBJ),
 				),
 			},
 			method: func(o Object, _ []Object, _ Environment) Object {
-				return NewFloat(math.Floor(o.(*Float).Value))
+				// 1, -1 or nil rather than a boolean, so the direction is not
+				// lost. finite? is the plain yes-or-no question.
+				switch {
+				case math.IsInf(o.(*Float).Value, 1):
+					return NewInteger(1)
+				case math.IsInf(o.(*Float).Value, -1):
+					return NewInteger(-1)
+				default:
+					return NIL
+				}
 			},
 		},
-		"round": ObjectMethod{
-			Layout: MethodLayout{
-				ReturnPattern: Args(
-					Arg(FLOAT_OBJ),
-				),
-			},
-			method: func(o Object, _ []Object, _ Environment) Object {
-				return NewFloat(math.Round(o.(*Float).Value))
-			},
+	}
+
+	// Rounding a float takes an optional number of decimal places. A negative
+	// count rounds to a power of ten, so 555.5.round(-1) is 560.0. The result
+	// stays a FLOAT: a numeric method returns the type it was given, which is
+	// why this differs from Ruby, where 1.5.round is an Integer.
+	floatRounding("ceil", math.Ceil)
+	floatRounding("floor", math.Floor)
+	floatRounding("round", math.Round)
+	floatRounding("truncate", math.Trunc)
+
+	floatPredicate("zero?", func(value float64) bool { return value == 0 })
+	floatPredicate("positive?", func(value float64) bool { return value > 0 })
+	floatPredicate("negative?", func(value float64) bool { return value < 0 })
+	floatPredicate("nan?", math.IsNaN)
+	floatPredicate("finite?", func(value float64) bool {
+		return !math.IsInf(value, 0) && !math.IsNaN(value)
+	})
+}
+
+// floatPredicate registers a method returning a BOOLEAN about the value.
+func floatPredicate(name string, test func(value float64) bool) {
+	objectMethods[FLOAT_OBJ][name] = ObjectMethod{
+		Layout: MethodLayout{
+			ReturnPattern: Args(Arg(BOOLEAN_OBJ)),
+		},
+		method: func(o Object, _ []Object, _ Environment) Object {
+			if test(o.(*Float).Value) {
+				return TRUE
+			}
+
+			return FALSE
+		},
+	}
+}
+
+// floatRounding registers ceil, floor, round or truncate, each taking an
+// optional number of decimal places.
+func floatRounding(name string, apply func(float64) float64) {
+	objectMethods[FLOAT_OBJ][name] = ObjectMethod{
+		Layout: MethodLayout{
+			ArgPattern:    Args(OptArg(INTEGER_OBJ)),
+			ReturnPattern: Args(Arg(FLOAT_OBJ)),
+		},
+		method: func(o Object, args []Object, _ Environment) Object {
+			value := o.(*Float).Value
+
+			if len(args) == 0 {
+				return NewFloat(apply(value))
+			}
+
+			// Scaling by a power of ten and back is what gives the digit
+			// count its meaning. Guard the non-finite cases, where scaling
+			// produces NaN instead of leaving the value alone.
+			if math.IsInf(value, 0) || math.IsNaN(value) {
+				return NewFloat(value)
+			}
+
+			scale := math.Pow(10, float64(args[0].(*Integer).Value))
+
+			return NewFloat(apply(value*scale) / scale)
 		},
 	}
 }

--- a/object/float_test.go
+++ b/object/float_test.go
@@ -70,3 +70,39 @@ func TestFloatInspect(t *testing.T) {
 		t.Errorf("float inspect does not match value")
 	}
 }
+
+// TestFloatRubyMethods covers the methods added to close the gap with Ruby's
+// Float. Rounding keeps returning a FLOAT rather than an INTEGER, which is this
+// language's rule that a numeric method answers with the type it was given.
+func TestFloatRubyMethods(t *testing.T) {
+	tests := []inputTestCase{
+		{`1.567.round(2)`, 1.57},
+		{`1.561.ceil(2)`, 1.57},
+		{`1.567.floor(2)`, 1.56},
+		{`1.567.truncate(2)`, 1.56},
+		{`555.5.round(0 - 1)`, 560.0},
+		{`1.567.truncate()`, 1.0},
+		{`(0.0 - 1.5).truncate()`, -1.0},
+		{`(0.0 - 1.5).floor()`, -2.0},
+		{`(0.0 - 1.5).ceil()`, -1.0},
+		// Still a FLOAT, not an INTEGER as in Ruby.
+		{`1.5.round().type()`, "FLOAT"},
+		{`1.5.truncate().type()`, "FLOAT"},
+
+		{`0.0.zero?()`, true},
+		{`1.5.zero?()`, false},
+		{`1.5.positive?()`, true},
+		{`(0.0 - 1.5).negative?()`, true},
+		{`0.0.positive?()`, false},
+		{`1.5.nan?()`, false},
+		{`1.5.finite?()`, true},
+		// 1, -1 or nil rather than a boolean, so the direction survives.
+		{`1.5.infinite?()`, nil},
+
+		{`11.0.divmod(4.0)`, "[2.0, 3.0]"},
+		{`11.0.divmod(0.0)`, "division by zero not allowed"},
+		// Truncated, so it agrees with Integer#divmod and with /.
+		{`11.0.divmod(0.0 - 4.0)`, "[-2.0, 3.0]"},
+	}
+	testInput(t, tests)
+}

--- a/object/hash.go
+++ b/object/hash.go
@@ -159,7 +159,192 @@ func init() {
 				return args[1]
 			},
 		},
+		"size": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(INTEGER_OBJ),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				return NewInteger(len(o.(*Hash).Pairs))
+			},
+		},
+		"empty?": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(BOOLEAN_OBJ),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				if len(o.(*Hash).Pairs) == 0 {
+					return TRUE
+				}
+
+				return FALSE
+			},
+		},
+		"fetch": ObjectMethod{
+			Layout: MethodLayout{
+				ArgPattern: Args(
+					Arg(ANY_OBJ...),
+					OptArg(ANY_OBJ...),
+				),
+				ReturnPattern: Args(
+					Arg(ANY_OBJ...),
+				),
+			},
+			method: func(o Object, args []Object, _ Environment) Object {
+				h := o.(*Hash)
+
+				key, ok := args[0].(Hashable)
+				if !ok {
+					return NewErrorFormat("unusable as hash key: %s", args[0].Type())
+				}
+
+				if pair, found := h.Pairs[key.HashKey()]; found {
+					return pair.Value
+				}
+
+				// Without a fallback a missing key is an error rather than nil.
+				// That is the difference from get(), which always needs one.
+				if len(args) > 1 {
+					return args[1]
+				}
+
+				return NewErrorFormat("key not found: %s", args[0].Inspect())
+			},
+		},
+		"delete": ObjectMethod{
+			Layout: MethodLayout{
+				ArgPattern: Args(
+					Arg(ANY_OBJ...),
+				),
+				ReturnPattern: Args(
+					Arg(ANY_OBJ...),
+				),
+			},
+			method: func(o Object, args []Object, _ Environment) Object {
+				h := o.(*Hash)
+
+				key, ok := args[0].(Hashable)
+				if !ok {
+					return NewErrorFormat("unusable as hash key: %s", args[0].Type())
+				}
+
+				hashed := key.HashKey()
+				pair, found := h.Pairs[hashed]
+				if !found {
+					return NIL
+				}
+				delete(h.Pairs, hashed)
+
+				// The value that went, so a delete can be told from a miss.
+				return pair.Value
+			},
+		},
+		"clear": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(HASH_OBJ),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				h := o.(*Hash)
+				h.Pairs = make(map[HashKey]HashPair)
+
+				return h
+			},
+		},
+		"invert": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(HASH_OBJ, ERROR_OBJ),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				pairs := make(map[HashKey]HashPair)
+
+				for _, pair := range o.(*Hash).Pairs {
+					value, ok := pair.Value.(Hashable)
+					if !ok {
+						return NewErrorFormat("unusable as hash key: %s", pair.Value.Type())
+					}
+					// Duplicate values collapse into one entry, and which one
+					// survives is not defined -- the same caveat Ruby carries.
+					pairs[value.HashKey()] = HashPair{Key: pair.Value, Value: pair.Key}
+				}
+
+				return NewHash(pairs)
+			},
+		},
 	}
+
+	hashPair("merge", Args(Arg(HASH_OBJ)), func(pairs map[HashKey]HashPair, args []Object) (map[HashKey]HashPair, Object) {
+		merged := copyPairs(pairs)
+		// The argument wins on a clash, as it does in Ruby.
+		for hashed, pair := range args[0].(*Hash).Pairs {
+			merged[hashed] = pair
+		}
+
+		return merged, nil
+	})
+	hashPair("compact", nil, func(pairs map[HashKey]HashPair, _ []Object) (map[HashKey]HashPair, Object) {
+		kept := make(map[HashKey]HashPair, len(pairs))
+		for hashed, pair := range pairs {
+			if pair.Value.Type() == NIL_OBJ {
+				continue
+			}
+			kept[hashed] = pair
+		}
+
+		return kept, nil
+	})
+}
+
+// hashPair registers a method and its in-place counterpart from one
+// transformation. See stringPair in string.go for why the two halves are not
+// written out separately.
+func hashPair(name string, argPattern []Argument, transform func(pairs map[HashKey]HashPair, args []Object) (map[HashKey]HashPair, Object)) {
+	layout := MethodLayout{
+		ArgPattern:    argPattern,
+		ReturnPattern: Args(Arg(HASH_OBJ, ERROR_OBJ)),
+	}
+
+	objectMethods[HASH_OBJ][name] = ObjectMethod{
+		Layout: layout,
+		method: func(o Object, args []Object, _ Environment) Object {
+			pairs, err := transform(o.(*Hash).Pairs, args)
+			if err != nil {
+				return err
+			}
+
+			return NewHash(pairs)
+		},
+	}
+
+	objectMethods[HASH_OBJ][name+"!"] = ObjectMethod{
+		Layout: layout,
+		method: func(o Object, args []Object, _ Environment) Object {
+			h := o.(*Hash)
+
+			pairs, err := transform(h.Pairs, args)
+			if err != nil {
+				return err
+			}
+			h.Pairs = pairs
+
+			return h
+		},
+	}
+}
+
+func copyPairs(src map[HashKey]HashPair) map[HashKey]HashPair {
+	out := make(map[HashKey]HashPair, len(src))
+	for hashed, pair := range src {
+		out[hashed] = pair
+	}
+
+	return out
 }
 
 func (h *Hash) InvokeMethod(method string, env Environment, args ...Object) Object {
@@ -173,6 +358,12 @@ func (h *Hash) GetIterator(_, _ int, _ bool) Iterator {
 		pairs = append(pairs, val)
 	}
 	return &hashIterator{pairs: pairs}
+}
+
+// ToStringObj renders the hash the way Inspect does. See Array.ToStringObj
+// for why this is not left to the generic to_s.
+func (h *Hash) ToStringObj() *String {
+	return NewString(h.Inspect())
 }
 
 func (h *Hash) MarshalJSON() ([]byte, error) {

--- a/object/hash_test.go
+++ b/object/hash_test.go
@@ -38,7 +38,9 @@ func TestHashObjectMethods(t *testing.T) {
 		{`{"a": 1, 1: "b"}.include?()`, `to few arguments: got=0, want=1`},
 		{`{"a": 1, "b": 2}.get("a", 10)`, 1},
 		{`{"a": 1, "b": 2}.get("c", 10)`, 10},
-		{`{"a": 1, "b": 2}.to_s()`, ""},
+		// to_s used to be "" because Hash was not Stringable. A single entry,
+		// because the order of a bigger hash is not defined.
+		{`{"a": 1}.to_s()`, `{"a": 1}`},
 		{`{"a": 1, "b": 2}.to_i()`, nil},
 		{`{"a": 1, "b": 2}.to_f()`, nil},
 	}
@@ -103,4 +105,64 @@ func TestHashSet(t *testing.T) {
 			t.Errorf("unexpected type of value, got=%s want=%s", obj.Type(), object.INTEGER_OBJ)
 		}
 	}
+}
+
+// TestHashRubyMethods covers the methods added to close the gap with Ruby's
+// Hash. Only the order-independent ones: keys(), values() and anything built on
+// them still come back in map order, so to_a is left out until a hash keeps
+// insertion order.
+func TestHashRubyMethods(t *testing.T) {
+	tests := []inputTestCase{
+		{`{"a": 1}.size()`, 1},
+		{`{}.size()`, 0},
+		{`{}.empty?()`, true},
+		{`{"a": 1}.empty?()`, false},
+
+		// fetch errors on a missing key unless given a fallback. That is the
+		// difference from get(), which always requires one.
+		{`{"a": 1}.fetch("a")`, 1},
+		{`{"a": 1}.fetch("z", 0)`, 0},
+		{`{"a": 1}.fetch("z")`, `key not found: "z"`},
+		{`{"a": 1}.fetch(nil)`, "unusable as hash key: NIL"},
+
+		// delete reports the value that went, or nil when nothing did.
+		{`h = {"a": 1}; h.delete("a")`, 1},
+		{`h = {"a": 1}; h.delete("a"); h.size()`, 0},
+		{`h = {"a": 1}; h.delete("z")`, nil},
+		{`h = {"a": 1}; h.delete("z"); h.size()`, 1},
+
+		{`h = {"a": 1}; h.clear().size()`, 0},
+		{`h = {"a": 1}; h.clear(); h.size()`, 0},
+
+		{`{"a": 1}.merge({"b": 2}).size()`, 2},
+		// The argument wins a clash.
+		{`{"a": 1}.merge({"a": 9}).get("a", 0)`, 9},
+		{`{"a": 1}.invert().get(1, "missing")`, "a"},
+		{`{"a": nil}.invert()`, "unusable as hash key: NIL"},
+
+		{`{"a": 1, "b": nil}.compact().size()`, 1},
+		{`{"a": nil}.compact().get("a", "gone")`, "gone"},
+
+		// to_json renders a nil value as null now that Nil is serializable.
+		{`{"a": nil}.to_json()`, `{"a":null}`},
+	}
+	testInput(t, tests)
+}
+
+// TestHashBangPairsAreComplete checks the convention on Hash's two pairs.
+func TestHashBangPairsAreComplete(t *testing.T) {
+	tests := []inputTestCase{
+		// Pure.
+		{`h = {"a": 1}; h.merge({"b": 2}); h.size()`, 1},
+		{`h = {"a": nil}; h.compact(); h.size()`, 1},
+
+		// In place.
+		{`h = {"a": 1}; h.merge!({"b": 2}); h.size()`, 2},
+		{`h = {"a": nil}; h.compact!(); h.size()`, 0},
+
+		// ...and they chain, because each returns the hash.
+		{`{"a": 1}.merge!({"b": nil}).compact!().size()`, 1},
+		{`{"a": 1}.merge!({"b": 2}).type()`, "HASH"},
+	}
+	testInput(t, tests)
 }

--- a/object/http.go
+++ b/object/http.go
@@ -21,6 +21,10 @@ type HTTP struct {
 func NewHTTP() *HTTP             { return &HTTP{mux: http.NewServeMux()} }
 func (h *HTTP) Type() ObjectType { return HTTP_OBJ }
 func (h *HTTP) Inspect() string  { return "HTTP" }
+func (h *HTTP) ToStringObj() *String {
+	return NewString(h.Inspect())
+}
+
 func (h *HTTP) InvokeMethod(method string, env Environment, args ...Object) Object {
 	return objectMethodLookup(h, method, env, args)
 }

--- a/object/integer.go
+++ b/object/integer.go
@@ -3,6 +3,7 @@ package object
 import (
 	"encoding/json"
 	"fmt"
+	"unicode"
 )
 
 type Integer struct {
@@ -74,7 +75,376 @@ func init() {
 				return NewIntegerWithBase(o.(*Integer).Value, args[0].(*Integer).Value)
 			},
 		},
+		"chr": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(STRING_OBJ, ERROR_OBJ),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				value := o.(*Integer).Value
+				if value < 0 || value > unicode.MaxRune {
+					return NewErrorFormat("%d is out of the range of a character", value)
+				}
+
+				return NewString(string(rune(value)))
+			},
+		},
+		"digits": ObjectMethod{
+			Layout: MethodLayout{
+				ArgPattern: Args(
+					OptArg(INTEGER_OBJ),
+				),
+				ReturnPattern: Args(
+					Arg(ARRAY_OBJ, ERROR_OBJ),
+				),
+			},
+			method: func(o Object, args []Object, _ Environment) Object {
+				value := o.(*Integer).Value
+				if value < 0 {
+					return NewError("digits of a negative number are not defined")
+				}
+
+				base := 10
+				if len(args) > 0 {
+					base = args[0].(*Integer).Value
+				}
+				if base < 2 {
+					return NewErrorFormat("base has to be 2 or greater, got %d", base)
+				}
+
+				// Least significant digit first, as in Ruby: 12345.digits is
+				// [5, 4, 3, 2, 1].
+				if value == 0 {
+					return NewArrayWithObjects(NewInteger(0))
+				}
+
+				digits := make([]Object, 0)
+				for value > 0 {
+					digits = append(digits, NewInteger(value%base))
+					value /= base
+				}
+
+				return NewArray(digits)
+			},
+		},
+		"divmod": ObjectMethod{
+			Layout: MethodLayout{
+				ArgPattern: Args(
+					Arg(INTEGER_OBJ),
+				),
+				ReturnPattern: Args(
+					Arg(ARRAY_OBJ, ERROR_OBJ),
+				),
+			},
+			method: func(o Object, args []Object, _ Environment) Object {
+				i := o.(*Integer)
+				other := args[0].(*Integer)
+
+				if err := requireSameBase(i, other); err != nil {
+					return err
+				}
+				if other.Value == 0 {
+					return NewError("division by zero not allowed")
+				}
+
+				// Matches this language's own / and %, which truncate toward
+				// zero. Ruby floors instead, so 11.divmod(-4) is [-3, -1] there
+				// and [-2, 3] here -- but here it agrees with 11 / -4 and
+				// 11 % -4, which matters more than agreeing with Ruby.
+				return NewArrayWithObjects(
+					NewIntegerWithBase(i.Value/other.Value, i.Base),
+					NewIntegerWithBase(i.Value%other.Value, i.Base),
+				)
+			},
+		},
+		"gcd": ObjectMethod{
+			Layout: MethodLayout{
+				ArgPattern: Args(
+					Arg(INTEGER_OBJ),
+				),
+				ReturnPattern: Args(
+					Arg(INTEGER_OBJ, ERROR_OBJ),
+				),
+			},
+			method: func(o Object, args []Object, _ Environment) Object {
+				i := o.(*Integer)
+				other := args[0].(*Integer)
+
+				if err := requireSameBase(i, other); err != nil {
+					return err
+				}
+
+				return NewIntegerWithBase(greatestCommonDivisor(i.Value, other.Value), i.Base)
+			},
+		},
+		"lcm": ObjectMethod{
+			Layout: MethodLayout{
+				ArgPattern: Args(
+					Arg(INTEGER_OBJ),
+				),
+				ReturnPattern: Args(
+					Arg(INTEGER_OBJ, ERROR_OBJ),
+				),
+			},
+			method: func(o Object, args []Object, _ Environment) Object {
+				i := o.(*Integer)
+				other := args[0].(*Integer)
+
+				if err := requireSameBase(i, other); err != nil {
+					return err
+				}
+
+				divisor := greatestCommonDivisor(i.Value, other.Value)
+				if divisor == 0 {
+					return NewIntegerWithBase(0, i.Base)
+				}
+
+				return NewIntegerWithBase(absInt(i.Value/divisor*other.Value), i.Base)
+			},
+		},
+		"pow": ObjectMethod{
+			Layout: MethodLayout{
+				ArgPattern: Args(
+					Arg(INTEGER_OBJ),
+					OptArg(INTEGER_OBJ),
+				),
+				ReturnPattern: Args(
+					Arg(INTEGER_OBJ, ERROR_OBJ),
+				),
+			},
+			method: func(o Object, args []Object, _ Environment) Object {
+				i := o.(*Integer)
+				exponent := args[0].(*Integer).Value
+
+				// Ruby answers a Rational here. There is no such type, and
+				// silently handing back a float would break the rule that a
+				// numeric method returns the type it was given.
+				if exponent < 0 {
+					return NewError("negative exponent is not supported")
+				}
+
+				modulus := 0
+				if len(args) > 1 {
+					modulus = args[1].(*Integer).Value
+					if modulus == 0 {
+						return NewError("modulus of zero not allowed")
+					}
+				}
+
+				return NewIntegerWithBase(integerPow(i.Value, exponent, modulus), i.Base)
+			},
+		},
+		"succ": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(INTEGER_OBJ),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				i := o.(*Integer)
+
+				return NewIntegerWithBase(i.Value+1, i.Base)
+			},
+		},
+		"pred": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(INTEGER_OBJ),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				i := o.(*Integer)
+
+				return NewIntegerWithBase(i.Value-1, i.Base)
+			},
+		},
+		"bit_length": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(INTEGER_OBJ),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				// A negative number needs as many bits as its complement, so
+				// -256 is 8 bits just like 255.
+				value := o.(*Integer).Value
+				if value < 0 {
+					value = ^value
+				}
+
+				length := 0
+				for value > 0 {
+					length++
+					value >>= 1
+				}
+
+				return NewInteger(length)
+			},
+		},
 	}
+
+	// Rounding an integer only does something with a negative digit count,
+	// which rounds to a power of ten: 555.floor(-1) is 550.
+	integerRounding("ceil", func(value, factor int) int {
+		return ceilTo(value, factor)
+	})
+	integerRounding("floor", func(value, factor int) int {
+		return floorTo(value, factor)
+	})
+	integerRounding("round", func(value, factor int) int {
+		return roundTo(value, factor)
+	})
+	integerRounding("truncate", func(value, factor int) int {
+		return value / factor * factor
+	})
+
+	integerPredicate("even?", func(value int) bool { return value%2 == 0 })
+	integerPredicate("odd?", func(value int) bool { return value%2 != 0 })
+	integerPredicate("zero?", func(value int) bool { return value == 0 })
+	integerPredicate("positive?", func(value int) bool { return value > 0 })
+	integerPredicate("negative?", func(value int) bool { return value < 0 })
+}
+
+// integerPredicate registers a method returning a BOOLEAN about the value.
+func integerPredicate(name string, test func(value int) bool) {
+	objectMethods[INTEGER_OBJ][name] = ObjectMethod{
+		Layout: MethodLayout{
+			ReturnPattern: Args(Arg(BOOLEAN_OBJ)),
+		},
+		method: func(o Object, _ []Object, _ Environment) Object {
+			if test(o.(*Integer).Value) {
+				return TRUE
+			}
+
+			return FALSE
+		},
+	}
+}
+
+// integerRounding registers ceil, floor, round or truncate. Without an
+// argument, or with a digit count of zero or more, an integer is already as
+// precise as it gets and is returned unchanged.
+func integerRounding(name string, apply func(value, factor int) int) {
+	objectMethods[INTEGER_OBJ][name] = ObjectMethod{
+		Layout: MethodLayout{
+			ArgPattern:    Args(OptArg(INTEGER_OBJ)),
+			ReturnPattern: Args(Arg(INTEGER_OBJ)),
+		},
+		method: func(o Object, args []Object, _ Environment) Object {
+			i := o.(*Integer)
+
+			digits := 0
+			if len(args) > 0 {
+				digits = args[0].(*Integer).Value
+			}
+			if digits >= 0 {
+				return i
+			}
+
+			factor := 1
+			for range -digits {
+				factor *= 10
+			}
+
+			return NewIntegerWithBase(apply(i.Value, factor), i.Base)
+		},
+	}
+}
+
+// requireSameBase mirrors the check the infix operators make: 0x10 + 4 is an
+// error, so 0x10.gcd(4) is one too.
+func requireSameBase(left, right *Integer) Object {
+	if left.Base != right.Base {
+		return NewError("infix operation with unequal base not allowed")
+	}
+
+	return nil
+}
+
+func absInt(value int) int {
+	if value < 0 {
+		return -value
+	}
+
+	return value
+}
+
+func greatestCommonDivisor(a, b int) int {
+	a, b = absInt(a), absInt(b)
+	for b != 0 {
+		a, b = b, a%b
+	}
+
+	return a
+}
+
+// integerPow raises base to exponent by squaring. A non-zero modulus reduces
+// at every step, which is what keeps a.pow(b, m) usable for large exponents.
+func integerPow(base, exponent, modulus int) int {
+	result := 1
+	if modulus != 0 {
+		result %= modulus
+		base %= modulus
+	}
+
+	for exponent > 0 {
+		if exponent&1 == 1 {
+			result *= base
+			if modulus != 0 {
+				result %= modulus
+			}
+		}
+
+		exponent >>= 1
+		if exponent == 0 {
+			break
+		}
+
+		base *= base
+		if modulus != 0 {
+			base %= modulus
+		}
+	}
+
+	return result
+}
+
+// ceilTo, floorTo and roundTo round value to a multiple of factor. They are
+// written for integers so that no float rounding creeps in.
+func ceilTo(value, factor int) int {
+	truncated := value / factor * factor
+	if value > 0 && truncated != value {
+		truncated += factor
+	}
+
+	return truncated
+}
+
+func floorTo(value, factor int) int {
+	truncated := value / factor * factor
+	if value < 0 && truncated != value {
+		truncated -= factor
+	}
+
+	return truncated
+}
+
+// roundTo rounds half away from zero, matching Ruby's default and Go's
+// math.Round.
+func roundTo(value, factor int) int {
+	remainder := value % factor
+	truncated := value - remainder
+
+	if absInt(remainder)*2 >= factor {
+		if value < 0 {
+			return truncated - factor
+		}
+
+		return truncated + factor
+	}
+
+	return truncated
 }
 
 func (i *Integer) InvokeMethod(method string, env Environment, args ...Object) Object {

--- a/object/integer_test.go
+++ b/object/integer_test.go
@@ -94,3 +94,84 @@ func TestIntegerIteratable(t *testing.T) {
 		t.Errorf("new integer iteration shouldn't finish after first next")
 	}
 }
+
+// TestIntegerRubyMethods covers the methods added to close the gap with Ruby's
+// Integer. The expectations come from the example lines in
+// https://ruby-doc.org/3.4.1/Integer.html, except where noted.
+func TestIntegerRubyMethods(t *testing.T) {
+	tests := []inputTestCase{
+		{`12345.digits()`, "[5, 4, 3, 2, 1]"},
+		{`12345.digits(7)`, "[4, 6, 6, 0, 5]"},
+		{`0.digits()`, "[0]"},
+		{`(0 - 1).digits()`, "digits of a negative number are not defined"},
+		{`5.digits(1)`, "base has to be 2 or greater, got 1"},
+
+		{`36.gcd(60)`, 12},
+		{`3.gcd(0 - 7)`, 1},
+		{`0.gcd(0)`, 0},
+		{`36.lcm(60)`, 180},
+		{`3.lcm(0 - 7)`, 21},
+		{`0.lcm(2)`, 0},
+
+		{`2.pow(3)`, 8},
+		{`2.pow(3, 5)`, 3},
+		{`2.pow(0)`, 1},
+		{`2.pow(0 - 1)`, "negative exponent is not supported"},
+		{`2.pow(3, 0)`, "modulus of zero not allowed"},
+
+		{`0.bit_length()`, 0},
+		{`255.bit_length()`, 8},
+		{`256.bit_length()`, 9},
+		// A negative number needs as many bits as its complement.
+		{`(0 - 1).bit_length()`, 0},
+		{`(0 - 256).bit_length()`, 8},
+
+		{`1.succ()`, 2},
+		{`1.pred()`, 0},
+		{`(0 - 1).pred()`, -2},
+
+		{`4.even?()`, true},
+		{`5.even?()`, false},
+		{`5.odd?()`, true},
+		{`(0 - 3).odd?()`, true},
+		{`(0 - 3).even?()`, false},
+		{`0.zero?()`, true},
+		{`1.positive?()`, true},
+		{`(0 - 1).negative?()`, true},
+		{`0.positive?()`, false},
+
+		{`65.chr()`, "A"},
+		{`(0 - 1).chr()`, "-1 is out of the range of a character"},
+
+		// Rounding an integer only does something with a negative digit count.
+		{`555.ceil(0 - 1)`, 560},
+		{`555.floor(0 - 1)`, 550},
+		{`555.round(0 - 1)`, 560},
+		{`555.truncate(0 - 1)`, 550},
+		{`555.truncate(0 - 2)`, 500},
+		{`555.ceil()`, 555},
+		{`555.round(2)`, 555},
+		{`(0 - 555).floor(0 - 1)`, -560},
+		{`(0 - 555).ceil(0 - 1)`, -550},
+		{`(0 - 555).round(0 - 1)`, -560},
+		{`(0 - 555).truncate(0 - 1)`, -550},
+		// A value already on the boundary is left alone rather than pushed to
+		// the next multiple.
+		{`550.ceil(0 - 1)`, 550},
+		{`550.floor(0 - 1)`, 550},
+
+		// divmod follows this language's / and %, which truncate toward zero.
+		// Ruby floors, so it answers [-3, -1] for the third case.
+		{`11.divmod(4)`, "[2, 3]"},
+		{`11.divmod(4).first()`, 2},
+		{`11.divmod(0 - 4)`, "[-2, 3]"},
+		{`11.divmod(0)`, "division by zero not allowed"},
+
+		// An arithmetic method rejects a mixed base for the same reason 0x10 + 4
+		// does.
+		{`"0x10".to_i().gcd(4)`, "infix operation with unequal base not allowed"},
+		{`"0x10".to_i().succ().base()`, 16},
+		{`"0b101".to_i().pred().base()`, 2},
+	}
+	testInput(t, tests)
+}

--- a/object/matrix.go
+++ b/object/matrix.go
@@ -359,7 +359,8 @@ func init() {
 				if err != nil {
 					return NewErrorFormat("%s", err.Error())
 				}
-				return NIL
+
+				return m
 			},
 		},
 		"row": {

--- a/object/matrix_test.go
+++ b/object/matrix_test.go
@@ -569,8 +569,8 @@ func TestMatrixMethodSet(t *testing.T) {
 
 	// Valid set with integer
 	result := m.InvokeMethod("set", *env, NewInteger(0), NewInteger(2), NewInteger(99))
-	if result.Type() != NIL_OBJ {
-		t.Errorf("set method should return NIL, got %s", result.Type())
+	if result.Type() != MATRIX_OBJ {
+		t.Errorf("set method should return MATRIX, got %s", result.Type())
 	}
 	if m.Data[0][2] != 99.0 {
 		t.Errorf("After set, m[0][2] = %f, want 99.0", m.Data[0][2])
@@ -578,8 +578,8 @@ func TestMatrixMethodSet(t *testing.T) {
 
 	// Valid set with float
 	result = m.InvokeMethod("set", *env, NewInteger(1), NewInteger(1), NewFloat(3.14))
-	if result.Type() != NIL_OBJ {
-		t.Errorf("set method should return NIL, got %s", result.Type())
+	if result.Type() != MATRIX_OBJ {
+		t.Errorf("set method should return MATRIX, got %s", result.Type())
 	}
 	if m.Data[1][1] != 3.14 {
 		t.Errorf("After set, m[1][1] = %f, want 3.14", m.Data[1][1])

--- a/object/nil.go
+++ b/object/nil.go
@@ -14,6 +14,13 @@ func (n *Nil) ToStringObj() *String {
 	return NewString("")
 }
 
+// MarshalJSON renders nil as JSON null. Without it Nil was not Serializable at
+// all, so nil.to_json() was an error, and a nil inside an array came out as {}
+// because json.Marshal fell back to encoding the empty struct.
+func (n *Nil) MarshalJSON() ([]byte, error) {
+	return []byte("null"), nil
+}
+
 func init() {
 	objectMethods[NIL_OBJ] = map[string]ObjectMethod{}
 }

--- a/object/object.go
+++ b/object/object.go
@@ -3,6 +3,7 @@ package object
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/flipez/rocket-lang/ast"
@@ -278,6 +279,20 @@ func init() {
 				return NewErrorFormat("%s is not serializable", o.Type())
 			},
 		},
+		"nil?": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(BOOLEAN_OBJ),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				if o.Type() == NIL_OBJ {
+					return TRUE
+				}
+
+				return FALSE
+			},
+		},
 		"methods": ObjectMethod{
 			Layout: MethodLayout{
 				ReturnPattern: Args(
@@ -286,12 +301,19 @@ func init() {
 			},
 			method: func(o Object, _ []Object, _ Environment) Object {
 				oms := objectMethods[o.Type()]
-				result := make([]Object, len(oms))
-				var i int
+				names := make([]string, 0, len(oms))
 				for name := range oms {
-					result[i] = NewString(name)
-					i++
+					names = append(names, name)
 				}
+				// Sorted, because reading it straight out of the map made the
+				// order differ between runs of the same program.
+				sort.Strings(names)
+
+				result := make([]Object, len(names))
+				for i, name := range names {
+					result[i] = NewString(name)
+				}
+
 				return NewArray(result)
 			},
 		},
@@ -303,12 +325,18 @@ func init() {
 			},
 			method: func(o Object, _ []Object, _ Environment) Object {
 				oms := objectMethods[o.Type()]
-				result := make([]string, len(oms))
-				var i int
-				for name, objectMethod := range oms {
-					result[i] = fmt.Sprintf("\t%s", objectMethod.Layout.Usage(name))
-					i++
+				names := make([]string, 0, len(oms))
+				for name := range oms {
+					names = append(names, name)
 				}
+				// Sorted for the same reason as methods() above.
+				sort.Strings(names)
+
+				result := make([]string, len(names))
+				for i, name := range names {
+					result[i] = fmt.Sprintf("\t%s", oms[name].Layout.Usage(name))
+				}
+
 				return NewString(fmt.Sprintf("%s supports the following methods:\n%s", o.Type(), strings.Join(result, "\n")))
 			},
 		},

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -2,6 +2,8 @@ package object_test
 
 import (
 	"errors"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -54,11 +56,9 @@ func testInput(t *testing.T, tests []inputTestCase) {
 				testStringObject(t, strObj, expected)
 				continue
 			}
-			_, ok = evaluated.(*object.Nil)
-			if ok {
-				continue
-			}
-
+			// A NIL used to be accepted here, which meant every string and
+			// every error-message expectation in this file silently passed
+			// when the method under test returned nil instead.
 			errObj, ok := evaluated.(*object.Error)
 			if !ok {
 				t.Errorf("object is not Error. got=%T (%+v)", evaluated, evaluated)
@@ -183,5 +183,133 @@ func TestObjectToAny(t *testing.T) {
 
 	for input, expected := range testcases {
 		require.Equal(t, expected, object.ObjectToAny(input))
+	}
+}
+
+// TestMethodListingIsSorted covers methods() and wat(), which used to read the
+// method names straight out of a map. That made the same program print a
+// different order on every run, so their output could not be relied on or
+// documented.
+func TestMethodListingIsSorted(t *testing.T) {
+	for _, subject := range []string{`[1,2,3]`, `"a"`, `{"a": 1}`, `1`, `1.0`, `true`} {
+		names := object.NewArray(nil)
+
+		// Repeat, because a map-order bug reproduces by chance rather than
+		// every time.
+		for range 20 {
+			listed, ok := testEval(`(` + subject + `).methods()`).(*object.Array)
+			require.True(t, ok, "methods() should return an array for %s", subject)
+
+			rendered := listed.Inspect()
+			require.Equal(t, sortedInspect(listed), rendered,
+				"methods() of %s should be sorted", subject)
+
+			if len(names.Elements) == 0 {
+				names = listed
+				continue
+			}
+			require.Equal(t, names.Inspect(), rendered,
+				"methods() of %s should not vary between calls", subject)
+		}
+
+		first := testEval(`(` + subject + `).wat()`).Inspect()
+		for range 20 {
+			require.Equal(t, first, testEval(`(`+subject+`).wat()`).Inspect(),
+				"wat() of %s should not vary between calls", subject)
+		}
+	}
+}
+
+// sortedInspect renders the array with its elements in sorted order, giving the
+// expectation to compare the real rendering against. It sorts the bare names
+// rather than their quoted renderings, because a quote sorts after "!" and
+// would put "reverse!" ahead of "reverse".
+func sortedInspect(a *object.Array) string {
+	names := make([]string, len(a.Elements))
+	for i, element := range a.Elements {
+		name, ok := element.(*object.String)
+		if !ok {
+			return "element " + string(element.Type()) + " is not a string"
+		}
+		names[i] = name.Value
+	}
+	sort.Strings(names)
+
+	for i, name := range names {
+		names[i] = `"` + name + `"`
+	}
+
+	return "[" + strings.Join(names, ", ") + "]"
+}
+
+// TestGenericMethodsWorkEverywhere checks the methods every type answers to.
+// to_s used to fall through to an empty string for ARRAY, HASH, ERROR, FILE and
+// HTTP, because none of them implemented Stringable -- so [1,2].to_s() was ""
+// while [1,2].to_json() worked.
+func TestGenericMethodsWorkEverywhere(t *testing.T) {
+	tests := []inputTestCase{
+		{`[1,2].to_s()`, "[1, 2]"},
+		{`[].to_s()`, "[]"},
+		{`{"a": 1}.to_s()`, `{"a": 1}`},
+		{`"a".to_s()`, "a"},
+		{`1.to_s()`, "1"},
+		{`1.5.to_s()`, "1.5"},
+		{`true.to_s()`, "true"},
+		{`nil.to_s()`, ""},
+		// to_s on a matrix already worked and must keep working.
+		{`[[1,2]].to_m().to_s().size() > 0`, true},
+
+		// nil? asks the question that comparing against nil already allowed,
+		// but reads better in a chain.
+		{`nil.nil?()`, true},
+		{`1.nil?()`, false},
+		{`"".nil?()`, false},
+		{`[].nil?()`, false},
+		{`{}.nil?()`, false},
+		{`false.nil?()`, false},
+		// A method that returns nil on a miss can be asked directly.
+		{`[].first().nil?()`, true},
+		{`[1].first().nil?()`, false},
+
+		{`nil.to_json()`, "null"},
+	}
+	testInput(t, tests)
+}
+
+// TestEveryTypeAnswersTheGenericMethods walks every registered type and calls
+// each generic method on a value of that type, so a type added later cannot
+// quietly fail to answer one of them.
+func TestEveryTypeAnswersTheGenericMethods(t *testing.T) {
+	// One literal per type that can be written down.
+	subjects := map[string]string{
+		"ARRAY":   `[1,2]`,
+		"BOOLEAN": `true`,
+		"FLOAT":   `1.5`,
+		"HASH":    `{"a": 1}`,
+		"INTEGER": `1`,
+		"MATRIX":  `[[1,2]].to_m()`,
+		"NIL":     `nil`,
+		"STRING":  `"a"`,
+	}
+
+	for wantType, literal := range subjects {
+		if got := testEval(literal + ".type()"); got.Inspect() != `"`+wantType+`"` {
+			t.Errorf("%s.type() = %s, want %q", literal, got.Inspect(), wantType)
+			continue
+		}
+
+		for _, method := range []string{"to_s", "to_json", "methods", "type", "wat", "nil?"} {
+			got := testEval(literal + "." + method + "()")
+			if got.Type() == object.ERROR_OBJ {
+				t.Errorf("%s.%s() failed: %s", literal, method, got.Inspect())
+			}
+		}
+
+		// to_s must never be the empty string except for nil, whose string form
+		// genuinely is empty.
+		got := testEval(literal + ".to_s()")
+		if wantType != "NIL" && got.Inspect() == `""` {
+			t.Errorf("%s.to_s() is empty; the type is probably not Stringable", literal)
+		}
 	}
 }

--- a/object/string.go
+++ b/object/string.go
@@ -6,6 +6,7 @@ import (
 	"hash/fnv"
 	"strconv"
 	"strings"
+	"unicode"
 	"unicode/utf8"
 )
 
@@ -78,58 +79,6 @@ func init() {
 				return NewInteger(utf8.RuneCountInString(s.Value))
 			},
 		},
-		"replace": ObjectMethod{
-			Layout: MethodLayout{
-				ArgPattern: Args(
-					Arg(STRING_OBJ),
-					Arg(STRING_OBJ),
-				),
-				ReturnPattern: Args(
-					Arg(STRING_OBJ),
-				),
-			},
-			method: func(o Object, args []Object, _ Environment) Object {
-				s := o.(*String)
-				oldS := args[0].(*String).Value
-				newS := args[1].(*String).Value
-				return NewString(strings.Replace(s.Value, oldS, newS, -1))
-			},
-		},
-		"reverse": ObjectMethod{
-			Layout: MethodLayout{
-				ReturnPattern: Args(
-					Arg(STRING_OBJ),
-				),
-			},
-			method: func(o Object, _ []Object, _ Environment) Object {
-				s := o.(*String)
-				out := make([]rune, utf8.RuneCountInString(s.Value))
-				i := len(out)
-				for _, c := range s.Value {
-					i--
-					out[i] = c
-				}
-				return NewString(string(out))
-			},
-		},
-		"reverse!": ObjectMethod{
-			Layout: MethodLayout{
-				ReturnPattern: Args(
-					Arg(NIL_OBJ),
-				),
-			},
-			method: func(o Object, _ []Object, _ Environment) Object {
-				s := o.(*String)
-				out := make([]rune, utf8.RuneCountInString(s.Value))
-				i := len(out)
-				for _, c := range s.Value {
-					i--
-					out[i] = c
-				}
-				s.Value = string(out)
-				return NIL
-			},
-		},
 		"split": ObjectMethod{
 			Layout: MethodLayout{
 				ArgPattern: Args(
@@ -177,75 +126,6 @@ func init() {
 				return NewArray(result)
 			},
 		},
-		"strip": ObjectMethod{
-			Layout: MethodLayout{
-				ReturnPattern: Args(
-					Arg(STRING_OBJ),
-				),
-			},
-			method: func(o Object, _ []Object, _ Environment) Object {
-				s := o.(*String)
-				return NewString(strings.TrimSpace(s.Value))
-			},
-		},
-		"strip!": ObjectMethod{
-			Layout: MethodLayout{
-				ReturnPattern: Args(
-					Arg(NIL_OBJ),
-				),
-			},
-			method: func(o Object, _ []Object, _ Environment) Object {
-				s := o.(*String)
-				s.Value = strings.TrimSpace(s.Value)
-				return NIL
-			},
-		},
-		"downcase": ObjectMethod{
-			Layout: MethodLayout{
-				ReturnPattern: Args(
-					Arg(STRING_OBJ),
-				),
-			},
-			method: func(o Object, _ []Object, _ Environment) Object {
-				s := o.(*String)
-				return NewString(strings.ToLower(s.Value))
-			},
-		},
-		"downcase!": ObjectMethod{
-			Layout: MethodLayout{
-				ReturnPattern: Args(
-					Arg(NIL_OBJ),
-				),
-			},
-			method: func(o Object, _ []Object, _ Environment) Object {
-				s := o.(*String)
-				s.Value = strings.ToLower(s.Value)
-				return NIL
-			},
-		},
-		"upcase": ObjectMethod{
-			Layout: MethodLayout{
-				ReturnPattern: Args(
-					Arg(STRING_OBJ),
-				),
-			},
-			method: func(o Object, _ []Object, _ Environment) Object {
-				s := o.(*String)
-				return NewString(strings.ToUpper(s.Value))
-			},
-		},
-		"upcase!": ObjectMethod{
-			Layout: MethodLayout{
-				ReturnPattern: Args(
-					Arg(NIL_OBJ),
-				),
-			},
-			method: func(o Object, _ []Object, _ Environment) Object {
-				s := o.(*String)
-				s.Value = strings.ToUpper(s.Value)
-				return NIL
-			},
-		},
 		"ascii": ObjectMethod{
 			Layout: MethodLayout{
 				ReturnPattern: Args(
@@ -269,6 +149,216 @@ func init() {
 			},
 		},
 	}
+
+	// Pure method and ! counterpart, each derived from a single transform. See
+	// stringPair for why they are not written out twice.
+	stringPair("reverse", nil, func(value string, _ []Object) string {
+		return reverseString(value)
+	})
+	stringPair("upcase", nil, func(value string, _ []Object) string {
+		return strings.ToUpper(value)
+	})
+	stringPair("downcase", nil, func(value string, _ []Object) string {
+		return strings.ToLower(value)
+	})
+	stringPair("capitalize", nil, func(value string, _ []Object) string {
+		return capitalizeString(value)
+	})
+	stringPair("swapcase", nil, func(value string, _ []Object) string {
+		return swapCaseString(value)
+	})
+	stringPair("strip", nil, func(value string, _ []Object) string {
+		return strings.TrimSpace(value)
+	})
+	stringPair("lstrip", nil, func(value string, _ []Object) string {
+		return strings.TrimLeftFunc(value, unicode.IsSpace)
+	})
+	stringPair("rstrip", nil, func(value string, _ []Object) string {
+		return strings.TrimRightFunc(value, unicode.IsSpace)
+	})
+	stringPair("chop", nil, func(value string, _ []Object) string {
+		return chopString(value)
+	})
+	stringPair("chomp", Args(OptArg(STRING_OBJ)), func(value string, args []Object) string {
+		if len(args) == 0 {
+			return chompLineEnding(value)
+		}
+
+		return chompSeparator(value, args[0].(*String).Value)
+	})
+	stringPair("replace", Args(Arg(STRING_OBJ), Arg(STRING_OBJ)), func(value string, args []Object) string {
+		return strings.ReplaceAll(value, args[0].(*String).Value, args[1].(*String).Value)
+	})
+
+	stringPredicate("empty?", nil, func(value string, _ []Object) bool {
+		return value == ""
+	})
+	stringPredicate("include?", Args(Arg(STRING_OBJ)), func(value string, args []Object) bool {
+		return strings.Contains(value, args[0].(*String).Value)
+	})
+	stringPredicate("start_with?", Args(OverloadArg(STRING_OBJ)), func(value string, args []Object) bool {
+		return anyAffix(args, func(affix string) bool {
+			return strings.HasPrefix(value, affix)
+		})
+	})
+	stringPredicate("end_with?", Args(OverloadArg(STRING_OBJ)), func(value string, args []Object) bool {
+		return anyAffix(args, func(affix string) bool {
+			return strings.HasSuffix(value, affix)
+		})
+	})
+}
+
+// stringPair registers a method and its in-place counterpart from one
+// transformation. Writing the pair out twice is what let Array#reverse mutate
+// while Array#uniq did not: the two halves drifted because nothing tied them
+// together. Here the ! method can only ever do what the plain one does.
+//
+// Both return a STRING. A ! method hands back the receiver so calls chain, which
+// is a deliberate departure from Ruby, where String#upcase! returns nil when it
+// changed nothing and "ABC".upcase!.reverse! therefore raises NoMethodError.
+func stringPair(name string, argPattern []Argument, transform func(value string, args []Object) string) {
+	layout := MethodLayout{
+		ArgPattern:    argPattern,
+		ReturnPattern: Args(Arg(STRING_OBJ)),
+	}
+
+	objectMethods[STRING_OBJ][name] = ObjectMethod{
+		Layout: layout,
+		method: func(o Object, args []Object, _ Environment) Object {
+			return NewString(transform(o.(*String).Value, args))
+		},
+	}
+
+	objectMethods[STRING_OBJ][name+"!"] = ObjectMethod{
+		Layout: layout,
+		method: func(o Object, args []Object, _ Environment) Object {
+			s := o.(*String)
+			s.Value = transform(s.Value, args)
+
+			return s
+		},
+	}
+}
+
+// stringPredicate registers a method returning a BOOLEAN. Predicates have no !
+// counterpart: there is nothing to change.
+func stringPredicate(name string, argPattern []Argument, test func(value string, args []Object) bool) {
+	objectMethods[STRING_OBJ][name] = ObjectMethod{
+		Layout: MethodLayout{
+			ArgPattern:    argPattern,
+			ReturnPattern: Args(Arg(BOOLEAN_OBJ)),
+		},
+		method: func(o Object, args []Object, _ Environment) Object {
+			if test(o.(*String).Value, args) {
+				return TRUE
+			}
+
+			return FALSE
+		},
+	}
+}
+
+// anyAffix reports whether any of the given strings satisfies match, which is
+// how Ruby's start_with? and end_with? take more than one candidate.
+func anyAffix(args []Object, match func(affix string) bool) bool {
+	for _, arg := range args {
+		if match(arg.(*String).Value) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func reverseString(value string) string {
+	out := make([]rune, utf8.RuneCountInString(value))
+	i := len(out)
+	for _, c := range value {
+		i--
+		out[i] = c
+	}
+
+	return string(out)
+}
+
+// capitalizeString upcases the first character and downcases the rest, as
+// Ruby's capitalize does -- 'hello World!' becomes 'Hello world!' rather than
+// keeping the W.
+func capitalizeString(value string) string {
+	if value == "" {
+		return value
+	}
+
+	runes := []rune(value)
+	out := make([]rune, len(runes))
+	out[0] = unicode.ToUpper(runes[0])
+	for i, c := range runes[1:] {
+		out[i+1] = unicode.ToLower(c)
+	}
+
+	return string(out)
+}
+
+func swapCaseString(value string) string {
+	return strings.Map(func(c rune) rune {
+		switch {
+		case unicode.IsUpper(c):
+			return unicode.ToLower(c)
+		case unicode.IsLower(c):
+			return unicode.ToUpper(c)
+		default:
+			return c
+		}
+	}, value)
+}
+
+// chopString removes the last character, or both characters of a trailing
+// CRLF so that a line ending is never left half there. An empty string chops
+// to an empty string rather than erroring.
+func chopString(value string) string {
+	if value == "" {
+		return value
+	}
+
+	if strings.HasSuffix(value, "\r\n") {
+		return value[:len(value)-2]
+	}
+
+	runes := []rune(value)
+
+	return string(runes[:len(runes)-1])
+}
+
+// chompLineEnding removes one trailing line ending: CRLF, LF or CR. A trailing
+// "\n\r" loses only the "\r", which is what Ruby does.
+func chompLineEnding(value string) string {
+	for _, ending := range []string{"\r\n", "\n", "\r"} {
+		if strings.HasSuffix(value, ending) {
+			return value[:len(value)-len(ending)]
+		}
+	}
+
+	return value
+}
+
+// chompSeparator removes one trailing occurrence of separator. The empty
+// separator is Ruby's special case for "strip every trailing blank line": it
+// removes any number of trailing CRLF or LF, but leaves a bare CR alone.
+func chompSeparator(value, separator string) string {
+	if separator == "" {
+		for {
+			switch {
+			case strings.HasSuffix(value, "\r\n"):
+				value = value[:len(value)-2]
+			case strings.HasSuffix(value, "\n"):
+				value = value[:len(value)-1]
+			default:
+				return value
+			}
+		}
+	}
+
+	return strings.TrimSuffix(value, separator)
 }
 
 func (s *String) Type() ObjectType { return STRING_OBJ }

--- a/object/string_test.go
+++ b/object/string_test.go
@@ -1,6 +1,7 @@
 package object_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/flipez/rocket-lang/object"
@@ -200,4 +201,172 @@ func TestStringConversionFailureIsNil(t *testing.T) {
 	}
 
 	testInput(t, tests)
+}
+
+// TestStringRubyMethods covers the methods added to close the gap with Ruby's
+// String. Each expectation is taken from the example lines in
+// https://ruby-doc.org/3.4.1/String.html so the behaviour matches Ruby rather
+// than whatever Go's strings package happens to do.
+func TestStringRubyMethods(t *testing.T) {
+	tests := []inputTestCase{
+		// capitalize downcases the rest, so a capital in the middle is lost.
+		{`"hello World!".capitalize()`, "Hello world!"},
+		{`"".capitalize()`, ""},
+		{`"hELLO".swapcase()`, "Hello"},
+		{`"Hello World".swapcase()`, "hELLO wORLD"},
+
+		{`"  a  ".lstrip()`, "a  "},
+		{`"  a  ".rstrip()`, "  a"},
+		{`"a".lstrip()`, "a"},
+		{`"\t\n a".lstrip()`, "a"},
+
+		// chomp with no argument removes one CR, LF or CRLF...
+		{`"abc\r".chomp()`, "abc"},
+		{`"abc\n".chomp()`, "abc"},
+		{`"abc\r\n".chomp()`, "abc"},
+		// ...but "\n\r" loses only the "\r", as in Ruby.
+		{`"abc\n\r".chomp()`, "abc\n"},
+		{`"abc".chomp()`, "abc"},
+		// With a separator it removes one trailing occurrence.
+		{`"abcd".chomp("d")`, "abc"},
+		{`"abcdd".chomp("d")`, "abcd"},
+		// The empty separator is Ruby's "drop every trailing blank line".
+		{`"abc\n\n\n".chomp("")`, "abc"},
+		{`"abc\r\n\r\n\r\n".chomp("")`, "abc"},
+		// It leaves bare CRs alone, which is the part that is easy to get wrong.
+		{`"abc\r\r\r".chomp("")`, "abc\r\r\r"},
+
+		{`"abcd".chop()`, "abc"},
+		// A trailing CRLF goes as a unit, so chop never splits a line ending.
+		{`"abc\r\n".chop()`, "abc"},
+		{`"".chop()`, ""},
+		{`"a".chop()`, ""},
+
+		{`"".empty?()`, true},
+		{`"a".empty?()`, false},
+		{`"abc".include?("b")`, true},
+		{`"abc".include?("z")`, false},
+		{`"abc".include?("")`, true},
+		{`"abc".start_with?("ab")`, true},
+		{`"abc".start_with?("z")`, false},
+		{`"abc".end_with?("bc")`, true},
+		{`"abc".end_with?("z")`, false},
+		// start_with? and end_with? take more than one candidate and are true
+		// if any of them matches, as Ruby's do.
+		{`"abc".start_with?("z", "y", "a")`, true},
+		{`"abc".start_with?("z", "y")`, false},
+		{`"abc".end_with?("z", "c")`, true},
+		{`"abc".end_with?("z", "y")`, false},
+		{`"abc".start_with?()`, "to few arguments: got=0, want=1"},
+		{`"abc".include?()`, "to few arguments: got=0, want=1"},
+		{`"abc".empty?("x")`, "to many arguments: got=1, want=0"},
+	}
+	testInput(t, tests)
+}
+
+// TestStringBangConvention checks the convention across every String pair: the
+// plain method leaves the receiver alone, the ! method changes it and returns
+// it. Ruby's String bangs return nil when they changed nothing, which is why
+// "ABC".upcase!.reverse! raises there; RocketLang returns the receiver instead
+// so chains hold.
+func TestStringBangConvention(t *testing.T) {
+	tests := []inputTestCase{
+		// Plain methods are pure.
+		{`s = "hello World"; s.capitalize(); s`, "hello World"},
+		{`s = "hello World"; s.swapcase(); s`, "hello World"},
+		{`s = "  a  "; s.lstrip(); s`, "  a  "},
+		{`s = "  a  "; s.rstrip(); s`, "  a  "},
+		{`s = "abc\n"; s.chomp(); s`, "abc\n"},
+		{`s = "abcd"; s.chop(); s`, "abcd"},
+		{`s = "a-b"; s.replace("-", "+"); s`, "a-b"},
+
+		// ! methods change the receiver.
+		{`s = "hello World"; s.capitalize!(); s`, "Hello world"},
+		{`s = "hello World"; s.swapcase!(); s`, "HELLO wORLD"},
+		{`s = "  a  "; s.lstrip!(); s`, "a  "},
+		{`s = "  a  "; s.rstrip!(); s`, "  a"},
+		{`s = "abc\n"; s.chomp!(); s`, "abc"},
+		{`s = "abcd"; s.chop!(); s`, "abc"},
+		{`s = "a-b"; s.replace!("-", "+"); s`, "a+b"},
+
+		// ...and return it, so they chain even when a call changes nothing.
+		{`"  hello World  ".strip!().capitalize!().swapcase!()`, "hELLO WORLD"},
+		{`"ABC".upcase!().reverse!()`, "CBA"},
+		{`"a-b\n".chomp!().replace!("-", "+").upcase!()`, "A+B"},
+		{`"abc".chomp!().chomp!()`, "abc"},
+
+		// Every ! method returns a STRING rather than NIL.
+		{`"a".upcase!().type()`, "STRING"},
+		{`"a".downcase!().type()`, "STRING"},
+		{`"a".capitalize!().type()`, "STRING"},
+		{`"a".swapcase!().type()`, "STRING"},
+		{`"a".strip!().type()`, "STRING"},
+		{`"a".lstrip!().type()`, "STRING"},
+		{`"a".rstrip!().type()`, "STRING"},
+		{`"a".reverse!().type()`, "STRING"},
+		{`"a".chomp!().type()`, "STRING"},
+		{`"a".chop!().type()`, "STRING"},
+		{`"a".replace!("a", "b").type()`, "STRING"},
+
+		// A ! method takes the same arguments as its plain counterpart.
+		{`"abcd".chomp!("d")`, "abc"},
+		{`"a-b".replace!("-")`, "to few arguments: got=1, want=2"},
+	}
+	testInput(t, tests)
+}
+
+// TestStringPairsAreComplete guards the convention itself: every String method
+// that changes the receiver has a pure counterpart of the same name and the
+// other way round. Adding one half of a pair and forgetting the other is the
+// gap this test exists to catch.
+func TestStringPairsAreComplete(t *testing.T) {
+	listed, ok := testEval(`"a".methods()`).(*object.Array)
+	if !ok {
+		t.Fatal(`"a".methods() should return an array`)
+	}
+
+	names := make(map[string]bool, len(listed.Elements))
+	for _, element := range listed.Elements {
+		name, ok := element.(*object.String)
+		if !ok {
+			t.Fatalf("method name is not a string, got %s", element.Type())
+		}
+		names[name.Value] = true
+	}
+
+	// Every ! method must have a pure counterpart. The other direction does not
+	// hold: size() and split() return something other than a string, so there
+	// is nothing for a size!() to mean.
+	for name := range names {
+		if !strings.HasSuffix(name, "!") {
+			continue
+		}
+		if !names[strings.TrimSuffix(name, "!")] {
+			t.Errorf("%s has no pure counterpart", name)
+		}
+	}
+
+	// The pairs that must exist. Listed explicitly so that dropping one is a
+	// failure rather than a silently smaller loop.
+	for _, name := range []string{
+		"capitalize", "chomp", "chop", "downcase", "lstrip",
+		"replace", "reverse", "rstrip", "strip", "swapcase", "upcase",
+	} {
+		if !names[name] {
+			t.Errorf("expected String to have %s()", name)
+		}
+		if !names[name+"!"] {
+			t.Errorf("expected String to have %s!()", name)
+		}
+	}
+
+	// Predicates have nothing to change, so they must not have a ! form.
+	for _, name := range []string{"empty?", "include?", "start_with?", "end_with?"} {
+		if !names[name] {
+			t.Errorf("expected String to have %s()", name)
+		}
+		if names[name+"!"] {
+			t.Errorf("%s should not have a ! form", name)
+		}
+	}
 }


### PR DESCRIPTION
Closes #231. Makes `!` mean one thing everywhere, then fills in the methods that were missing so there is something to be consistent about.

## Method counts

| Type | Before | After |
| --- | --- | --- |
| `ARRAY` | 14 | **37** |
| `STRING` | 16 | **33** |
| `INTEGER` | 3 | **21** |
| `HASH` | 4 | **14** |
| `FLOAT` | 4 | **12** |
| generic (every type) | 7 | **8** |

## The convention

`!` changes the receiver and hands it back; the plain name returns a new value.

| | Before | After |
| --- | --- | --- |
| `a = [3,1,2]; a.sort(); a` | `[1, 2, 3]` — mutated | `[3, 1, 2]` |
| `a.sort!()` | no such method | `[1, 2, 3]`, `a` sorted |
| `"abc".upcase!()` | `nil` | `"ABC"` |
| `"abc".upcase!().reverse!()` | `ERROR: undefined method .reverse!() for NIL` | `"CBA"` |
| `[1].push(2).push(3)` | `ERROR` (`push` returned `nil`) | `[1, 2, 3]` |
| `m.set(0,0,9).set(1,1,9)` | `ERROR` (`set` returned `nil`) | the matrix |
| `[1,"a"].sort!()` | array left half-ordered | array untouched |
| `["a",1,1,2].uniq()` | order varied per run | `["a", 1, 2]` |
| `[1,2].methods()` | order varied per run | sorted |

`pop`/`shift`/`delete`/`delete_at` return what they removed; `push`/`unshift`/`insert`/`concat`/`clear`/`set` return the receiver.

## New methods

| Type | Added |
| --- | --- |
| `STRING` | pairs `capitalize/!` `swapcase/!` `lstrip/!` `rstrip/!` `chomp/!` `chop/!` `replace!`; `empty?` `include?` `start_with?` `end_with?` |
| `ARRAY` | pairs `compact/!` `flatten/!` `rotate/!`; `empty?` `count` `rindex` `min` `max` `shift` `unshift` `insert` `delete` `delete_at` `clear` `concat` `take` `drop`; optional count on `first`/`last` |
| `HASH` | pairs `merge/!` `compact/!`; `size` `empty?` `fetch` `delete` `clear` `invert` |
| `INTEGER` | `even?` `odd?` `zero?` `positive?` `negative?` `succ` `pred` `chr` `digits` `divmod` `gcd` `lcm` `pow` `bit_length` `ceil` `floor` `round` `truncate` |
| `FLOAT` | `truncate` `zero?` `positive?` `negative?` `nan?` `finite?` `infinite?` `divmod`; digit count on `ceil`/`floor`/`round` |
| every type | `nil?` |

`include?` closed a gap between types: `ARRAY` and `HASH` had it, `STRING` did not.

## Bugs found

| | Before | After |
| --- | --- | --- |
| `[1,2].to_s()` | `""` — no `Stringable` on ARRAY/HASH/ERROR/FILE/HTTP | `"[1, 2]"` |
| `[1,2,3,{}].join()` | `ERROR: Found non stringable element HASH` | `"123{}"` |
| `nil.to_json()` | `ERROR: NIL is not serializable` | `null` |
| `[1,nil].to_json()` | `[1,{}]` | `[1,null]` |
| `1.567.round(2)` | `ERROR: to many arguments` | `1.57` |
| `testInput` with a string expectation | a `NIL` result passed silently | compared properly |
| `string.yml` examples | `example:` key never read — 15 of 16 methods rendered with no example | `input`/`output`, all rendered |
| dead `to_i`/`to_f`/`to_s` entries in `integer.yml`, `float.yml`, `nil.yml` | never rendered, claimed wrong values | removed |

The `testInput` hole is the notable one: every string and error-message assertion in the object tests passed if the method returned nil. Found by mutation-testing, and two existing cases were written `{"[].first()", "NIL"}` — asserting nothing.

## Deliberate divergences from Ruby

| | Ruby | RocketLang |
| --- | --- | --- |
| `"ABC".upcase!` | `nil`, so `.reverse!` raises | the receiver, so chains hold |
| `11.divmod(-4)` | `[-3, -1]` (floored) | `[-2, 3]`, matching this language's `/` and `%` |
| `1.5.round` | `Integer` | `FLOAT` — a numeric method returns the type it got |
| `0x10.gcd(4)` | fine | error, as `0x10 + 4` already is |
| `256.chr` | `RangeError` | any code point |

`divmod` agreeing with `/` and `%` matters more than agreeing with Ruby — though it does mean those operators are Go-truncated, not Ruby-floored. Changing them is a separate question.

## Left out

- Anything taking a function: `map` `select` `reject` `each` `sort_by` `min_by` `all?` `any?` `none?` `Integer#times`. An object method cannot call one yet — `object.Evaluator` only evaluates an AST node, `evaluator.applyFunction` is unexported, and `http.go` works around it by evaluating a function's `Body` without binding parameters. Needs an injected applier next to the existing `AddEvaluator` hook.
- `shuffle`/`sample` — would make their own documentation unrepeatable.
- `Hash#to_a` — no defined order until a hash keeps one.

## Verification

| Check | Result |
| --- | --- |
| `go test ./...` | green |
| documented examples, 6 runs each | **138** (was 85), 0 mismatches, 0 nondeterministic |
| tracked `.rl` files vs a `main` binary | 42/42 byte-identical\* |
| `yarn build` | succeeds |
| new tests | each mutation-tested |

\* `examples/len_out_of_range.rl` relied on `reverse()` mutating and uses `reverse!()` now; verified to produce the same output as before (its `STRING + NIL` error pre-dates this branch). Broken-link warnings in the docs build are pre-existing — blog posts link to `/docs/builtins/json` while the page is `JSON.md`.

Two mutations initially survived and both found real gaps: the `testInput` hole, and missing coverage that `take`/`drop`/`first(n)`/`last(n)` return copies — `a = [1,2,3]; b = a.drop(1); a[1] = 9` could otherwise change `b`.

## Still open

- **Hash insertion order.** `keys()`/`values()` come back in map order and differ between runs. Ruby documents insertion order, so there is a right answer, but the parser stores a hash literal's pairs in a Go map — the order is lost in the AST, not just the object.
- Non-ASCII string literals are read byte-by-byte by the lexer: `"тест".size()` is `8`, not `4`. Identical on `main`; the new rune-based methods become correct once it is fixed.
- `Usage()` does not mark optional or variadic arguments, so `chomp(STRING)` reads as required and `start_with?(STRING)` as single.

🤖 Generated with [Claude Code](https://claude.com/claude-code)