### PR TITLE
fix(object): make wat() print its listing instead of returning it

### DIFF
--- a/docs/docs/literals/array.md
+++ b/docs/docs/literals/array.md
@@ -681,13 +681,29 @@ Returns the type of the object.
 
 
 ### wat()
-> Returns `STRING`
+> Returns `NIL`
 
-Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none.
+Prints the type's literal-specific methods with their argument and return types, sorted by name, one per line. It returns `nil` rather than the listing: this exists to be read, and the REPL echoes a returned value through its escaped representation, which would put the whole thing on one line. Use `methods` when the names are wanted as data. A type with no methods of its own prints only the heading.
 
 
 <CodeBlockSimple input='true.wat()
-' output='"BOOLEAN supports the following methods:\n"
+1.0.wat()
+' output='BOOLEAN supports the following methods:
+nil
+FLOAT supports the following methods:
+	abs()
+	ceil([INTEGER])
+	divmod(FLOAT)
+	finite?()
+	floor([INTEGER])
+	infinite?()
+	nan?()
+	negative?()
+	positive?()
+	round([INTEGER])
+	truncate([INTEGER])
+	zero?()
+nil
 ' />
 
 

--- a/docs/docs/literals/boolean.md
+++ b/docs/docs/literals/boolean.md
@@ -144,13 +144,29 @@ Returns the type of the object.
 
 
 ### wat()
-> Returns `STRING`
+> Returns `NIL`
 
-Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none.
+Prints the type's literal-specific methods with their argument and return types, sorted by name, one per line. It returns `nil` rather than the listing: this exists to be read, and the REPL echoes a returned value through its escaped representation, which would put the whole thing on one line. Use `methods` when the names are wanted as data. A type with no methods of its own prints only the heading.
 
 
 <CodeBlockSimple input='true.wat()
-' output='"BOOLEAN supports the following methods:\n"
+1.0.wat()
+' output='BOOLEAN supports the following methods:
+nil
+FLOAT supports the following methods:
+	abs()
+	ceil([INTEGER])
+	divmod(FLOAT)
+	finite?()
+	floor([INTEGER])
+	infinite?()
+	nan?()
+	negative?()
+	positive?()
+	round([INTEGER])
+	truncate([INTEGER])
+	zero?()
+nil
 ' />
 
 

--- a/docs/docs/literals/error.md
+++ b/docs/docs/literals/error.md
@@ -179,13 +179,29 @@ Returns the type of the object.
 
 
 ### wat()
-> Returns `STRING`
+> Returns `NIL`
 
-Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none.
+Prints the type's literal-specific methods with their argument and return types, sorted by name, one per line. It returns `nil` rather than the listing: this exists to be read, and the REPL echoes a returned value through its escaped representation, which would put the whole thing on one line. Use `methods` when the names are wanted as data. A type with no methods of its own prints only the heading.
 
 
 <CodeBlockSimple input='true.wat()
-' output='"BOOLEAN supports the following methods:\n"
+1.0.wat()
+' output='BOOLEAN supports the following methods:
+nil
+FLOAT supports the following methods:
+	abs()
+	ceil([INTEGER])
+	divmod(FLOAT)
+	finite?()
+	floor([INTEGER])
+	infinite?()
+	nan?()
+	negative?()
+	positive?()
+	round([INTEGER])
+	truncate([INTEGER])
+	zero?()
+nil
 ' />
 
 

--- a/docs/docs/literals/file.md
+++ b/docs/docs/literals/file.md
@@ -198,13 +198,29 @@ Returns the type of the object.
 
 
 ### wat()
-> Returns `STRING`
+> Returns `NIL`
 
-Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none.
+Prints the type's literal-specific methods with their argument and return types, sorted by name, one per line. It returns `nil` rather than the listing: this exists to be read, and the REPL echoes a returned value through its escaped representation, which would put the whole thing on one line. Use `methods` when the names are wanted as data. A type with no methods of its own prints only the heading.
 
 
 <CodeBlockSimple input='true.wat()
-' output='"BOOLEAN supports the following methods:\n"
+1.0.wat()
+' output='BOOLEAN supports the following methods:
+nil
+FLOAT supports the following methods:
+	abs()
+	ceil([INTEGER])
+	divmod(FLOAT)
+	finite?()
+	floor([INTEGER])
+	infinite?()
+	nan?()
+	negative?()
+	positive?()
+	round([INTEGER])
+	truncate([INTEGER])
+	zero?()
+nil
 ' />
 
 

--- a/docs/docs/literals/float.md
+++ b/docs/docs/literals/float.md
@@ -288,13 +288,29 @@ Returns the type of the object.
 
 
 ### wat()
-> Returns `STRING`
+> Returns `NIL`
 
-Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none.
+Prints the type's literal-specific methods with their argument and return types, sorted by name, one per line. It returns `nil` rather than the listing: this exists to be read, and the REPL echoes a returned value through its escaped representation, which would put the whole thing on one line. Use `methods` when the names are wanted as data. A type with no methods of its own prints only the heading.
 
 
 <CodeBlockSimple input='true.wat()
-' output='"BOOLEAN supports the following methods:\n"
+1.0.wat()
+' output='BOOLEAN supports the following methods:
+nil
+FLOAT supports the following methods:
+	abs()
+	ceil([INTEGER])
+	divmod(FLOAT)
+	finite?()
+	floor([INTEGER])
+	infinite?()
+	nan?()
+	negative?()
+	positive?()
+	round([INTEGER])
+	truncate([INTEGER])
+	zero?()
+nil
 ' />
 
 

--- a/docs/docs/literals/hash.md
+++ b/docs/docs/literals/hash.md
@@ -377,13 +377,29 @@ Returns the type of the object.
 
 
 ### wat()
-> Returns `STRING`
+> Returns `NIL`
 
-Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none.
+Prints the type's literal-specific methods with their argument and return types, sorted by name, one per line. It returns `nil` rather than the listing: this exists to be read, and the REPL echoes a returned value through its escaped representation, which would put the whole thing on one line. Use `methods` when the names are wanted as data. A type with no methods of its own prints only the heading.
 
 
 <CodeBlockSimple input='true.wat()
-' output='"BOOLEAN supports the following methods:\n"
+1.0.wat()
+' output='BOOLEAN supports the following methods:
+nil
+FLOAT supports the following methods:
+	abs()
+	ceil([INTEGER])
+	divmod(FLOAT)
+	finite?()
+	floor([INTEGER])
+	infinite?()
+	nan?()
+	negative?()
+	positive?()
+	round([INTEGER])
+	truncate([INTEGER])
+	zero?()
+nil
 ' />
 
 

--- a/docs/docs/literals/http.md
+++ b/docs/docs/literals/http.md
@@ -178,13 +178,29 @@ Returns the type of the object.
 
 
 ### wat()
-> Returns `STRING`
+> Returns `NIL`
 
-Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none.
+Prints the type's literal-specific methods with their argument and return types, sorted by name, one per line. It returns `nil` rather than the listing: this exists to be read, and the REPL echoes a returned value through its escaped representation, which would put the whole thing on one line. Use `methods` when the names are wanted as data. A type with no methods of its own prints only the heading.
 
 
 <CodeBlockSimple input='true.wat()
-' output='"BOOLEAN supports the following methods:\n"
+1.0.wat()
+' output='BOOLEAN supports the following methods:
+nil
+FLOAT supports the following methods:
+	abs()
+	ceil([INTEGER])
+	divmod(FLOAT)
+	finite?()
+	floor([INTEGER])
+	infinite?()
+	nan?()
+	negative?()
+	positive?()
+	round([INTEGER])
+	truncate([INTEGER])
+	zero?()
+nil
 ' />
 
 

--- a/docs/docs/literals/integer.md
+++ b/docs/docs/literals/integer.md
@@ -416,13 +416,29 @@ Returns the type of the object.
 
 
 ### wat()
-> Returns `STRING`
+> Returns `NIL`
 
-Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none.
+Prints the type's literal-specific methods with their argument and return types, sorted by name, one per line. It returns `nil` rather than the listing: this exists to be read, and the REPL echoes a returned value through its escaped representation, which would put the whole thing on one line. Use `methods` when the names are wanted as data. A type with no methods of its own prints only the heading.
 
 
 <CodeBlockSimple input='true.wat()
-' output='"BOOLEAN supports the following methods:\n"
+1.0.wat()
+' output='BOOLEAN supports the following methods:
+nil
+FLOAT supports the following methods:
+	abs()
+	ceil([INTEGER])
+	divmod(FLOAT)
+	finite?()
+	floor([INTEGER])
+	infinite?()
+	nan?()
+	negative?()
+	positive?()
+	round([INTEGER])
+	truncate([INTEGER])
+	zero?()
+nil
 ' />
 
 

--- a/docs/docs/literals/matrix.md
+++ b/docs/docs/literals/matrix.md
@@ -317,13 +317,29 @@ Returns the type of the object.
 
 
 ### wat()
-> Returns `STRING`
+> Returns `NIL`
 
-Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none.
+Prints the type's literal-specific methods with their argument and return types, sorted by name, one per line. It returns `nil` rather than the listing: this exists to be read, and the REPL echoes a returned value through its escaped representation, which would put the whole thing on one line. Use `methods` when the names are wanted as data. A type with no methods of its own prints only the heading.
 
 
 <CodeBlockSimple input='true.wat()
-' output='"BOOLEAN supports the following methods:\n"
+1.0.wat()
+' output='BOOLEAN supports the following methods:
+nil
+FLOAT supports the following methods:
+	abs()
+	ceil([INTEGER])
+	divmod(FLOAT)
+	finite?()
+	floor([INTEGER])
+	infinite?()
+	nan?()
+	negative?()
+	positive?()
+	round([INTEGER])
+	truncate([INTEGER])
+	zero?()
+nil
 ' />
 
 

--- a/docs/docs/literals/nil.md
+++ b/docs/docs/literals/nil.md
@@ -132,13 +132,29 @@ Returns the type of the object.
 
 
 ### wat()
-> Returns `STRING`
+> Returns `NIL`
 
-Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none.
+Prints the type's literal-specific methods with their argument and return types, sorted by name, one per line. It returns `nil` rather than the listing: this exists to be read, and the REPL echoes a returned value through its escaped representation, which would put the whole thing on one line. Use `methods` when the names are wanted as data. A type with no methods of its own prints only the heading.
 
 
 <CodeBlockSimple input='true.wat()
-' output='"BOOLEAN supports the following methods:\n"
+1.0.wat()
+' output='BOOLEAN supports the following methods:
+nil
+FLOAT supports the following methods:
+	abs()
+	ceil([INTEGER])
+	divmod(FLOAT)
+	finite?()
+	floor([INTEGER])
+	infinite?()
+	nan?()
+	negative?()
+	positive?()
+	round([INTEGER])
+	truncate([INTEGER])
+	zero?()
+nil
 ' />
 
 

--- a/docs/docs/literals/string.md
+++ b/docs/docs/literals/string.md
@@ -667,13 +667,29 @@ Returns the type of the object.
 
 
 ### wat()
-> Returns `STRING`
+> Returns `NIL`
 
-Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none.
+Prints the type's literal-specific methods with their argument and return types, sorted by name, one per line. It returns `nil` rather than the listing: this exists to be read, and the REPL echoes a returned value through its escaped representation, which would put the whole thing on one line. Use `methods` when the names are wanted as data. A type with no methods of its own prints only the heading.
 
 
 <CodeBlockSimple input='true.wat()
-' output='"BOOLEAN supports the following methods:\n"
+1.0.wat()
+' output='BOOLEAN supports the following methods:
+nil
+FLOAT supports the following methods:
+	abs()
+	ceil([INTEGER])
+	divmod(FLOAT)
+	finite?()
+	floor([INTEGER])
+	infinite?()
+	nan?()
+	negative?()
+	positive?()
+	round([INTEGER])
+	truncate([INTEGER])
+	zero?()
+nil
 ' />
 
 

--- a/docs/literals/object.yml
+++ b/docs/literals/object.yml
@@ -84,8 +84,24 @@ methods:
     output: |
       "STRING"
   wat:
-    description: "Returns the type's literal-specific methods with their usage information, as a single string, sorted by name. Types with no methods of their own list none."
+    description: "Prints the type's literal-specific methods with their argument and return types, sorted by name, one per line. It returns `nil` rather than the listing: this exists to be read, and the REPL echoes a returned value through its escaped representation, which would put the whole thing on one line. Use `methods` when the names are wanted as data. A type with no methods of its own prints only the heading."
     input: |
       true.wat()
+      1.0.wat()
     output: |
-      "BOOLEAN supports the following methods:\n"
+      BOOLEAN supports the following methods:
+      nil
+      FLOAT supports the following methods:
+      	abs()
+      	ceil([INTEGER])
+      	divmod(FLOAT)
+      	finite?()
+      	floor([INTEGER])
+      	infinite?()
+      	nan?()
+      	negative?()
+      	positive?()
+      	round([INTEGER])
+      	truncate([INTEGER])
+      	zero?()
+      nil

--- a/object/array_test.go
+++ b/object/array_test.go
@@ -35,7 +35,6 @@ func TestArrayObjectMethods(t *testing.T) {
 		{`[1,2,3].type()`, "ARRAY"},
 		{`a = []; a.push(1); a`, "[1]"},
 		{`[].nope()`, "test:1:3: undefined method `.nope()` for ARRAY"},
-		{`([].wat().lines().size() == [].methods().size() + 1).to_s()`, "true"},
 		{"a = [\"a\", \"b\"]; b = []; foreach i, item in a \n b.push(item) \nend; b.size()", 2},
 		{`[1,2,3].index(4)`, -1},
 		{`[1,2,3].index(3)`, 2},

--- a/object/file_test.go
+++ b/object/file_test.go
@@ -22,7 +22,6 @@ func TestFileObjectMethods(t *testing.T) {
 		{`IO.open("../fixtures/nope", "r", "0644")`, "open ../fixtures/nope: no such file or directory"},
 		{`IO.open("../fixtures/nope", "r", "0644").content()`, "test:1:41: undefined method `.content()` for ERROR"},
 		{`a = IO.open("../fixtures/nope", "rw", "0644"); a.content()`, ""},
-		{`f = IO.open("../fixtures/module.rl", "r", "0644"); (f.wat().lines().size() == f.methods().size() + 1).to_s()`, "true"},
 		{`IO.open("").type()`, "ERROR"},
 		{`IO.open("../fixtures/module.rl", "r", "0644").type()`, "FILE"},
 	}

--- a/object/hash_test.go
+++ b/object/hash_test.go
@@ -22,7 +22,6 @@ func TestHashObjectMethods(t *testing.T) {
 	tests := []inputTestCase{
 		{`{"a": 2}.keys()`, `["a"]`},
 		{`{}.nope()`, "test:1:3: undefined method `.nope()` for HASH"},
-		{`({}.wat().lines().size() == {}.methods().size() + 1).to_s()`, "true"},
 		{`{}.type()`, "HASH"},
 		{"a = {\"a\": \"b\", \"b\":\"a\"};b = []; foreach key, value in a \n b.push(key) \nend; b.size()", 2},
 		{`{"a": 1, "b": 2}["a"]`, 1},

--- a/object/object.go
+++ b/object/object.go
@@ -347,7 +347,7 @@ func init() {
 		"wat": ObjectMethod{
 			Layout: MethodLayout{
 				ReturnPattern: Args(
-					Arg(STRING_OBJ),
+					Arg(NIL_OBJ),
 				),
 			},
 			method: func(o Object, _ []Object, _ Environment) Object {
@@ -359,12 +359,18 @@ func init() {
 				// Sorted for the same reason as methods() above.
 				sort.Strings(names)
 
-				result := make([]string, len(names))
-				for i, name := range names {
-					result[i] = fmt.Sprintf("\t%s", oms[name].Layout.Usage(name))
+				// Printed rather than returned. This listing exists to be read,
+				// and the REPL echoes a value through Inspect(), which escapes
+				// the newlines and tabs and put the whole thing on one line.
+				// puts() already prints a string's raw value for the same
+				// reason. methods() covers the case where the names are wanted
+				// as data.
+				fmt.Printf("%s supports the following methods:\n", o.Type())
+				for _, name := range names {
+					fmt.Printf("\t%s\n", oms[name].Layout.Usage(name))
 				}
 
-				return NewString(fmt.Sprintf("%s supports the following methods:\n%s", o.Type(), strings.Join(result, "\n")))
+				return NIL
 			},
 		},
 		"type": ObjectMethod{

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -2,6 +2,8 @@ package object_test
 
 import (
 	"errors"
+	"io"
+	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -212,9 +214,28 @@ func TestMethodListingIsSorted(t *testing.T) {
 				"methods() of %s should not vary between calls", subject)
 		}
 
-		first := testEval(`(` + subject + `).wat()`).Inspect()
+		// wat() prints its listing and returns nil, so comparing return
+		// values would compare "nil" to "nil" and assert nothing. Captured so
+		// the listing does not end up in the test output.
+		var watResult object.Object
+		captureStdout(t, func() { watResult = testEval(`(` + subject + `).wat()`) })
+		require.Equal(t, object.ObjectType(object.NIL_OBJ), watResult.Type(),
+			"wat() of %s should return nil", subject)
+
+		first := captureStdout(t, func() { testEval(`(` + subject + `).wat()`) })
+		require.Equal(t, sortedWatListing(first), first,
+			"wat() of %s should list its methods sorted", subject)
+
+		// One header line plus one line per method, so nothing is dropped from
+		// the listing or counted twice.
+		listed, ok := testEval(`(` + subject + `).methods()`).(*object.Array)
+		require.True(t, ok)
+		require.Len(t, strings.Split(strings.TrimSuffix(first, "\n"), "\n"), len(listed.Elements)+1,
+			"wat() of %s should print one line per method plus the header", subject)
+
 		for range 20 {
-			require.Equal(t, first, testEval(`(`+subject+`).wat()`).Inspect(),
+			printed := captureStdout(t, func() { testEval(`(` + subject + `).wat()`) })
+			require.Equal(t, first, printed,
 				"wat() of %s should not vary between calls", subject)
 		}
 	}
@@ -391,4 +412,55 @@ func TestArgumentStringStaysBare(t *testing.T) {
 		{`"a".start_with?(1)`, "wrong argument type on position 1: got=INTEGER, want=STRING"},
 	}
 	testInput(t, tests)
+}
+
+// captureStdout collects what fn writes to os.Stdout. wat() prints its listing
+// instead of returning it, so this is the only way to assert on it.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	read, write, err := os.Pipe()
+	require.NoError(t, err)
+
+	original := os.Stdout
+	os.Stdout = write
+	defer func() { os.Stdout = original }()
+
+	fn()
+	require.NoError(t, write.Close())
+
+	printed, err := io.ReadAll(read)
+	require.NoError(t, err)
+
+	return string(printed)
+}
+
+// sortedWatListing returns the listing with its method lines sorted, giving the
+// expectation to compare the real output against. The header stays first.
+//
+// It sorts on the bare method name rather than the rendered line, because "("
+// sorts after "!" and would otherwise put chomp!([STRING]) ahead of
+// chomp([STRING]).
+func sortedWatListing(listing string) string {
+	lines := strings.Split(strings.TrimSuffix(listing, "\n"), "\n")
+	if len(lines) < 2 {
+		return listing
+	}
+
+	sorted := make([]string, len(lines)-1)
+	copy(sorted, lines[1:])
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return watMethodName(sorted[i]) < watMethodName(sorted[j])
+	})
+
+	return lines[0] + "\n" + strings.Join(sorted, "\n") + "\n"
+}
+
+func watMethodName(line string) string {
+	name := strings.TrimPrefix(line, "\t")
+	if open := strings.Index(name, "("); open >= 0 {
+		return name[:open]
+	}
+
+	return name
 }

--- a/object/string_test.go
+++ b/object/string_test.go
@@ -105,7 +105,6 @@ func TestStringObjectMethods(t *testing.T) {
 		{`a = "tESt"; a.downcase!(); a`, "test"},
 		{`a = "test"; a.reverse!(); a`, "tset"},
 		{`a = " test "; a.strip!(); a`, "test"},
-		{`("test".wat().lines().size() == "test".methods().size() + 1).to_s()`, "true"},
 		{"a = \"test\"; b = []; foreach char in a \n b.push(char) \nend; b.size()", 4},
 		{`"test" * 2`, "testtest"},
 		{`2 * "test"`, "testtest"},


### PR DESCRIPTION
At the REPL, `wat()` came back as one unreadable line:

```
🚀 » "test".wat()
» "STRING supports the following methods:\n\tascii()\n\tcapitalize()\n\t..."
```

`wat()` returned the listing as a `STRING`, and `repl/repl.go:78` echoes every value through `Inspect()`, which escapes `\n` and `\t`. The one method whose entire purpose is to be read by a person was the one method the REPL could not display. `puts("test".wat())` rendered fine, which is the tell.

## Change

| Before | After |
| --- | --- |
| returns a `STRING` holding the whole listing | prints the listing, returns `nil` |
| `» "STRING supports…\n\tascii()\n\t…"` | one method per line, then `» nil` |
| `Returns STRING` | `Returns NIL` |

```
🚀 » "test".wat()
STRING supports the following methods:
	ascii()
	capitalize()
	chomp([STRING])
	...
» nil
```

`puts()` already prints a string's raw value rather than its representation for exactly this reason, so this follows an existing precedent rather than inventing one. `methods()` still returns an array, for when the names are wanted as data.

## Test coverage that had to move

Four tests asserted `wat().lines().size() == methods().size() + 1`, which worked only because `wat()` returned a string:

| File | Removed case |
| --- | --- |
| `array_test.go` | `[].wat().lines().size() == [].methods().size() + 1` |
| `hash_test.go` | `{}.wat()...` |
| `string_test.go` | `"test".wat()...` |
| `file_test.go` | `f.wat()...` |

That property — one heading plus one line per method — moved into `TestMethodListingIsSorted`, which reads what `wat()` prints via a stdout capture and checks **all eight literal types** instead of the four that happened to have a case.

The move was necessary, not cosmetic: that test also asserted `wat()`'s output is sorted and stable across calls, and with `wat()` returning `nil` it would have compared `"nil"` to `"nil"` and checked nothing.

## Verification

| Check | Result |
| --- | --- |
| `go test ./...` | green |
| reproducible documented examples | 160, 0 mismatches |
| tracked `.rl` files vs a `main` binary | 42/42 byte-identical (no example uses `wat()`) |
| `yarn build` | succeeds |
| `GOOS=js GOARCH=wasm go build` | succeeds — `wat()` prints via `fmt`, as `puts()` already does |
| new tests | mutation-tested: unsorting `wat`, skipping a method, printing one twice, or returning a string again are each caught |

The doc example uses `FLOAT`, the smallest type that has methods, so the listing shown is short. It does pin that type's method list, but the example checker fails loudly if it drifts.