### PR TITLE
feat: type groups for arguments and elements, with a docs page (#296)

### DIFF
--- a/docs/docs/language/methods.md
+++ b/docs/docs/language/methods.md
@@ -14,6 +14,36 @@ names with their arguments:
 Both are sorted by name. Before `0.24` they came out in a different order on
 every run.
 
+## Reading a signature
+
+The documentation gives each method as a signature, for example
+`fetch(HASHABLE, [ANY])`. Three things appear in the argument list:
+
+| Notation | Meaning |
+| -------- | ------- |
+| `STRING` | a concrete type |
+| `[STRING]` | may be left out |
+| `STRING...` | one or more of them |
+
+Where a method takes a whole family of types, the family is named rather than
+listed. These names are **type groups**, not types — you never write them in
+RocketLang, they only appear in signatures and in error messages:
+
+| Group | Accepts | Used by |
+| ----- | ------- | ------- |
+| `ANY` | every value | `push`, `unshift`, `insert`, `include?` and `index` on an `ARRAY`, the fallback of `HASH.get` |
+| `HASHABLE` | anything usable as a hash key: `STRING`, `INTEGER`, `FLOAT`, `BOOLEAN`, `ARRAY`, `HASH` | the key arguments of `HASH.get`, `fetch`, `delete` and `include?` |
+| `NUMERIC` | `INTEGER` and `FLOAT` | `MATRIX.set` |
+
+A group is checked by asking the value what it can do, not by comparing it
+against a list, so a type added to the language joins the group it qualifies
+for. An error names the group rather than spelling out its members:
+
+```js
+🚀 > {"a": 1}.get(nil, 0)
+=> ERROR: wrong argument type on position 1: got=NIL, want=HASHABLE
+```
+
 ## Methods ending in `!`
 
 A method whose name ends in `!` changes the value it is called on. The plain

--- a/docs/docs/language/methods.md
+++ b/docs/docs/language/methods.md
@@ -26,53 +26,10 @@ The documentation gives each method as a signature, for example
 | `STRING...` | one or more of them |
 
 Where a method takes a whole family of types, the family is named rather than
-listed. These names are **type groups**, not types — you never write them in
-RocketLang, they only appear in signatures and in error messages:
-
-| Group | Accepts | Used by |
-| ----- | ------- | ------- |
-| `ANY` | every value | `push`, `unshift`, `insert`, `include?` and `index` on an `ARRAY`, the fallback of `HASH.get` |
-| `HASHABLE` | anything usable as a hash key: `STRING`, `INTEGER`, `FLOAT`, `BOOLEAN`, `ARRAY`, `HASH` | the key arguments of `HASH.get`, `fetch`, `delete` and `include?`; the elements of `ARRAY.uniq` |
-| `COMPARABLE` | `STRING`, `INTEGER`, `FLOAT` | the elements of `ARRAY.sort`, `min` and `max` |
-| `STRINGABLE` | anything with a string form; a function and a module do not have one | the elements of `ARRAY.join` |
-| `INTEGERABLE` | anything readable as an integer, so also a `BOOLEAN` and a `STRING` that parses | the elements of `ARRAY.sum` |
-| `NUMERIC` | `INTEGER` and `FLOAT` | `MATRIX.set` |
-
-A group is checked by asking the value what it can do, not by comparing it
-against a list, so a type added to the language joins the group it qualifies
-for. An error names the group rather than spelling out its members:
-
-```js
-🚀 > {"a": 1}.get(nil, 0)
-=> ERROR: wrong argument type on position 1: got=NIL, want=HASHABLE
-```
-
-### Groups also describe elements
-
-A signature can only state what the *arguments* must be. Several methods have a
-requirement on the **elements** they are given instead, and they name the same
-groups:
-
-```js
-🚀 > [def() end].join()
-=> ERROR: element 0 is not STRINGABLE, got FUNCTION
-🚀 > [1, nil].uniq()
-=> ERROR: element 1 is not HASHABLE, got NIL
-🚀 > [1, nil].sum()
-=> ERROR: element 1 is not INTEGERABLE, got NIL
-🚀 > [1, nil].sort()
-=> ERROR: element 1 is not COMPARABLE, got NIL
-```
-
-Ordering carries one rule a group cannot express, because it is about the
-collection rather than any single value: the elements have to be the *same*
-comparable type. `1` and `2.5` are each `COMPARABLE` and still cannot be sorted
-together:
-
-```js
-🚀 > [1, 2.5].sort()
-=> ERROR: elements must all be one COMPARABLE type, got INTEGER at 0 and FLOAT at 1
-```
+listed — `push(ANY)`, `get(HASHABLE, ANY)`, `set(INTEGER, INTEGER, NUMERIC)`.
+Those names are **type groups**; see
+[Types and type groups](./types#type-groups) for what each one accepts and which
+types belong to it.
 
 ## Methods ending in `!`
 

--- a/docs/docs/language/methods.md
+++ b/docs/docs/language/methods.md
@@ -32,7 +32,10 @@ RocketLang, they only appear in signatures and in error messages:
 | Group | Accepts | Used by |
 | ----- | ------- | ------- |
 | `ANY` | every value | `push`, `unshift`, `insert`, `include?` and `index` on an `ARRAY`, the fallback of `HASH.get` |
-| `HASHABLE` | anything usable as a hash key: `STRING`, `INTEGER`, `FLOAT`, `BOOLEAN`, `ARRAY`, `HASH` | the key arguments of `HASH.get`, `fetch`, `delete` and `include?` |
+| `HASHABLE` | anything usable as a hash key: `STRING`, `INTEGER`, `FLOAT`, `BOOLEAN`, `ARRAY`, `HASH` | the key arguments of `HASH.get`, `fetch`, `delete` and `include?`; the elements of `ARRAY.uniq` |
+| `COMPARABLE` | `STRING`, `INTEGER`, `FLOAT` | the elements of `ARRAY.sort`, `min` and `max` |
+| `STRINGABLE` | anything with a string form; a function and a module do not have one | the elements of `ARRAY.join` |
+| `INTEGERABLE` | anything readable as an integer, so also a `BOOLEAN` and a `STRING` that parses | the elements of `ARRAY.sum` |
 | `NUMERIC` | `INTEGER` and `FLOAT` | `MATRIX.set` |
 
 A group is checked by asking the value what it can do, not by comparing it
@@ -42,6 +45,33 @@ for. An error names the group rather than spelling out its members:
 ```js
 🚀 > {"a": 1}.get(nil, 0)
 => ERROR: wrong argument type on position 1: got=NIL, want=HASHABLE
+```
+
+### Groups also describe elements
+
+A signature can only state what the *arguments* must be. Several methods have a
+requirement on the **elements** they are given instead, and they name the same
+groups:
+
+```js
+🚀 > [def() end].join()
+=> ERROR: element 0 is not STRINGABLE, got FUNCTION
+🚀 > [1, nil].uniq()
+=> ERROR: element 1 is not HASHABLE, got NIL
+🚀 > [1, nil].sum()
+=> ERROR: element 1 is not INTEGERABLE, got NIL
+🚀 > [1, nil].sort()
+=> ERROR: element 1 is not COMPARABLE, got NIL
+```
+
+Ordering carries one rule a group cannot express, because it is about the
+collection rather than any single value: the elements have to be the *same*
+comparable type. `1` and `2.5` are each `COMPARABLE` and still cannot be sorted
+together:
+
+```js
+🚀 > [1, 2.5].sort()
+=> ERROR: elements must all be one COMPARABLE type, got INTEGER at 0 and FLOAT at 1
 ```
 
 ## Methods ending in `!`

--- a/docs/docs/language/types.md
+++ b/docs/docs/language/types.md
@@ -1,0 +1,130 @@
+# Types and type groups
+
+> 👉 Type groups were introduced in `0.24`
+
+Every value in RocketLang has a type, and `type()` reports it:
+
+```js
+🚀 > "abc".type()
+=> "STRING"
+🚀 > [1, 2].type()
+=> "ARRAY"
+```
+
+## The types
+
+| Type | How you get one | Own methods |
+| ---- | --------------- | ----------- |
+| `STRING` | `"abc"`, `'abc'` | [String](../literals/string) |
+| `INTEGER` | `1`. A base prefix is not a literal: write `"0x1f".to_i()` | [Integer](../literals/integer) |
+| `FLOAT` | `1.5` | [Float](../literals/float) |
+| `BOOLEAN` | `true`, `false`, `👍`, `👎` | none |
+| `NIL` | `nil`, or anything that has nothing to return | none |
+| `ARRAY` | `[1, 2]` | [Array](../literals/array) |
+| `HASH` | `{"a": 1}` | [Hash](../literals/hash) |
+| `MATRIX` | `[[1, 2], [3, 4]].to_m()` | [Matrix](../literals/matrix) |
+| `FUNCTION` | `def(x) return x end` | none |
+| `ERROR` | a failing operation, caught with `begin`/`rescue` | [Error](../literals/error) |
+| `FILE` | `IO.open("f.txt", "r", "0644")` | [File](../literals/file) |
+| `HTTP` | `HTTP.new()` | [HTTP](../literals/http) |
+| `MODULE` | `import "./lib" as lib` | none |
+| `BUILTIN_MODULE` | `Math`, `IO`, `JSON`, `OS`, `Time` | see [Builtins](../builtins/Math) |
+
+Every type also answers the
+[generic methods](../literals/string#generic-literal-methods)
+`to_s`, `to_i`, `to_f`, `to_json`, `type`, `methods`, `wat` and `nil?` — except a
+`MODULE`, which only exposes what the module exports, so `lib.type()` is an
+error rather than `"MODULE"`.
+
+## Type groups
+
+A method that accepts a whole family of types names the family rather than
+listing it. These names are **type groups**. You never write one in RocketLang:
+they appear only in signatures and in error messages.
+
+```js
+🚀 > {"a": 1}.get(nil, 0)
+=> ERROR: wrong argument type on position 1: got=NIL, want=HASHABLE
+```
+
+| Group | Means | Where it appears |
+| ----- | ----- | ---------------- |
+| `ANY` | any value at all | `push`, `unshift`, `insert`, `include?`, `index`, `rindex`, `count` and `delete` on an `ARRAY`; the fallback of `HASH.get` and `fetch`; `format`; `puts` |
+| `HASHABLE` | can be used as a hash key | the key argument of `HASH.get`, `fetch`, `delete` and `include?`; the elements of `ARRAY.uniq` |
+| `COMPARABLE` | can be ordered against its own kind | the elements of `ARRAY.sort`, `min` and `max` |
+| `STRINGABLE` | has a string form | the elements of `ARRAY.join` |
+| `INTEGERABLE` | can be read as an integer | the elements of `ARRAY.sum` |
+| `NUMERIC` | a number | the value argument of `MATRIX.set` |
+
+### What belongs to what
+
+| Type | `ANY` | `HASHABLE` | `COMPARABLE` | `STRINGABLE` | `INTEGERABLE` | `NUMERIC` |
+| -------- | --- | --- | --- | --- | --- | --- |
+| `STRING` | ✅ | ✅ | ✅ | ✅ | ✅ | |
+| `INTEGER` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `FLOAT` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `BOOLEAN` | ✅ | ✅ | | ✅ | ✅ | |
+| `ARRAY` | ✅ | ✅ | | ✅ | | |
+| `HASH` | ✅ | ✅ | | ✅ | | |
+| `MATRIX` | ✅ | | | ✅ | | |
+| `NIL` | ✅ | | | ✅ | | |
+| `ERROR` | ✅ | | | ✅ | | |
+| `FILE` | ✅ | | | ✅ | | |
+| `HTTP` | ✅ | | | ✅ | | |
+| `FUNCTION` | ✅ | | | | | |
+| `MODULE` | ✅ | | | | | |
+
+Two rows are worth a second look:
+
+- A `BOOLEAN` is `INTEGERABLE`, and a `STRING` is too when it parses. That is
+  wider than being a number, which is why `["12"].sum()` is `12` and
+  `[true].sum()` is `1`.
+- An `ARRAY` and a `HASH` are `HASHABLE`, so they can be hash keys:
+  `{[1]: "a"}` is a valid hash.
+
+A group is decided by asking the value what it can do, not by comparing it
+against a list of type names. A type added to the language therefore joins every
+group it qualifies for without anyone maintaining a list — which is how
+`push` once came to accept a `FUNCTION` but reject a `FLOAT`.
+
+## Where groups show up
+
+### In a signature
+
+The documentation gives each method as a signature. A group sits where a type
+would:
+
+```
+push(ANY)
+get(HASHABLE, ANY)
+set(INTEGER, INTEGER, NUMERIC)
+```
+
+See [Methods](./methods#reading-a-signature) for the rest of the notation,
+including how an optional or repeatable argument is written.
+
+### In a requirement on elements
+
+A signature can only describe the *arguments*. Some methods require something of
+the **elements** they are given, and they name the same groups:
+
+```js
+🚀 > [def() end].join()
+=> ERROR: element 0 is not STRINGABLE, got FUNCTION
+🚀 > [1, nil].uniq()
+=> ERROR: element 1 is not HASHABLE, got NIL
+🚀 > [1, nil].sum()
+=> ERROR: element 1 is not INTEGERABLE, got NIL
+🚀 > [1, nil].sort()
+=> ERROR: element 1 is not COMPARABLE, got NIL
+```
+
+Ordering carries one requirement no group can express, because it is about the
+collection rather than any single value: the elements have to be the **same**
+comparable type. `1` and `2.5` are each `COMPARABLE` and still cannot be sorted
+together:
+
+```js
+🚀 > [1, 2.5].sort()
+=> ERROR: elements must all be one COMPARABLE type, got INTEGER at 0 and FLOAT at 1
+```

--- a/docs/docs/literals/array.md
+++ b/docs/docs/literals/array.md
@@ -87,7 +87,7 @@ a
 ' />
 
 
-### count([INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL])
+### count([ANY])
 > Returns `INTEGER`
 
 Without an argument this is `size`. With one it counts how often that element occurs, which is what `index` cannot tell you.
@@ -102,8 +102,8 @@ Without an argument this is `size`. With one it counts how often that element oc
 ' />
 
 
-### delete(INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL)
-> Returns `INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL`
+### delete(ANY)
+> Returns `ANY`
 
 Removes every element equal to the argument and returns that argument, or `nil` when there was nothing to remove, so a removal can be told from a miss.
 
@@ -120,7 +120,7 @@ nil
 
 
 ### delete_at(INTEGER)
-> Returns `INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL`
+> Returns `ANY`
 
 Removes the element at the given index and returns it. A negative index counts back from the end. An index that is not there gives `nil`, the same answer `first` gives for an empty array.
 
@@ -163,7 +163,7 @@ false
 
 
 ### first([INTEGER])
-> Returns `INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL`
+> Returns `ANY`
 
 Returns the first element of the array. Shorthand for `array[0]`
 
@@ -205,7 +205,7 @@ a
 ' />
 
 
-### include?(STRING|ARRAY|HASH|BOOLEAN|INTEGER|NIL|FILE)
+### include?(ANY)
 > Returns `BOOLEAN`
 
 Returns true or false wether the array contains the given element
@@ -218,7 +218,7 @@ true
 ' />
 
 
-### index(STRING|ARRAY|HASH|BOOLEAN|INTEGER|NIL|FILE)
+### index(ANY)
 > Returns `INTEGER`
 
 Returns the index of the given element in the array if found. Otherwise return `-1`.
@@ -229,7 +229,7 @@ Returns the index of the given element in the array if found. Otherwise return `
 ' />
 
 
-### insert(INTEGER, INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL)
+### insert(INTEGER, ANY)
 > Returns `ARRAY|ERROR`
 
 Inserts an element at the given index and returns the array. A negative index counts back from the end, so `-1` appends. An index past the end is an error rather than a silent padding with `nil`.
@@ -260,7 +260,7 @@ Joins the elements into a string, with an optional separator between them. Every
 
 
 ### last([INTEGER])
-> Returns `INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL`
+> Returns `ANY`
 
 Returns the last element of the array.
 
@@ -271,7 +271,7 @@ Returns the last element of the array.
 
 
 ### max()
-> Returns `INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL`
+> Returns `ANY`
 
 Returns the largest element, or `nil` for an empty array. Takes the same elements as `min`.
 
@@ -284,7 +284,7 @@ nil
 
 
 ### min()
-> Returns `INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL`
+> Returns `ANY`
 
 Returns the smallest element, or `nil` for an empty array. The elements have to be all strings, all integers or all floats, exactly as `sort` requires.
 
@@ -299,7 +299,7 @@ nil
 
 
 ### pop()
-> Returns `STRING|ARRAY|HASH|BOOLEAN|INTEGER|NIL|FUNCTION|FILE`
+> Returns `ANY`
 
 Removes the last element of the array and returns it.
 
@@ -313,7 +313,7 @@ a
 ' />
 
 
-### push(STRING|ARRAY|HASH|BOOLEAN|INTEGER|NIL|FUNCTION|FILE)
+### push(ANY)
 > Returns `ARRAY`
 
 Adds the given object as the last element and returns the array, so calls can be chained.
@@ -358,7 +358,7 @@ a
 ' />
 
 
-### rindex(INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL)
+### rindex(ANY)
 > Returns `INTEGER`
 
 Returns the index of the last matching element, or `-1` when there is none. The mirror of `index`.
@@ -406,7 +406,7 @@ a
 
 
 ### shift()
-> Returns `INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL`
+> Returns `ANY`
 
 Removes the first element and returns it, or `nil` for an empty array. The mirror of `pop`, and like `pop` it changes the array without a `!`, because there is no pure version of taking something out.
 
@@ -543,7 +543,7 @@ c
 ' />
 
 
-### unshift(INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL)
+### unshift(ANY)
 > Returns `ARRAY`
 
 Adds an element to the front and returns the array, so calls can be chained. The mirror of `push`.

--- a/docs/docs/literals/array.md
+++ b/docs/docs/literals/array.md
@@ -249,7 +249,7 @@ a
 ### join([STRING])
 > Returns `STRING`
 
-Joins the elements into a string, with an optional separator between them. Every element has to have a string form; a function does not.
+Joins the elements into a string, with an optional separator between them. Every element has to be `STRINGABLE`; a function is not.
 
 
 <CodeBlockSimple input='[1, 2, 3].join()
@@ -286,7 +286,7 @@ nil
 ### min()
 > Returns `ANY`
 
-Returns the smallest element, or `nil` for an empty array. The elements have to be all strings, all integers or all floats, exactly as `sort` requires.
+Returns the smallest element, or `nil` for an empty array. The elements have to satisfy exactly what `sort` requires.
 
 
 <CodeBlockSimple input='[3, 1, 2].min()
@@ -445,7 +445,7 @@ Returns the elements of the array in slices with the size of the given integer
 ### sort()
 > Returns `ARRAY|ERROR`
 
-Returns a new sorted array. The elements must all be STRING, all INTEGER or all FLOAT, otherwise an error is returned and the array is left untouched. Use `sort!` to sort in place.
+Returns a new sorted array. Every element has to be `COMPARABLE` -- a `STRING`, `INTEGER` or `FLOAT` -- and they all have to be the same one of those, otherwise an error is returned naming the element at fault and the array is left untouched. Use `sort!` to sort in place.
 
 
 <CodeBlockSimple input='b = [3.4, 3.1, 2.0]
@@ -475,7 +475,7 @@ b
 ### sum()
 > Returns `INTEGER`
 
-Adds the elements up. They all have to be numbers.
+Adds the elements up. Every element has to be `INTEGERABLE`, which is wider than being a number: a string that parses and a boolean both count.
 
 
 <CodeBlockSimple input='[1, 2, 3].sum()
@@ -516,7 +516,7 @@ Converts a nested array (2D array) to a Matrix object.
 ### uniq()
 > Returns `ARRAY|ERROR`
 
-Returns a new array with duplicates removed, keeping the order of first appearance. Returns an error if an element is not hashable. Use `uniq!` to deduplicate in place.
+Returns a new array with duplicates removed, keeping the order of first appearance. Every element has to be `HASHABLE`, otherwise an error is returned naming the element at fault. Use `uniq!` to deduplicate in place.
 
 
 <CodeBlockSimple input='c = ["a", 1, 1, 2]

--- a/docs/docs/literals/hash.md
+++ b/docs/docs/literals/hash.md
@@ -97,8 +97,8 @@ h.size()
 ' />
 
 
-### delete(INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL)
-> Returns `INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL`
+### delete(HASHABLE)
+> Returns `ANY`
 
 Removes the entry for a key and returns its value, or `nil` when the key was not there, so a removal can be told from a miss.
 
@@ -127,10 +127,10 @@ false
 ' />
 
 
-### fetch(INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL, [INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL])
-> Returns `INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL`
+### fetch(HASHABLE, [ANY])
+> Returns `ANY`
 
-Returns the value for a key. Without a fallback a missing key is an error, which is the difference from `get`, where a fallback is required.
+Returns the value for a key. Without a fallback a missing key is an error, which is the difference from `get`, where a fallback is required. The key has to be `HASHABLE`; the fallback can be anything.
 
 
 <CodeBlockSimple input='h = {"a": 1}
@@ -142,10 +142,10 @@ h.fetch("z", 0)
 ' />
 
 
-### get(INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL, INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL)
-> Returns `INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL`
+### get(HASHABLE, ANY)
+> Returns `ANY`
 
-Returns the value of the given key or the default
+Returns the value stored under the given key, or the given default when there is no such entry. The key has to be `HASHABLE`; the default can be anything.
 
 
 <CodeBlockSimple input='{"a": "1", "b": "2"}.get("a", 10)
@@ -155,10 +155,10 @@ Returns the value of the given key or the default
 ' />
 
 
-### include?(BOOLEAN|STRING|INTEGER|FLOAT|ARRAY|HASH)
+### include?(HASHABLE)
 > Returns `BOOLEAN`
 
-Returns true or false wether the hash contains the given object as key
+Returns `true` when the hash has an entry under the given key. The argument has to be usable as a key, which is what `HASHABLE` in the signature means: a `STRING`, `INTEGER`, `FLOAT`, `BOOLEAN`, `ARRAY` or `HASH`.
 
 
 <CodeBlockSimple input='{"a": 1, 1: "b"}.include?(1)

--- a/docs/docs/literals/matrix.md
+++ b/docs/docs/literals/matrix.md
@@ -98,7 +98,7 @@ m.rows()
 ' />
 
 
-### set(INTEGER, INTEGER, FLOAT|INTEGER)
+### set(INTEGER, INTEGER, NUMERIC)
 > Returns `NIL|ERROR`
 
 Sets the element at the specified row and column (0-indexed) and returns the matrix, so calls can be chained.

--- a/docs/docs/literals/string.md
+++ b/docs/docs/literals/string.md
@@ -260,7 +260,7 @@ Returns the character index of a given string if found. Otherwise returns `-1`
 ' />
 
 
-### format((STRING|INTEGER|FLOAT|BOOLEAN|ARRAY|HASH)...)
+### format(ANY...)
 > Returns `STRING`
 
 Formats according to a format specifier and returns the resulting string

--- a/docs/literals/array.yml
+++ b/docs/literals/array.yml
@@ -162,7 +162,7 @@ methods:
       [1, 9, 2, 8]
       [1, 9, 2, 8]
   join:
-    description: "Joins the elements into a string, with an optional separator between them. Every element has to have a string form; a function does not."
+    description: "Joins the elements into a string, with an optional separator between them. Every element has to be `STRINGABLE`; a function is not."
     input: |
       [1, 2, 3].join()
       [1, 2, 3].join("-")
@@ -184,7 +184,7 @@ methods:
       3
       nil
   min:
-    description: "Returns the smallest element, or `nil` for an empty array. The elements have to be all strings, all integers or all floats, exactly as `sort` requires."
+    description: "Returns the smallest element, or `nil` for an empty array. The elements have to satisfy exactly what `sort` requires."
     input: |
       [3, 1, 2].min()
       ["b", "a"].min()
@@ -288,7 +288,7 @@ methods:
     output: |
       [[1, 2, 3], [4, 5, 6], [7, 8]]
   sort:
-    description: "Returns a new sorted array. The elements must all be STRING, all INTEGER or all FLOAT, otherwise an error is returned and the array is left untouched. Use `sort!` to sort in place."
+    description: "Returns a new sorted array. Every element has to be `COMPARABLE` -- a `STRING`, `INTEGER` or `FLOAT` -- and they all have to be the same one of those, otherwise an error is returned naming the element at fault and the array is left untouched. Use `sort!` to sort in place."
     input: |
       b = [3.4, 3.1, 2.0]
       b.sort()
@@ -308,7 +308,7 @@ methods:
       [2.0, 3.1, 3.4]
       [2.0, 3.1, 3.4]
   sum:
-    description: "Adds the elements up. They all have to be numbers."
+    description: "Adds the elements up. Every element has to be `INTEGERABLE`, which is wider than being a number: a string that parses and a boolean both count."
     input: |
       [1, 2, 3].sum()
       [1.5, 2.5].sum()
@@ -334,7 +334,7 @@ methods:
       │ 3.0  4.0 │
       └          ┘
   uniq:
-    description: "Returns a new array with duplicates removed, keeping the order of first appearance. Returns an error if an element is not hashable. Use `uniq!` to deduplicate in place."
+    description: "Returns a new array with duplicates removed, keeping the order of first appearance. Every element has to be `HASHABLE`, otherwise an error is returned naming the element at fault. Use `uniq!` to deduplicate in place."
     input: |
       c = ["a", 1, 1, 2]
       c.uniq()

--- a/docs/literals/hash.yml
+++ b/docs/literals/hash.yml
@@ -94,7 +94,7 @@ methods:
       true
       false
   fetch:
-    description: "Returns the value for a key. Without a fallback a missing key is an error, which is the difference from `get`, where a fallback is required."
+    description: "Returns the value for a key. Without a fallback a missing key is an error, which is the difference from `get`, where a fallback is required. The key has to be `HASHABLE`; the fallback can be anything."
     input: |
       h = {"a": 1}
       h.fetch("a")
@@ -104,7 +104,7 @@ methods:
       1
       0
   get:
-    description: "Returns the value of the given key or the default"
+    description: "Returns the value stored under the given key, or the given default when there is no such entry. The key has to be `HASHABLE`; the default can be anything."
     input: |
       {"a": "1", "b": "2"}.get("a", 10)
       {"a": "1", "b": "2"}.get("c", 10)
@@ -112,7 +112,7 @@ methods:
       "1"
       10
   include?:
-    description: "Returns true or false wether the hash contains the given object as key"
+    description: "Returns `true` when the hash has an entry under the given key. The argument has to be usable as a key, which is what `HASHABLE` in the signature means: a `STRING`, `INTEGER`, `FLOAT`, `BOOLEAN`, `ARRAY` or `HASH`."
     input: |
       {"a": 1, 1: "b"}.include?(1)
       {"a": 1, 1: "b"}.include?("c")

--- a/object/array.go
+++ b/object/array.go
@@ -85,12 +85,12 @@ func init() {
 					join = args[0].(*String).Value
 				}
 
+				if err := requireElements(ao.Elements, STRINGABLE); err != nil {
+					return err
+				}
+
 				for i, element := range ao.Elements {
-					if e, ok := element.(Stringable); ok {
-						arr[i] = e.ToStringObj().Value
-					} else {
-						return NewErrorFormat("Found non stringable element %s on index %d", element.Type(), i)
-					}
+					arr[i] = element.(Stringable).ToStringObj().Value
 				}
 
 				return NewString(strings.Join(arr, join))
@@ -169,17 +169,16 @@ func init() {
 				ao := o.(*Array)
 				var result int
 
-				for i, element := range ao.Elements {
-					val, ok := element.(Integerable)
-					if !ok {
-						return NewErrorFormat("Found non number element %s on index %d", element.Type(), i)
-					}
+				if err := requireElements(ao.Elements, INTEGERABLE); err != nil {
+					return err
+				}
 
-					// A convertible type can still fail to convert, for
-					// instance a string that does not parse as a number.
-					integer, ok := val.ToIntegerObj().(*Integer)
+				for i, element := range ao.Elements {
+					// Being convertible is not the same as converting: a string
+					// is INTEGERABLE whether or not it parses as a number.
+					integer, ok := element.(Integerable).ToIntegerObj().(*Integer)
 					if !ok {
-						return NewErrorFormat("Found non number element %s on index %d", element.Type(), i)
+						return NewErrorFormat("element %d does not convert to a number, got %s", i, element.Type())
 					}
 
 					result += int(integer.Value)
@@ -875,6 +874,21 @@ func (a *arrayIterator) Next() (Object, Object, bool) {
 	return nil, NewInteger(0), false
 }
 
+// requireElements returns an error naming the first element outside the group,
+// or nil. The four requirements on elements -- STRINGABLE for join, INTEGERABLE
+// for sum, HASHABLE for uniq and COMPARABLE for sort -- used to be four checks
+// with four unrelated messages, one of which did not say which element was at
+// fault.
+func requireElements(elements []Object, group string) Object {
+	for i, element := range elements {
+		if !InGroup(group, element) {
+			return NewErrorFormat("element %d is not %s, got %s", i, group, element.Type())
+		}
+	}
+
+	return nil
+}
+
 // reversedElements returns a reversed copy, leaving src untouched.
 func reversedElements(src []Object) []Object {
 	out := make([]Object, len(src))
@@ -886,9 +900,13 @@ func reversedElements(src []Object) []Object {
 }
 
 // sortedElements returns a sorted copy of src. The second value is an error
-// object when the elements are not a single sortable type, in which case the
+// object when the elements are not a single COMPARABLE type, in which case the
 // copy must not be used -- working on a copy means a failed sort cannot leave a
 // half-ordered array behind.
+//
+// Both requirements are checked before any comparison runs, so the comparison
+// functions can assert without a fallback. They used to carry an ok check each
+// and set a flag that sort.SliceStable might or might not have reached.
 //
 // Can be refactored to generics once
 // https://github.com/golang/go/issues/48522 is fixed.
@@ -900,48 +918,34 @@ func sortedElements(src []Object) ([]Object, Object) {
 		return out, nil
 	}
 
-	sortError := false
-
-	switch out[0].(type) {
-	case *Float:
-		sort.SliceStable(out, func(i, j int) bool {
-			left, leftOk := out[i].(*Float)
-			right, rightOk := out[j].(*Float)
-			if !leftOk || !rightOk {
-				sortError = true
-				return false
-			}
-
-			return left.Value < right.Value
-		})
-	case *Integer:
-		sort.SliceStable(out, func(i, j int) bool {
-			left, leftOk := out[i].(*Integer)
-			right, rightOk := out[j].(*Integer)
-			if !leftOk || !rightOk {
-				sortError = true
-				return false
-			}
-
-			return left.Value < right.Value
-		})
-	case *String:
-		sort.SliceStable(out, func(i, j int) bool {
-			left, leftOk := out[i].(*String)
-			right, rightOk := out[j].(*String)
-			if !leftOk || !rightOk {
-				sortError = true
-				return false
-			}
-
-			return left.Value < right.Value
-		})
-	default:
-		sortError = true
+	// Two separate requirements, and they used to share one message that named
+	// neither the element nor which of the two had failed: [1, nil].sort() and
+	// [1, 2.5].sort() both said "an object not INTEGER, FLOAT or STRING or is
+	// mixed".
+	if err := requireElements(out, COMPARABLE); err != nil {
+		return nil, err
 	}
 
-	if sortError {
-		return nil, NewError("Array does contain either an object not INTEGER, FLOAT or STRING or is mixed")
+	wanted := out[0].Type()
+	for i, element := range out {
+		if element.Type() != wanted {
+			return nil, NewErrorFormat("elements must all be one %s type, got %s at 0 and %s at %d", COMPARABLE, wanted, element.Type(), i)
+		}
+	}
+
+	switch wanted {
+	case FLOAT_OBJ:
+		sort.SliceStable(out, func(i, j int) bool {
+			return out[i].(*Float).Value < out[j].(*Float).Value
+		})
+	case INTEGER_OBJ:
+		sort.SliceStable(out, func(i, j int) bool {
+			return out[i].(*Integer).Value < out[j].(*Integer).Value
+		})
+	case STRING_OBJ:
+		sort.SliceStable(out, func(i, j int) bool {
+			return out[i].(*String).Value < out[j].(*String).Value
+		})
 	}
 
 	return out, nil
@@ -954,13 +958,12 @@ func uniqueElements(src []Object) ([]Object, Object) {
 	seen := make(map[HashKey]struct{}, len(src))
 	out := make([]Object, 0, len(src))
 
-	for _, element := range src {
-		hashable, ok := element.(Hashable)
-		if !ok {
-			return nil, NewErrorFormat("failed because element %s is not hashable", element.Type())
-		}
+	if err := requireElements(src, HASHABLE); err != nil {
+		return nil, err
+	}
 
-		key := hashable.HashKey()
+	for _, element := range src {
+		key := element.(Hashable).HashKey()
 		if _, duplicate := seen[key]; duplicate {
 			continue
 		}

--- a/object/array.go
+++ b/object/array.go
@@ -226,7 +226,7 @@ func init() {
 					Arg(INTEGER_OBJ),
 				),
 				ArgPattern: Args(
-					Arg(STRING_OBJ, ARRAY_OBJ, HASH_OBJ, BOOLEAN_OBJ, INTEGER_OBJ, NIL_OBJ, FILE_OBJ),
+					Arg(ANY),
 				),
 			},
 			method: func(o Object, args []Object, _ Environment) Object {
@@ -240,7 +240,7 @@ func init() {
 					OptArg(INTEGER_OBJ),
 				),
 				ReturnPattern: Args(
-					Arg(ANY_OBJ...),
+					Arg(ANY),
 				),
 			},
 			method: func(o Object, args []Object, _ Environment) Object {
@@ -273,7 +273,7 @@ func init() {
 					OptArg(INTEGER_OBJ),
 				),
 				ReturnPattern: Args(
-					Arg(ANY_OBJ...),
+					Arg(ANY),
 				),
 			},
 			method: func(o Object, args []Object, _ Environment) Object {
@@ -303,7 +303,7 @@ func init() {
 		"pop": ObjectMethod{
 			Layout: MethodLayout{
 				ReturnPattern: Args(
-					Arg(STRING_OBJ, ARRAY_OBJ, HASH_OBJ, BOOLEAN_OBJ, INTEGER_OBJ, NIL_OBJ, FUNCTION_OBJ, FILE_OBJ),
+					Arg(ANY),
 				),
 			},
 			method: func(o Object, _ []Object, _ Environment) Object {
@@ -330,7 +330,7 @@ func init() {
 					Arg(ARRAY_OBJ),
 				),
 				ArgPattern: Args(
-					Arg(STRING_OBJ, ARRAY_OBJ, HASH_OBJ, BOOLEAN_OBJ, INTEGER_OBJ, NIL_OBJ, FUNCTION_OBJ, FILE_OBJ),
+					Arg(ANY),
 				),
 			},
 			method: func(o Object, args []Object, _ Environment) Object {
@@ -346,7 +346,7 @@ func init() {
 					Arg(BOOLEAN_OBJ),
 				),
 				ArgPattern: Args(
-					Arg(STRING_OBJ, ARRAY_OBJ, HASH_OBJ, BOOLEAN_OBJ, INTEGER_OBJ, NIL_OBJ, FILE_OBJ),
+					Arg(ANY),
 				),
 			},
 			method: func(o Object, args []Object, _ Environment) Object {
@@ -419,7 +419,7 @@ func init() {
 		"count": ObjectMethod{
 			Layout: MethodLayout{
 				ArgPattern: Args(
-					OptArg(ANY_OBJ...),
+					OptArg(ANY),
 				),
 				ReturnPattern: Args(
 					Arg(INTEGER_OBJ),
@@ -448,7 +448,7 @@ func init() {
 		"rindex": ObjectMethod{
 			Layout: MethodLayout{
 				ArgPattern: Args(
-					Arg(ANY_OBJ...),
+					Arg(ANY),
 				),
 				ReturnPattern: Args(
 					Arg(INTEGER_OBJ),
@@ -470,7 +470,7 @@ func init() {
 		"min": ObjectMethod{
 			Layout: MethodLayout{
 				ReturnPattern: Args(
-					Arg(ANY_OBJ...),
+					Arg(ANY),
 				),
 			},
 			method: func(o Object, _ []Object, _ Environment) Object {
@@ -480,7 +480,7 @@ func init() {
 		"max": ObjectMethod{
 			Layout: MethodLayout{
 				ReturnPattern: Args(
-					Arg(ANY_OBJ...),
+					Arg(ANY),
 				),
 			},
 			method: func(o Object, _ []Object, _ Environment) Object {
@@ -490,7 +490,7 @@ func init() {
 		"shift": ObjectMethod{
 			Layout: MethodLayout{
 				ReturnPattern: Args(
-					Arg(ANY_OBJ...),
+					Arg(ANY),
 				),
 			},
 			method: func(o Object, _ []Object, _ Environment) Object {
@@ -511,7 +511,7 @@ func init() {
 		"unshift": ObjectMethod{
 			Layout: MethodLayout{
 				ArgPattern: Args(
-					Arg(ANY_OBJ...),
+					Arg(ANY),
 				),
 				ReturnPattern: Args(
 					Arg(ARRAY_OBJ),
@@ -528,7 +528,7 @@ func init() {
 			Layout: MethodLayout{
 				ArgPattern: Args(
 					Arg(INTEGER_OBJ),
-					Arg(ANY_OBJ...),
+					Arg(ANY),
 				),
 				ReturnPattern: Args(
 					Arg(ARRAY_OBJ, ERROR_OBJ),
@@ -561,10 +561,10 @@ func init() {
 		"delete": ObjectMethod{
 			Layout: MethodLayout{
 				ArgPattern: Args(
-					Arg(ANY_OBJ...),
+					Arg(ANY),
 				),
 				ReturnPattern: Args(
-					Arg(ANY_OBJ...),
+					Arg(ANY),
 				),
 			},
 			method: func(o Object, args []Object, _ Environment) Object {
@@ -596,7 +596,7 @@ func init() {
 					Arg(INTEGER_OBJ),
 				),
 				ReturnPattern: Args(
-					Arg(ANY_OBJ...),
+					Arg(ANY),
 				),
 			},
 			method: func(o Object, args []Object, _ Environment) Object {

--- a/object/array_test.go
+++ b/object/array_test.go
@@ -46,7 +46,7 @@ func TestArrayObjectMethods(t *testing.T) {
 		{`["test","test",2].uniq().size()`, 2},
 		// nil is not hashable, so it cannot be de-duplicated. Written with a
 		// literal rather than relying on what a !-method hands back.
-		{`[nil].uniq()`, "failed because element NIL is not hashable"},
+		{`[nil].uniq()`, "element 0 is not HASHABLE, got NIL"},
 		{"[].first()", nil},
 		{"[1,2,3].first()", 1},
 		{"[].last()", nil},
@@ -56,10 +56,10 @@ func TestArrayObjectMethods(t *testing.T) {
 		{`[3.4, 3.1, 2.0].sort()`, `[2.0, 3.1, 3.4]`},
 		{`[3, 1, 4].sort()`, `[1, 3, 4]`},
 		{`["Gopher", "Go", "Alpha"].sort()`, `["Alpha", "Go", "Gopher"]`},
-		{`["Gopher", 1, "Alpha"].sort()`, "Array does contain either an object not INTEGER, FLOAT or STRING or is mixed"},
-		{`[1, "Go", 1].sort()`, "Array does contain either an object not INTEGER, FLOAT or STRING or is mixed"},
-		{`[2.0, "Go", 2.0].sort()`, "Array does contain either an object not INTEGER, FLOAT or STRING or is mixed"},
-		{`[true, "Go", true].sort()`, "Array does contain either an object not INTEGER, FLOAT or STRING or is mixed"},
+		{`["Gopher", 1, "Alpha"].sort()`, "elements must all be one COMPARABLE type, got STRING at 0 and INTEGER at 1"},
+		{`[1, "Go", 1].sort()`, "elements must all be one COMPARABLE type, got INTEGER at 0 and STRING at 1"},
+		{`[2.0, "Go", 2.0].sort()`, "elements must all be one COMPARABLE type, got FLOAT at 0 and STRING at 1"},
+		{`[true, "Go", true].sort()`, "element 0 is not COMPARABLE, got BOOLEAN"},
 		{`[].sort()`, `[]`},
 		{`["a", "b", 1, 2].reverse()`, `[2, 1, "b", "a"]`},
 		{`[1,2,3].include?(4)`, false},
@@ -75,15 +75,15 @@ func TestArrayObjectMethods(t *testing.T) {
 		// has no string form -- a function -- is refused.
 		{"[1,2,3,{}].join()", "123{}"},
 		{"[1,2,3,[4]].join()", "123[4]"},
-		{"[def() end].join()", "Found non stringable element FUNCTION on index 0"},
+		{"[def() end].join()", "element 0 is not STRINGABLE, got FUNCTION"},
 		{"[1,2,3].join()", "123"},
 		{"[1,2,3].join('-')", "1-2-3"},
-		{"['1',2, 2.5,{}].sum()", "Found non number element HASH on index 3"},
+		{"['1',2, 2.5,{}].sum()", "element 3 is not INTEGERABLE, got HASH"},
 		{"['1', 2, 2.5].sum()", 5},
 		// A type can be convertible in principle and still fail to convert:
 		// nil and a non-numeric string both used to contribute a silent 0.
-		{"[1, nil].sum()", "Found non number element NIL on index 1"},
-		{"['abc'].sum()", "Found non number element STRING on index 0"},
+		{"[1, nil].sum()", "element 1 is not INTEGERABLE, got NIL"},
+		{"['abc'].sum()", "element 0 does not convert to a number, got STRING"},
 		{`[[1, 2], [3, 4]].to_m()`, "2x2 matrix\n┌          ┐\n│ 1.0  2.0 │\n│ 3.0  4.0 │\n└          ┘"},
 		{`[[1, 2], [3, 4]].to_m().to_a()`, "[[1.0, 2.0], [3.0, 4.0]]"},
 		{`[1, 2].to_m()`, "failed to convert array to matrix: matrix must be created from 2D array"},
@@ -172,7 +172,7 @@ func TestArrayBangConvention(t *testing.T) {
 		{`a = [1,2,3]; a.pop(); a.to_json()`, "[1,2]"},
 
 		// A sort that cannot compare its elements errors...
-		{`[1,"a"].sort()`, "Array does contain either an object not INTEGER, FLOAT or STRING or is mixed"},
+		{`[1,"a"].sort()`, "elements must all be one COMPARABLE type, got INTEGER at 0 and STRING at 1"},
 		// ...and leaves the array alone rather than half-ordered. The error has
 		// to be caught, or it would propagate before to_json runs and the
 		// assertion would pass without checking anything.
@@ -213,7 +213,7 @@ func TestArrayRubyMethods(t *testing.T) {
 		{`[].max()`, nil},
 		// min and max borrow sort's rule about what can be compared, so they
 		// fail the same way and with the same words.
-		{`[1,"a"].min()`, "Array does contain either an object not INTEGER, FLOAT or STRING or is mixed"},
+		{`[1,"a"].min()`, "elements must all be one COMPARABLE type, got INTEGER at 0 and STRING at 1"},
 
 		{`[1,2,3].first(2)`, "[1, 2]"},
 		{`[1,2,3].first(9)`, "[1, 2, 3]"},
@@ -307,6 +307,51 @@ func TestArrayBangPairsAreComplete(t *testing.T) {
 		{`[1,[2,[3]]].flatten!(1).to_json()`, "[1,2,[3]]"},
 		{`[1,2,3].rotate!(2).to_json()`, "[3,1,2]"},
 		{`[1,2].flatten!(0 - 1)`, "negative depth -1"},
+	}
+	testInput(t, tests)
+}
+
+// TestElementGroupErrors covers the requirements a method places on the
+// elements it is given. These were four checks with four unrelated messages,
+// and sort's named neither the element at fault nor which of its two rules had
+// been broken -- [1, nil].sort() and [1, 2.5].sort() said the same thing.
+func TestElementGroupErrors(t *testing.T) {
+	tests := []inputTestCase{
+		// Each one names the group, the index and what was found instead.
+		{`[def() end].join()`, "element 0 is not STRINGABLE, got FUNCTION"},
+		{`[1, def() end].join()`, "element 1 is not STRINGABLE, got FUNCTION"},
+		{`[nil].uniq()`, "element 0 is not HASHABLE, got NIL"},
+		{`[1, nil].uniq()`, "element 1 is not HASHABLE, got NIL"},
+		{`[1, nil].sum()`, "element 1 is not INTEGERABLE, got NIL"},
+		{`[nil].sort()`, "element 0 is not COMPARABLE, got NIL"},
+		{`[1, nil].sort()`, "element 1 is not COMPARABLE, got NIL"},
+		{`[true].sort()`, "element 0 is not COMPARABLE, got BOOLEAN"},
+
+		// Ordering has a second rule that no per-element group can state, so it
+		// gets its own message -- and both types are named.
+		{`[1, 2.5].sort()`, "elements must all be one COMPARABLE type, got INTEGER at 0 and FLOAT at 1"},
+		{`[1, "a"].sort()`, "elements must all be one COMPARABLE type, got INTEGER at 0 and STRING at 1"},
+		{`["a", 1].sort()`, "elements must all be one COMPARABLE type, got STRING at 0 and INTEGER at 1"},
+		// min and max borrow the same rules, so they report the same way.
+		{`[1, "a"].min()`, "elements must all be one COMPARABLE type, got INTEGER at 0 and STRING at 1"},
+		{`[1, "a"].max()`, "elements must all be one COMPARABLE type, got INTEGER at 0 and STRING at 1"},
+		{`[nil].min()`, "element 0 is not COMPARABLE, got NIL"},
+
+		// One element of a COMPARABLE type is fine, and so is none.
+		{`[1].sort().to_json()`, "[1]"},
+		{`[].sort().to_json()`, "[]"},
+		{`[2.5, 1.5].sort().to_json()`, "[1.5,2.5]"},
+		{`["b", "a"].sort().to_json()`, `["a","b"]`},
+
+		// INTEGERABLE is wider than NUMERIC on purpose: a string that parses
+		// and a boolean both count, which is existing sum behaviour.
+		{`["12"].sum()`, 12},
+		{`[true].sum()`, 1},
+		{`[1.9].sum()`, 1},
+		// Being INTEGERABLE is not the same as converting, so that failure is
+		// reported differently rather than blamed on the type.
+		{`["abc"].sum()`, "element 0 does not convert to a number, got STRING"},
+		{`[1, "abc"].sum()`, "element 1 does not convert to a number, got STRING"},
 	}
 	testInput(t, tests)
 }

--- a/object/hash.go
+++ b/object/hash.go
@@ -77,7 +77,29 @@ func (h *Hash) Set(key, value any) {
 	} else {
 		valObj = AnyToObject(value)
 	}
-	h.Pairs[keyObj.(Hashable).HashKey()] = HashPair{Key: keyObj, Value: valObj}
+	hashable, ok := keyObj.(Hashable)
+	if !ok {
+		// Called from Go rather than from the interpreter, so there is no
+		// argument pattern guarding this one. Dropping the entry beats bringing
+		// the process down over a key that could never be looked up anyway.
+		return
+	}
+
+	h.Pairs[hashable.HashKey()] = HashPair{Key: keyObj, Value: valObj}
+}
+
+// hashKeyOf turns an argument into a hash key. The HASHABLE argument pattern
+// already rejects anything that cannot be one, so the error is unreachable from
+// the interpreter; it exists so that widening a pattern can never again turn
+// into a panic. include? and get used to assert without checking, and
+// {"a": 1}.get(nil, 0) brought the process down.
+func hashKeyOf(o Object) (HashKey, Object) {
+	hashable, ok := o.(Hashable)
+	if !ok {
+		return HashKey{}, NewErrorFormat("unusable as hash key: %s", o.Type())
+	}
+
+	return hashable.HashKey(), nil
 }
 
 func init() {
@@ -128,34 +150,46 @@ func init() {
 					Arg(BOOLEAN_OBJ),
 				),
 				ArgPattern: Args(
-					Arg(BOOLEAN_OBJ, STRING_OBJ, INTEGER_OBJ, FLOAT_OBJ, ARRAY_OBJ, HASH_OBJ),
+					Arg(HASHABLE),
 				),
 			},
 			method: func(o Object, args []Object, _ Environment) Object {
 				h := o.(*Hash)
-				key := args[0].(Hashable)
-				if _, ok := h.Pairs[key.HashKey()]; ok {
+
+				key, err := hashKeyOf(args[0])
+				if err != nil {
+					return err
+				}
+
+				if _, ok := h.Pairs[key]; ok {
 					return TRUE
 				}
+
 				return FALSE
 			},
 		},
 		"get": ObjectMethod{
 			Layout: MethodLayout{
 				ArgPattern: Args(
-					Arg(ANY_OBJ...),
-					Arg(ANY_OBJ...),
+					Arg(HASHABLE),
+					Arg(ANY),
 				),
 				ReturnPattern: Args(
-					Arg(ANY_OBJ...),
+					Arg(ANY),
 				),
 			},
 			method: func(o Object, args []Object, _ Environment) Object {
 				h := o.(*Hash)
-				k := args[0].(Hashable)
-				if pair, ok := h.Pairs[k.HashKey()]; ok {
+
+				key, err := hashKeyOf(args[0])
+				if err != nil {
+					return err
+				}
+
+				if pair, ok := h.Pairs[key]; ok {
 					return pair.Value
 				}
+
 				return args[1]
 			},
 		},
@@ -186,22 +220,22 @@ func init() {
 		"fetch": ObjectMethod{
 			Layout: MethodLayout{
 				ArgPattern: Args(
-					Arg(ANY_OBJ...),
-					OptArg(ANY_OBJ...),
+					Arg(HASHABLE),
+					OptArg(ANY),
 				),
 				ReturnPattern: Args(
-					Arg(ANY_OBJ...),
+					Arg(ANY),
 				),
 			},
 			method: func(o Object, args []Object, _ Environment) Object {
 				h := o.(*Hash)
 
-				key, ok := args[0].(Hashable)
-				if !ok {
-					return NewErrorFormat("unusable as hash key: %s", args[0].Type())
+				key, err := hashKeyOf(args[0])
+				if err != nil {
+					return err
 				}
 
-				if pair, found := h.Pairs[key.HashKey()]; found {
+				if pair, found := h.Pairs[key]; found {
 					return pair.Value
 				}
 
@@ -217,21 +251,20 @@ func init() {
 		"delete": ObjectMethod{
 			Layout: MethodLayout{
 				ArgPattern: Args(
-					Arg(ANY_OBJ...),
+					Arg(HASHABLE),
 				),
 				ReturnPattern: Args(
-					Arg(ANY_OBJ...),
+					Arg(ANY),
 				),
 			},
 			method: func(o Object, args []Object, _ Environment) Object {
 				h := o.(*Hash)
 
-				key, ok := args[0].(Hashable)
-				if !ok {
-					return NewErrorFormat("unusable as hash key: %s", args[0].Type())
+				hashed, err := hashKeyOf(args[0])
+				if err != nil {
+					return err
 				}
 
-				hashed := key.HashKey()
 				pair, found := h.Pairs[hashed]
 				if !found {
 					return NIL

--- a/object/hash_test.go
+++ b/object/hash_test.go
@@ -33,7 +33,7 @@ func TestHashObjectMethods(t *testing.T) {
 		{`{"a": 1, 1: "b"}.include?("a")`, true},
 		{`{"a": 1, 1: "b"}.include?(1)`, true},
 		{`{"a": 1, 1: "b"}.include?("c")`, false},
-		{`{"a": 1, 1: "b"}.include?(nil)`, `wrong argument type on position 1: got=NIL, want=BOOLEAN|STRING|INTEGER|FLOAT|ARRAY|HASH`},
+		{`{"a": 1, 1: "b"}.include?(nil)`, `wrong argument type on position 1: got=NIL, want=HASHABLE`},
 		{`{"a": 1, 1: "b"}.include?()`, `to few arguments: got=0, want=1`},
 		{`{"a": 1, "b": 2}.get("a", 10)`, 1},
 		{`{"a": 1, "b": 2}.get("c", 10)`, 10},
@@ -122,7 +122,7 @@ func TestHashRubyMethods(t *testing.T) {
 		{`{"a": 1}.fetch("a")`, 1},
 		{`{"a": 1}.fetch("z", 0)`, 0},
 		{`{"a": 1}.fetch("z")`, `key not found: "z"`},
-		{`{"a": 1}.fetch(nil)`, "unusable as hash key: NIL"},
+		{`{"a": 1}.fetch(nil)`, "wrong argument type on position 1: got=NIL, want=HASHABLE"},
 
 		// delete reports the value that went, or nil when nothing did.
 		{`h = {"a": 1}; h.delete("a")`, 1},

--- a/object/matrix.go
+++ b/object/matrix.go
@@ -340,7 +340,7 @@ func init() {
 		},
 		"set": {
 			Layout: MethodLayout{
-				ArgPattern:    Args(Arg(INTEGER_OBJ), Arg(INTEGER_OBJ), Arg(FLOAT_OBJ, INTEGER_OBJ)),
+				ArgPattern:    Args(Arg(INTEGER_OBJ), Arg(INTEGER_OBJ), Arg(NUMERIC)),
 				ReturnPattern: Args(Arg(NIL_OBJ, ERROR_OBJ)),
 			},
 			method: func(o Object, args []Object, _ Environment) Object {

--- a/object/object.go
+++ b/object/object.go
@@ -51,16 +51,44 @@ type Floatable interface {
 	ToFloatObj() Object
 }
 
-var ANY_OBJ = []string{
-	INTEGER_OBJ,
-	STRING_OBJ,
-	BOOLEAN_OBJ,
-	ARRAY_OBJ,
-	HASH_OBJ,
-	MATRIX_OBJ,
-	FLOAT_OBJ,
-	ERROR_OBJ,
-	NIL_OBJ,
+// Type groups name a set of accepted types by what an object can do rather than
+// by listing the types that can do it. They go wherever an ObjectType goes:
+// Arg(HASHABLE), OptArg(ANY), OverloadArg(NUMERIC).
+//
+// Listing types by hand is what these replace. "Any value" used to be written
+// four different ways, no two of them the same set: push accepted FUNCTION but
+// not FLOAT, so [1].push(1.5) was an error, and include? accepted neither FLOAT
+// nor MATRIX. A group is checked by asking the object, so a type added later
+// joins without anyone remembering to update a list.
+const (
+	// ANY accepts every object.
+	ANY = "ANY"
+	// HASHABLE accepts what can be a hash key, which is what a Hash's key
+	// arguments need. Declaring these ANY let a NIL or a MATRIX through to an
+	// unchecked type assertion, and {"a": 1}.get(nil, 0) panicked.
+	HASHABLE = "HASHABLE"
+	// STRINGABLE accepts what has a string form.
+	STRINGABLE = "STRINGABLE"
+	// NUMERIC accepts INTEGER and FLOAT.
+	NUMERIC = "NUMERIC"
+)
+
+// typeGroups maps each group to the question it asks of an object. Where a Go
+// interface already expresses the requirement, the group asserts against it, so
+// the group and the method body cannot disagree about what qualifies.
+var typeGroups = map[string]func(Object) bool{
+	ANY: func(Object) bool { return true },
+	HASHABLE: func(o Object) bool {
+		_, ok := o.(Hashable)
+		return ok
+	},
+	STRINGABLE: func(o Object) bool {
+		_, ok := o.(Stringable)
+		return ok
+	},
+	NUMERIC: func(o Object) bool {
+		return o.Type() == INTEGER_OBJ || o.Type() == FLOAT_OBJ
+	},
 }
 
 var NUMBER_OBJ = []string{
@@ -129,10 +157,19 @@ func (a Argument) usage() string {
 
 func (a Argument) Check(o Object) bool {
 	for _, t := range a.Types {
+		if group, isGroup := typeGroups[t]; isGroup {
+			if group(o) {
+				return true
+			}
+
+			continue
+		}
+
 		if ObjectType(t) == o.Type() {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/object/object.go
+++ b/object/object.go
@@ -67,8 +67,16 @@ const (
 	// arguments need. Declaring these ANY let a NIL or a MATRIX through to an
 	// unchecked type assertion, and {"a": 1}.get(nil, 0) panicked.
 	HASHABLE = "HASHABLE"
-	// STRINGABLE accepts what has a string form.
+	// STRINGABLE accepts what has a string form, which is what join needs of
+	// every element it is given.
 	STRINGABLE = "STRINGABLE"
+	// INTEGERABLE accepts what can be read as an integer. Wider than NUMERIC: a
+	// string that parses and a boolean qualify, which is why ["12"].sum() is 12.
+	INTEGERABLE = "INTEGERABLE"
+	// COMPARABLE accepts what can be ordered against its own kind. Ordering
+	// also requires the values to be of one type, which is a property of the
+	// collection rather than of any single value, so sort checks that on top.
+	COMPARABLE = "COMPARABLE"
 	// NUMERIC accepts INTEGER and FLOAT.
 	NUMERIC = "NUMERIC"
 )
@@ -86,14 +94,21 @@ var typeGroups = map[string]func(Object) bool{
 		_, ok := o.(Stringable)
 		return ok
 	},
+	INTEGERABLE: func(o Object) bool {
+		_, ok := o.(Integerable)
+		return ok
+	},
+	COMPARABLE: func(o Object) bool {
+		switch o.Type() {
+		case INTEGER_OBJ, FLOAT_OBJ, STRING_OBJ:
+			return true
+		default:
+			return false
+		}
+	},
 	NUMERIC: func(o Object) bool {
 		return o.Type() == INTEGER_OBJ || o.Type() == FLOAT_OBJ
 	},
-}
-
-var NUMBER_OBJ = []string{
-	INTEGER_OBJ,
-	FLOAT_OBJ,
 }
 
 const (
@@ -153,6 +168,19 @@ func (a Argument) usage() string {
 	}
 
 	return rendered
+}
+
+// InGroup reports whether o belongs to the named group. Argument patterns get
+// this through Check; method bodies need it directly, because a requirement on
+// the elements of a collection is not something an argument pattern can state:
+// join needs every element STRINGABLE, not its separator.
+func InGroup(group string, o Object) bool {
+	check, ok := typeGroups[group]
+	if !ok {
+		return false
+	}
+
+	return check(o)
 }
 
 func (a Argument) Check(o Object) bool {

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -464,3 +464,123 @@ func watMethodName(line string) string {
 
 	return name
 }
+
+// TestTypeGroups covers the argument groups introduced for #296. A group names
+// what an object must be able to do instead of listing the types that can do it,
+// which is how push came to accept FUNCTION but not FLOAT.
+func TestTypeGroups(t *testing.T) {
+	tests := []inputTestCase{
+		// ANY takes everything, so these are no longer type errors. Each of
+		// them was one, because the hand-written list behind it had forgotten
+		// FLOAT and MATRIX.
+		{`a = [1]; a.push(1.5); a.to_json()`, "[1,1.5]"},
+		{`a = [1]; a.unshift(1.5); a.to_json()`, "[1.5,1]"},
+		{`a = [1]; a.insert(0, 1.5); a.to_json()`, "[1.5,1]"},
+		{`[1.5].include?(1.5)`, true},
+		{`[1.5].index(1.5)`, 0},
+		{`[1.5].rindex(1.5)`, 0},
+		{`[1.5].count(1.5)`, 1},
+		{`a = [1.5]; a.delete(1.5); a.to_json()`, "[]"},
+		{`a = [1]; a.push([[1,2]].to_m()); a.size()`, 2},
+		{`[1].include?([[1,2]].to_m())`, false},
+
+		// HASHABLE takes what can be a key. get and include? used to assert
+		// without checking, so {"a": 1}.get(nil, 0) panicked and took the
+		// process with it.
+		{`{"a": 1}.get(nil, 0)`, "wrong argument type on position 1: got=NIL, want=HASHABLE"},
+		{`{"a": 1}.get([[1,2]].to_m(), 0)`, "wrong argument type on position 1: got=MATRIX, want=HASHABLE"},
+		{`{"a": 1}.include?(nil)`, "wrong argument type on position 1: got=NIL, want=HASHABLE"},
+		{`{"a": 1}.fetch(nil)`, "wrong argument type on position 1: got=NIL, want=HASHABLE"},
+		{`{"a": 1}.delete(nil)`, "wrong argument type on position 1: got=NIL, want=HASHABLE"},
+		// All four take the same keys, which was not true before: get accepted
+		// a NIL and crashed, include? rejected a FLOAT, delete accepted one.
+		{`{1.5: "a"}.get(1.5, "missing")`, "a"},
+		{`{1.5: "a"}.include?(1.5)`, true},
+		{`{1.5: "a"}.fetch(1.5)`, "a"},
+		{`h = {1.5: "a"}; h.delete(1.5)`, "a"},
+		// A hash and an array are hashable, so they are keys too.
+		{`{[1]: "a"}.get([1], "missing")`, "a"},
+
+		// The fallback value of get and fetch is ANY, not HASHABLE -- it is
+		// never used as a key.
+		{`{"a": 1}.get("z", nil)`, nil},
+		{`{"a": 1}.fetch("z", nil)`, nil},
+
+		// NUMERIC takes INTEGER or FLOAT.
+		{`m = [[1,2]].to_m(); m.set(0, 0, 9); m.to_a().to_json()`, "[[9,2]]"},
+		{`m = [[1,2]].to_m(); m.set(0, 0, 9.5); m.to_a().to_json()`, "[[9.5,2]]"},
+		{`[[1,2]].to_m().set(0, 0, "x")`, "wrong argument type on position 3: got=STRING, want=NUMERIC"},
+		{`[[1,2]].to_m().set(0, 0, nil)`, "wrong argument type on position 3: got=NIL, want=NUMERIC"},
+	}
+	testInput(t, tests)
+}
+
+// TestTypeGroupsRenderInSignatures checks that a group prints as its own name
+// rather than expanding. Hash#fetch used to render as a 118-character union of
+// nine types repeated twice, which told the reader nothing.
+func TestTypeGroupsRenderInSignatures(t *testing.T) {
+	tests := []struct {
+		name   string
+		layout object.MethodLayout
+		want   string
+	}{
+		{
+			"push",
+			object.MethodLayout{ArgPattern: object.Args(object.Arg(object.ANY))},
+			"push(ANY)",
+		},
+		{
+			"fetch",
+			object.MethodLayout{ArgPattern: object.Args(
+				object.Arg(object.HASHABLE),
+				object.OptArg(object.ANY),
+			)},
+			"fetch(HASHABLE, [ANY])",
+		},
+		{
+			"set",
+			object.MethodLayout{ArgPattern: object.Args(object.Arg(object.NUMERIC))},
+			"set(NUMERIC)",
+		},
+		{
+			"format",
+			object.MethodLayout{ArgPattern: object.Args(object.OverloadArg(object.ANY))},
+			"format(ANY...)",
+		},
+		{
+			// A group and a concrete type can sit in the same argument.
+			"mixed",
+			object.MethodLayout{ArgPattern: object.Args(
+				object.Arg(object.NUMERIC, object.STRING_OBJ),
+			)},
+			"mixed(NUMERIC|STRING)",
+		},
+	}
+
+	for _, tt := range tests {
+		if got := tt.layout.Usage(tt.name); got != tt.want {
+			t.Errorf("Usage(%q) = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+}
+
+// TestTypeGroupNamesDoNotCollideWithTypes guards the one thing that would make
+// groups silently wrong: a group shares its namespace with the object type
+// names, so a group called STRING would shadow the type.
+func TestTypeGroupNamesDoNotCollideWithTypes(t *testing.T) {
+	groups := []string{object.ANY, object.HASHABLE, object.STRINGABLE, object.NUMERIC}
+
+	types := []string{
+		object.INTEGER_OBJ, object.STRING_OBJ, object.BOOLEAN_OBJ, object.ARRAY_OBJ,
+		object.HASH_OBJ, object.MATRIX_OBJ, object.FLOAT_OBJ, object.ERROR_OBJ,
+		object.NIL_OBJ, object.FILE_OBJ, object.FUNCTION_OBJ, object.HTTP_OBJ,
+	}
+
+	for _, group := range groups {
+		for _, objType := range types {
+			if group == objType {
+				t.Errorf("type group %q collides with the object type of the same name", group)
+			}
+		}
+	}
+}

--- a/object/string.go
+++ b/object/string.go
@@ -53,7 +53,7 @@ func init() {
 		"format": ObjectMethod{
 			Layout: MethodLayout{
 				ArgPattern: Args(
-					OverloadArg(STRING_OBJ, INTEGER_OBJ, FLOAT_OBJ, BOOLEAN_OBJ, ARRAY_OBJ, HASH_OBJ),
+					OverloadArg(ANY),
 				),
 				ReturnPattern: Args(
 					Arg(STRING_OBJ),

--- a/stdlib/std.go
+++ b/stdlib/std.go
@@ -8,7 +8,7 @@ var Functions = map[string]*object.BuiltinFunction{}
 var Modules = map[string]*object.BuiltinModule{}
 
 func init() {
-	RegisterFunction("puts", object.MethodLayout{ArgPattern: object.Args(object.Arg(object.ANY_OBJ...))}, putsFunction)
+	RegisterFunction("puts", object.MethodLayout{ArgPattern: object.Args(object.Arg(object.ANY))}, putsFunction)
 	RegisterFunction(
 		"raise",
 		object.MethodLayout{


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.98.0
Closes #296. Two commits: groups for argument patterns, then the same groups for element requirements.

## 1. The bugs

Argument patterns spelled out every accepted type by hand. "Any value" was written four different ways, no two the same set:

| Expression | Before | After |
| --- | --- | --- |
| `[1].push(1.5)` | `ERROR: got=FLOAT, want=STRING\|ARRAY\|HASH\|BOOLEAN\|INTEGER\|NIL\|FUNCTION\|FILE` | `[1, 1.5]` |
| `[1].push([[1,2]].to_m())` | same error, `got=MATRIX` | works |
| `[1.5].include?(1.5)` | `ERROR: got=FLOAT, …` | `true` |
| `[1.5].index(1.5)` | `ERROR` | `0` |
| `[1].unshift(1.5)` | `ERROR` | `[1.5, 1]` |
| `[1].insert(0, 1.5)` | `ERROR` | `[1.5, 1]` |
| `[1.5].count(1.5)` | `1` — `count` used `ANY_OBJ`, which *has* FLOAT | `1` |

You could not push a float into an array. Two of the four lists were the same six types in a different order, so they rendered differently in the docs for no reason.

## 2. The crash

`ANY_OBJ` was used for arguments that become hash keys, and it contains `NIL` and `MATRIX`, neither of which is `Hashable`. `include?` and `get` asserted without checking:

```
🚀 » {"a": 1}.get(nil, 0)
panic: interface conversion: *object.Nil is not object.Hashable: missing method HashKey
```

That killed the REPL, the same shape as #291. Four methods take a hash key and each handled it differently:

| | Before | After |
| --- | --- | --- |
| `{"a":1}.get(nil, 0)` | **panic** | `ERROR: … want=HASHABLE` |
| `{"a":1}.get([[1,2]].to_m(), 0)` | **panic** | `ERROR: … want=HASHABLE` |
| `{"a":1}.delete(nil)` | `ERROR: unusable as hash key: NIL` | `ERROR: … want=HASHABLE` |
| `{"a":1}.fetch(nil)` | `ERROR: unusable as hash key: NIL` | `ERROR: … want=HASHABLE` |
| `{"a":1}.include?(nil)` | `ERROR: … want=BOOLEAN\|STRING\|INTEGER\|FLOAT\|ARRAY\|HASH` | `ERROR: … want=HASHABLE` |

## 3. The groups

| Group | Accepts | Checked by |
| --- | --- | --- |
| `ANY` | every value | always true |
| `HASHABLE` | usable as a hash key | the `Hashable` interface |
| `STRINGABLE` | has a string form | the `Stringable` interface |
| `INTEGERABLE` | readable as an integer | the `Integerable` interface |
| `COMPARABLE` | `STRING`, `INTEGER`, `FLOAT` | type comparison |
| `NUMERIC` | `INTEGER`, `FLOAT` | type comparison |

A group asks the object what it can do, against the Go interface that already expressed the requirement — so a group and the method body cannot disagree, and a type added to the language joins the group it qualifies for without anyone updating a list.

Groups share the namespace with the type names, so no new constructors were needed: `Arg(HASHABLE)`, `OptArg(ANY)`, `OverloadArg(ANY)` all work, and a group can sit beside a concrete type (`Arg(NUMERIC, STRING)`). A test guards the one thing that would make this silently wrong — a group named after an existing type.

`ANY_OBJ` is retired; its 20 uses became `ANY`, except the Hash key arguments, which became `HASHABLE`. `NUMBER_OBJ` is removed too — an unused list of INTEGER and FLOAT, which is what `NUMERIC` says. The four hash-key methods share one `hashKeyOf` helper so none can panic even if a pattern is widened later, and `Hash.Set`, called from Go where no pattern guards it, drops an unhashable key rather than crashing.

## 4. Groups describe elements too

A signature can only state what the *arguments* must be, but four methods place their requirement on the **elements** they are given — which is why `STRINGABLE` initially went in unused and `COMPARABLE` was missing. Each had invented its own wording:

| | Before | After |
| --- | --- | --- |
| `[def() end].join()` | `Found non stringable element FUNCTION on index 0` | `element 0 is not STRINGABLE, got FUNCTION` |
| `[1, nil].sum()` | `Found non number element NIL on index 1` | `element 1 is not INTEGERABLE, got NIL` |
| `[1, nil].uniq()` | `failed because element NIL is not hashable` | `element 1 is not HASHABLE, got NIL` |
| `[1, nil].sort()` | `Array does contain either an object not INTEGER, FLOAT or STRING or is mixed` | `element 1 is not COMPARABLE, got NIL` |

`sort` gains the most: its message named neither the element at fault nor which of its two rules had broken, so `[1, nil].sort()` and `[1, 2.5].sort()` said exactly the same thing. Ordering carries one rule no per-element group can express — the elements must be the *same* comparable type, a property of the collection — so that keeps its own message, and it now names both types:

```
[1, 2.5].sort()  →  elements must all be one COMPARABLE type, got INTEGER at 0 and FLOAT at 1
```

Checking both rules up front also let the comparison functions drop their per-call `ok` checks and the `sortError` flag that `sort.SliceStable` might or might not have reached.

`sum` needs `INTEGERABLE`, not `NUMERIC` — the group is wider than "is a number", which is why `["12"].sum()` is `12` and `[true].sum()` is `1`. Being convertible is still not converting, and that failure is now reported separately rather than blamed on the type: `["abc"].sum()` says the element does not convert.

## 5. Signatures got shorter

18 change. The longest went from 124 characters to 22:

```
fetch(INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL, [INTEGER|STRING|BOOLEAN|ARRAY|HASH|MATRIX|FLOAT|ERROR|NIL])
fetch(HASHABLE, [ANY])
```

| Before | After |
| --- | --- |
| `push(STRING\|ARRAY\|HASH\|BOOLEAN\|INTEGER\|NIL\|FUNCTION\|FILE)` | `push(ANY)` |
| `include?(BOOLEAN\|STRING\|INTEGER\|FLOAT\|ARRAY\|HASH)` (HASH) | `include?(HASHABLE)` |
| `include?(STRING\|ARRAY\|HASH\|BOOLEAN\|INTEGER\|NIL\|FILE)` (ARRAY) | `include?(ANY)` |
| `get(INTEGER\|STRING\|…\|NIL, INTEGER\|STRING\|…\|NIL)` | `get(HASHABLE, ANY)` |
| `format((STRING\|INTEGER\|FLOAT\|BOOLEAN\|ARRAY\|HASH)...)` | `format(ANY...)` |
| `set(INTEGER, INTEGER, FLOAT\|INTEGER)` | `set(INTEGER, INTEGER, NUMERIC)` |

The `language/methods` page gains a "Reading a signature" section: the groups table, the optional/variadic notation from #295, and what a group can and cannot state.

## Verification

| Check | Result |
| --- | --- |
| `go test ./...` | green |
| documented examples | 160, 0 mismatches |
| tracked `.rl` files vs a `main` binary | 42/42 byte-identical |
| `yarn build` | succeeds |
| `GOOS=js GOARCH=wasm go build` | succeeds |
| `sum` behaviour unchanged | `["12"]`→12, `[true]`→1, `[1.9]`→1, `[1,2]`→3 |

Every test expectation that changed was taken from the interpreter rather than written by hand. New tests mutation-tested: widening `HASHABLE`, `INTEGERABLE` or `COMPARABLE`, narrowing `NUMERIC`, skipping the group lookup in `Check`, skipping `requireElements`, dropping sort's same-type rule, and reporting the wrong element index are each caught.

One mutation survives by design — `hashKeyOf`'s error branch is unreachable from the interpreter, because the `HASHABLE` pattern rejects those inputs first. It is a guard against a future pattern widening, not live logic.

## 6. Documentation

New page: **Types and type groups** (`docs/language/types`).

| Section | Contents |
| --- | --- |
| The types | all 13 types, how to get one, where its own methods are documented |
| Type groups | the six groups and what each accepts |
| What belongs to what | a 13 x 6 membership matrix |
| Where groups show up | in a signature, and in a requirement on elements |

The groups had been wedged into the Methods page inside a section about reading a signature, which was the wrong home: they describe *values*, they appear in error messages as well as signatures, and half of them constrain elements rather than arguments. Methods keeps the notation table and links across.

The matrix is generated from `object.InGroup` and diffed against the page — 13 types x 6 groups, 0 disagreements. Two rows got a callout because neither is guessable: a `BOOLEAN` is `INTEGERABLE`, and an `ARRAY` is `HASHABLE`, so `{[1]: "a"}` is a valid hash.

Writing the page turned up that **`0x1f`, `0b101` and `0o17` are not integer literals** — they are parse errors. An integer carries a base and prints in it, but the only way to make one is `"0x1f".to_i()`. The page says so; recorded in the backlog as a separate gap.
