### PR TITLE
feat(object): add is_a? and type_groups

### DIFF
--- a/docs/docs/language/types.md
+++ b/docs/docs/language/types.md
@@ -32,9 +32,9 @@ Every value in RocketLang has a type, and `type()` reports it:
 
 Every type also answers the
 [generic methods](../literals/string#generic-literal-methods)
-`to_s`, `to_i`, `to_f`, `to_json`, `type`, `methods`, `wat` and `nil?` — except a
-`MODULE`, which only exposes what the module exports, so `lib.type()` is an
-error rather than `"MODULE"`.
+`to_s`, `to_i`, `to_f`, `to_json`, `type`, `type_groups`, `methods`, `wat`,
+`is_a?` and `nil?` — except a `MODULE`, which only exposes what the module
+exports, so `lib.type()` is an error rather than `"MODULE"`.
 
 ## Type groups
 
@@ -86,6 +86,43 @@ A group is decided by asking the value what it can do, not by comparing it
 against a list of type names. A type added to the language therefore joins every
 group it qualifies for without anyone maintaining a list — which is how
 `push` once came to accept a `FUNCTION` but reject a `FLOAT`.
+
+### Asking a value
+
+`type_groups()` lists the groups a value belongs to, and `is_a?` answers for one
+of them:
+
+```js
+🚀 > 1.type_groups()
+=> ["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+🚀 > def() end.type_groups()
+=> ["ANY"]
+🚀 > "a".is_a?("HASHABLE")
+=> true
+🚀 > nil.is_a?("HASHABLE")
+=> false
+```
+
+`is_a?` takes a type name as readily as a group name, so it covers both
+questions:
+
+```js
+🚀 > "a".is_a?("STRING")
+=> true
+🚀 > "a".is_a?("INTEGER")
+=> false
+```
+
+A name that is neither is an error rather than a `false`, because a typo would
+otherwise read as a real answer:
+
+```js
+🚀 > "a".is_a?("HASHBALE")
+=> ERROR: unknown type or type group: HASHBALE
+```
+
+The names are exact, and `type()` answers in upper case, so `is_a?` asks in it:
+`is_a?("string")` is an error too.
 
 ## Where groups show up
 

--- a/docs/docs/literals/array.md
+++ b/docs/docs/literals/array.md
@@ -561,6 +561,25 @@ a
 
 ## Generic Literal Methods
 
+### is_a?(STRING)
+> Returns `BOOLEAN|ERROR`
+
+Returns `true` when the value is of the given type or belongs to the given type group, so one question covers both. The name has to be one that exists: anything else is an error rather than a `false`, because a typo would otherwise read as a real answer. See [Types and type groups](/docs/language/types).
+
+
+<CodeBlockSimple input='nil.is_a?("NIL")
+"a".is_a?("HASHABLE")
+nil.is_a?("HASHABLE")
+true.is_a?("INTEGERABLE")
+"a".is_a?("INTEGER")
+' output='true
+true
+false
+true
+false
+' />
+
+
 ### methods()
 > Returns `ARRAY`
 
@@ -677,6 +696,21 @@ Returns the type of the object.
 
 <CodeBlockSimple input='"test".type()
 ' output='"STRING"
+' />
+
+
+### type_groups()
+> Returns `ARRAY`
+
+Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means.
+
+
+<CodeBlockSimple input='1.type_groups()
+nil.type_groups()
+def() end.type_groups()
+' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+["ANY", "STRINGABLE"]
+["ANY"]
 ' />
 
 

--- a/docs/docs/literals/boolean.md
+++ b/docs/docs/literals/boolean.md
@@ -24,6 +24,25 @@ is_true = a != b;
 
 ## Generic Literal Methods
 
+### is_a?(STRING)
+> Returns `BOOLEAN|ERROR`
+
+Returns `true` when the value is of the given type or belongs to the given type group, so one question covers both. The name has to be one that exists: anything else is an error rather than a `false`, because a typo would otherwise read as a real answer. See [Types and type groups](/docs/language/types).
+
+
+<CodeBlockSimple input='nil.is_a?("NIL")
+"a".is_a?("HASHABLE")
+nil.is_a?("HASHABLE")
+true.is_a?("INTEGERABLE")
+"a".is_a?("INTEGER")
+' output='true
+true
+false
+true
+false
+' />
+
+
 ### methods()
 > Returns `ARRAY`
 
@@ -140,6 +159,21 @@ Returns the type of the object.
 
 <CodeBlockSimple input='"test".type()
 ' output='"STRING"
+' />
+
+
+### type_groups()
+> Returns `ARRAY`
+
+Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means.
+
+
+<CodeBlockSimple input='1.type_groups()
+nil.type_groups()
+def() end.type_groups()
+' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+["ANY", "STRINGABLE"]
+["ANY"]
 ' />
 
 

--- a/docs/docs/literals/error.md
+++ b/docs/docs/literals/error.md
@@ -59,6 +59,25 @@ Please note that performing `.msg()` on a ERROR object does result in a STRING o
 
 ## Generic Literal Methods
 
+### is_a?(STRING)
+> Returns `BOOLEAN|ERROR`
+
+Returns `true` when the value is of the given type or belongs to the given type group, so one question covers both. The name has to be one that exists: anything else is an error rather than a `false`, because a typo would otherwise read as a real answer. See [Types and type groups](/docs/language/types).
+
+
+<CodeBlockSimple input='nil.is_a?("NIL")
+"a".is_a?("HASHABLE")
+nil.is_a?("HASHABLE")
+true.is_a?("INTEGERABLE")
+"a".is_a?("INTEGER")
+' output='true
+true
+false
+true
+false
+' />
+
+
 ### methods()
 > Returns `ARRAY`
 
@@ -175,6 +194,21 @@ Returns the type of the object.
 
 <CodeBlockSimple input='"test".type()
 ' output='"STRING"
+' />
+
+
+### type_groups()
+> Returns `ARRAY`
+
+Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means.
+
+
+<CodeBlockSimple input='1.type_groups()
+nil.type_groups()
+def() end.type_groups()
+' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+["ANY", "STRINGABLE"]
+["ANY"]
 ' />
 
 

--- a/docs/docs/literals/file.md
+++ b/docs/docs/literals/file.md
@@ -78,6 +78,25 @@ Writes the given string to the file. Returns number of written bytes on success.
 
 ## Generic Literal Methods
 
+### is_a?(STRING)
+> Returns `BOOLEAN|ERROR`
+
+Returns `true` when the value is of the given type or belongs to the given type group, so one question covers both. The name has to be one that exists: anything else is an error rather than a `false`, because a typo would otherwise read as a real answer. See [Types and type groups](/docs/language/types).
+
+
+<CodeBlockSimple input='nil.is_a?("NIL")
+"a".is_a?("HASHABLE")
+nil.is_a?("HASHABLE")
+true.is_a?("INTEGERABLE")
+"a".is_a?("INTEGER")
+' output='true
+true
+false
+true
+false
+' />
+
+
 ### methods()
 > Returns `ARRAY`
 
@@ -194,6 +213,21 @@ Returns the type of the object.
 
 <CodeBlockSimple input='"test".type()
 ' output='"STRING"
+' />
+
+
+### type_groups()
+> Returns `ARRAY`
+
+Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means.
+
+
+<CodeBlockSimple input='1.type_groups()
+nil.type_groups()
+def() end.type_groups()
+' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+["ANY", "STRINGABLE"]
+["ANY"]
 ' />
 
 

--- a/docs/docs/literals/float.md
+++ b/docs/docs/literals/float.md
@@ -168,6 +168,25 @@ false
 
 ## Generic Literal Methods
 
+### is_a?(STRING)
+> Returns `BOOLEAN|ERROR`
+
+Returns `true` when the value is of the given type or belongs to the given type group, so one question covers both. The name has to be one that exists: anything else is an error rather than a `false`, because a typo would otherwise read as a real answer. See [Types and type groups](/docs/language/types).
+
+
+<CodeBlockSimple input='nil.is_a?("NIL")
+"a".is_a?("HASHABLE")
+nil.is_a?("HASHABLE")
+true.is_a?("INTEGERABLE")
+"a".is_a?("INTEGER")
+' output='true
+true
+false
+true
+false
+' />
+
+
 ### methods()
 > Returns `ARRAY`
 
@@ -284,6 +303,21 @@ Returns the type of the object.
 
 <CodeBlockSimple input='"test".type()
 ' output='"STRING"
+' />
+
+
+### type_groups()
+> Returns `ARRAY`
+
+Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means.
+
+
+<CodeBlockSimple input='1.type_groups()
+nil.type_groups()
+def() end.type_groups()
+' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+["ANY", "STRINGABLE"]
+["ANY"]
 ' />
 
 

--- a/docs/docs/literals/hash.md
+++ b/docs/docs/literals/hash.md
@@ -257,6 +257,25 @@ Returns the values of the hash, in the same unspecified order as `keys`.
 
 ## Generic Literal Methods
 
+### is_a?(STRING)
+> Returns `BOOLEAN|ERROR`
+
+Returns `true` when the value is of the given type or belongs to the given type group, so one question covers both. The name has to be one that exists: anything else is an error rather than a `false`, because a typo would otherwise read as a real answer. See [Types and type groups](/docs/language/types).
+
+
+<CodeBlockSimple input='nil.is_a?("NIL")
+"a".is_a?("HASHABLE")
+nil.is_a?("HASHABLE")
+true.is_a?("INTEGERABLE")
+"a".is_a?("INTEGER")
+' output='true
+true
+false
+true
+false
+' />
+
+
 ### methods()
 > Returns `ARRAY`
 
@@ -373,6 +392,21 @@ Returns the type of the object.
 
 <CodeBlockSimple input='"test".type()
 ' output='"STRING"
+' />
+
+
+### type_groups()
+> Returns `ARRAY`
+
+Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means.
+
+
+<CodeBlockSimple input='1.type_groups()
+nil.type_groups()
+def() end.type_groups()
+' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+["ANY", "STRINGABLE"]
+["ANY"]
 ' />
 
 

--- a/docs/docs/literals/http.md
+++ b/docs/docs/literals/http.md
@@ -58,6 +58,25 @@ Starts a blocking webserver on the given port.
 
 ## Generic Literal Methods
 
+### is_a?(STRING)
+> Returns `BOOLEAN|ERROR`
+
+Returns `true` when the value is of the given type or belongs to the given type group, so one question covers both. The name has to be one that exists: anything else is an error rather than a `false`, because a typo would otherwise read as a real answer. See [Types and type groups](/docs/language/types).
+
+
+<CodeBlockSimple input='nil.is_a?("NIL")
+"a".is_a?("HASHABLE")
+nil.is_a?("HASHABLE")
+true.is_a?("INTEGERABLE")
+"a".is_a?("INTEGER")
+' output='true
+true
+false
+true
+false
+' />
+
+
 ### methods()
 > Returns `ARRAY`
 
@@ -174,6 +193,21 @@ Returns the type of the object.
 
 <CodeBlockSimple input='"test".type()
 ' output='"STRING"
+' />
+
+
+### type_groups()
+> Returns `ARRAY`
+
+Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means.
+
+
+<CodeBlockSimple input='1.type_groups()
+nil.type_groups()
+def() end.type_groups()
+' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+["ANY", "STRINGABLE"]
+["ANY"]
 ' />
 
 

--- a/docs/docs/literals/integer.md
+++ b/docs/docs/literals/integer.md
@@ -296,6 +296,25 @@ false
 
 ## Generic Literal Methods
 
+### is_a?(STRING)
+> Returns `BOOLEAN|ERROR`
+
+Returns `true` when the value is of the given type or belongs to the given type group, so one question covers both. The name has to be one that exists: anything else is an error rather than a `false`, because a typo would otherwise read as a real answer. See [Types and type groups](/docs/language/types).
+
+
+<CodeBlockSimple input='nil.is_a?("NIL")
+"a".is_a?("HASHABLE")
+nil.is_a?("HASHABLE")
+true.is_a?("INTEGERABLE")
+"a".is_a?("INTEGER")
+' output='true
+true
+false
+true
+false
+' />
+
+
 ### methods()
 > Returns `ARRAY`
 
@@ -412,6 +431,21 @@ Returns the type of the object.
 
 <CodeBlockSimple input='"test".type()
 ' output='"STRING"
+' />
+
+
+### type_groups()
+> Returns `ARRAY`
+
+Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means.
+
+
+<CodeBlockSimple input='1.type_groups()
+nil.type_groups()
+def() end.type_groups()
+' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+["ANY", "STRINGABLE"]
+["ANY"]
 ' />
 
 

--- a/docs/docs/literals/matrix.md
+++ b/docs/docs/literals/matrix.md
@@ -197,6 +197,25 @@ m.transpose()
 
 ## Generic Literal Methods
 
+### is_a?(STRING)
+> Returns `BOOLEAN|ERROR`
+
+Returns `true` when the value is of the given type or belongs to the given type group, so one question covers both. The name has to be one that exists: anything else is an error rather than a `false`, because a typo would otherwise read as a real answer. See [Types and type groups](/docs/language/types).
+
+
+<CodeBlockSimple input='nil.is_a?("NIL")
+"a".is_a?("HASHABLE")
+nil.is_a?("HASHABLE")
+true.is_a?("INTEGERABLE")
+"a".is_a?("INTEGER")
+' output='true
+true
+false
+true
+false
+' />
+
+
 ### methods()
 > Returns `ARRAY`
 
@@ -313,6 +332,21 @@ Returns the type of the object.
 
 <CodeBlockSimple input='"test".type()
 ' output='"STRING"
+' />
+
+
+### type_groups()
+> Returns `ARRAY`
+
+Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means.
+
+
+<CodeBlockSimple input='1.type_groups()
+nil.type_groups()
+def() end.type_groups()
+' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+["ANY", "STRINGABLE"]
+["ANY"]
 ' />
 
 

--- a/docs/docs/literals/nil.md
+++ b/docs/docs/literals/nil.md
@@ -12,6 +12,25 @@ It will be returned if something returns nothing (eg. puts or an empty break/nex
 
 ## Generic Literal Methods
 
+### is_a?(STRING)
+> Returns `BOOLEAN|ERROR`
+
+Returns `true` when the value is of the given type or belongs to the given type group, so one question covers both. The name has to be one that exists: anything else is an error rather than a `false`, because a typo would otherwise read as a real answer. See [Types and type groups](/docs/language/types).
+
+
+<CodeBlockSimple input='nil.is_a?("NIL")
+"a".is_a?("HASHABLE")
+nil.is_a?("HASHABLE")
+true.is_a?("INTEGERABLE")
+"a".is_a?("INTEGER")
+' output='true
+true
+false
+true
+false
+' />
+
+
 ### methods()
 > Returns `ARRAY`
 
@@ -128,6 +147,21 @@ Returns the type of the object.
 
 <CodeBlockSimple input='"test".type()
 ' output='"STRING"
+' />
+
+
+### type_groups()
+> Returns `ARRAY`
+
+Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means.
+
+
+<CodeBlockSimple input='1.type_groups()
+nil.type_groups()
+def() end.type_groups()
+' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+["ANY", "STRINGABLE"]
+["ANY"]
 ' />
 
 

--- a/docs/docs/literals/string.md
+++ b/docs/docs/literals/string.md
@@ -547,6 +547,25 @@ a
 
 ## Generic Literal Methods
 
+### is_a?(STRING)
+> Returns `BOOLEAN|ERROR`
+
+Returns `true` when the value is of the given type or belongs to the given type group, so one question covers both. The name has to be one that exists: anything else is an error rather than a `false`, because a typo would otherwise read as a real answer. See [Types and type groups](/docs/language/types).
+
+
+<CodeBlockSimple input='nil.is_a?("NIL")
+"a".is_a?("HASHABLE")
+nil.is_a?("HASHABLE")
+true.is_a?("INTEGERABLE")
+"a".is_a?("INTEGER")
+' output='true
+true
+false
+true
+false
+' />
+
+
 ### methods()
 > Returns `ARRAY`
 
@@ -663,6 +682,21 @@ Returns the type of the object.
 
 <CodeBlockSimple input='"test".type()
 ' output='"STRING"
+' />
+
+
+### type_groups()
+> Returns `ARRAY`
+
+Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means.
+
+
+<CodeBlockSimple input='1.type_groups()
+nil.type_groups()
+def() end.type_groups()
+' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+["ANY", "STRINGABLE"]
+["ANY"]
 ' />
 
 

--- a/docs/literals/object.yml
+++ b/docs/literals/object.yml
@@ -1,4 +1,28 @@
 methods:
+  is_a?:
+    description: "Returns `true` when the value is of the given type or belongs to the given type group, so one question covers both. The name has to be one that exists: anything else is an error rather than a `false`, because a typo would otherwise read as a real answer. See [Types and type groups](/docs/language/types)."
+    input: |
+      nil.is_a?("NIL")
+      "a".is_a?("HASHABLE")
+      nil.is_a?("HASHABLE")
+      true.is_a?("INTEGERABLE")
+      "a".is_a?("INTEGER")
+    output: |
+      true
+      true
+      false
+      true
+      false
+  type_groups:
+    description: "Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means."
+    input: |
+      1.type_groups()
+      nil.type_groups()
+      def() end.type_groups()
+    output: |
+      ["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+      ["ANY", "STRINGABLE"]
+      ["ANY"]
   methods:
     description: "Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The names are sorted, so the result is the same on every run. A type with no methods of its own returns an empty array."
     input: |

--- a/object/object.go
+++ b/object/object.go
@@ -133,6 +133,54 @@ const (
 	BUILTIN_PROPERTY_OBJ = "BUILTIN_PROPERTY"
 )
 
+// knownObjectTypes is every name a type can go by, which is what lets is_a?
+// tell an unknown name from one that simply does not match. A new type belongs
+// here; TestKnownObjectTypesAreComplete checks the ones that register methods.
+var knownObjectTypes = map[string]bool{
+	INTEGER_OBJ:          true,
+	FLOAT_OBJ:            true,
+	BOOLEAN_OBJ:          true,
+	NIL_OBJ:              true,
+	RETURN_VALUE_OBJ:     true,
+	BREAK_VALUE_OBJ:      true,
+	NEXT_VALUE_OBJ:       true,
+	ERROR_OBJ:            true,
+	FUNCTION_OBJ:         true,
+	STRING_OBJ:           true,
+	ARRAY_OBJ:            true,
+	HASH_OBJ:             true,
+	MATRIX_OBJ:           true,
+	FILE_OBJ:             true,
+	MODULE_OBJ:           true,
+	HTTP_OBJ:             true,
+	BUILTIN_MODULE_OBJ:   true,
+	BUILTIN_FUNCTION_OBJ: true,
+	BUILTIN_PROPERTY_OBJ: true,
+}
+
+// KnownObjectTypes returns the type names, sorted. Exported for the tests that
+// check the type groups and is_a? against every type there is.
+func KnownObjectTypes() []string {
+	names := make([]string, 0, len(knownObjectTypes))
+	for name := range knownObjectTypes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	return names
+}
+
+// TypeGroupNames returns the group names, sorted.
+func TypeGroupNames() []string {
+	names := make([]string, 0, len(typeGroups))
+	for name := range typeGroups {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	return names
+}
+
 type Argument struct {
 	Types    []string
 	Optional bool
@@ -369,6 +417,55 @@ func init() {
 				}
 
 				return NewErrorFormat("%s is not serializable", o.Type())
+			},
+		},
+		"is_a?": ObjectMethod{
+			Layout: MethodLayout{
+				ArgPattern: Args(
+					Arg(STRING_OBJ),
+				),
+				ReturnPattern: Args(
+					Arg(BOOLEAN_OBJ, ERROR_OBJ),
+				),
+			},
+			method: func(o Object, args []Object, _ Environment) Object {
+				name := args[0].(*String).Value
+
+				// A name that is neither is a mistake rather than a "no": a
+				// typo would otherwise answer false and read as a real result.
+				if !knownObjectTypes[name] {
+					if _, isGroup := typeGroups[name]; !isGroup {
+						return NewErrorFormat("unknown type or type group: %s", name)
+					}
+				}
+
+				// The same resolution the argument patterns use, so what a
+				// value says about itself and what a method accepts can never
+				// drift apart.
+				if Arg(name).Check(o) {
+					return TRUE
+				}
+
+				return FALSE
+			},
+		},
+		"type_groups": ObjectMethod{
+			Layout: MethodLayout{
+				ReturnPattern: Args(
+					Arg(ARRAY_OBJ),
+				),
+			},
+			method: func(o Object, _ []Object, _ Environment) Object {
+				// Sorted, for the same reason methods() is: read out of the map
+				// the order differed between runs.
+				groups := make([]Object, 0, len(typeGroups))
+				for _, name := range TypeGroupNames() {
+					if typeGroups[name](o) {
+						groups = append(groups, NewString(name))
+					}
+				}
+
+				return NewArray(groups)
 			},
 		},
 		"nil?": ObjectMethod{

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -584,3 +584,127 @@ func TestTypeGroupNamesDoNotCollideWithTypes(t *testing.T) {
 		}
 	}
 }
+
+// TestIsA covers the predicate for both a type name and a group name, and the
+// mistake it has to refuse: a name that is neither.
+func TestIsA(t *testing.T) {
+	tests := []inputTestCase{
+		// A group.
+		{`"a".is_a?("HASHABLE")`, true},
+		{`nil.is_a?("HASHABLE")`, false},
+		{`1.is_a?("COMPARABLE")`, true},
+		{`true.is_a?("COMPARABLE")`, false},
+		{`true.is_a?("INTEGERABLE")`, true},
+		{`[1].is_a?("STRINGABLE")`, true},
+		{`def() end.is_a?("STRINGABLE")`, false},
+		{`1.is_a?("NUMERIC")`, true},
+		{`1.5.is_a?("NUMERIC")`, true},
+		{`"1".is_a?("NUMERIC")`, false},
+		// ANY is true for everything, including a function and a nil.
+		{`"a".is_a?("ANY")`, true},
+		{`nil.is_a?("ANY")`, true},
+		{`def() end.is_a?("ANY")`, true},
+
+		// A concrete type, which collapses type() == "X" into the same question.
+		{`"a".is_a?("STRING")`, true},
+		{`"a".is_a?("INTEGER")`, false},
+		{`1.5.is_a?("FLOAT")`, true},
+		{`1.is_a?("FLOAT")`, false},
+		{`nil.is_a?("NIL")`, true},
+		{`[1].is_a?("ARRAY")`, true},
+		{`{"a": 1}.is_a?("HASH")`, true},
+		{`def() end.is_a?("FUNCTION")`, true},
+		{`[[1,2]].to_m().is_a?("MATRIX")`, true},
+
+		// A name that is neither is an error, not a false. A typo would
+		// otherwise answer "no" and read like a real result.
+		{`"a".is_a?("HASHBALE")`, "unknown type or type group: HASHBALE"},
+		{`"a".is_a?("STRIGN")`, "unknown type or type group: STRIGN"},
+		{`"a".is_a?("")`, "unknown type or type group: "},
+		// Names are exact; type() answers in upper case, so is_a? asks in it.
+		{`"a".is_a?("hashable")`, "unknown type or type group: hashable"},
+		{`"a".is_a?("string")`, "unknown type or type group: string"},
+
+		{`"a".is_a?(1)`, "wrong argument type on position 1: got=INTEGER, want=STRING"},
+		{`"a".is_a?()`, "to few arguments: got=0, want=1"},
+	}
+	testInput(t, tests)
+}
+
+// TestTypeGroupsMethod covers the listing. The expectations are the rows of the
+// membership table in docs/docs/language/types.md, so the two cannot
+// drift apart unnoticed.
+func TestTypeGroupsMethod(t *testing.T) {
+	tests := []inputTestCase{
+		{`"a".type_groups().to_json()`, `["ANY","COMPARABLE","HASHABLE","INTEGERABLE","STRINGABLE"]`},
+		{`1.type_groups().to_json()`, `["ANY","COMPARABLE","HASHABLE","INTEGERABLE","NUMERIC","STRINGABLE"]`},
+		{`1.5.type_groups().to_json()`, `["ANY","COMPARABLE","HASHABLE","INTEGERABLE","NUMERIC","STRINGABLE"]`},
+		{`true.type_groups().to_json()`, `["ANY","HASHABLE","INTEGERABLE","STRINGABLE"]`},
+		{`[1].type_groups().to_json()`, `["ANY","HASHABLE","STRINGABLE"]`},
+		{`{"a": 1}.type_groups().to_json()`, `["ANY","HASHABLE","STRINGABLE"]`},
+		{`nil.type_groups().to_json()`, `["ANY","STRINGABLE"]`},
+		{`[[1,2]].to_m().type_groups().to_json()`, `["ANY","STRINGABLE"]`},
+		// A function belongs to nothing but ANY, which is the whole reason the
+		// element checks in join, sum, uniq and sort exist.
+		{`def() end.type_groups().to_json()`, `["ANY"]`},
+
+		{`"a".type_groups("x")`, "to many arguments: got=1, want=0"},
+	}
+	testInput(t, tests)
+}
+
+// TestIsAAgreesWithTypeGroups walks every type against every group and checks
+// that the two methods answer the same. They share one predicate, and this is
+// what keeps a future change from giving them separate copies of it.
+func TestIsAAgreesWithTypeGroups(t *testing.T) {
+	subjects := []string{
+		`"a"`, `1`, `1.5`, `true`, `[1]`, `{"a": 1}`, `nil`,
+		`[[1,2]].to_m()`, `def() end`,
+	}
+
+	for _, subject := range subjects {
+		for _, group := range object.TypeGroupNames() {
+			predicate := testEval(`(` + subject + `).is_a?("` + group + `")`)
+			listed := testEval(`(` + subject + `).type_groups().include?("` + group + `")`)
+
+			require.Equal(t, listed.Inspect(), predicate.Inspect(),
+				"is_a?(%q) and type_groups() disagree for %s", group, subject)
+		}
+
+		// A value is always its own type, whatever that is.
+		own := testEval(`(` + subject + `).is_a?((` + subject + `).type())`)
+		require.Equal(t, "true", own.Inspect(),
+			"%s should be a %s", subject, testEval(`(`+subject+`).type()`).Inspect())
+
+		// ...and belongs to ANY, whatever it is.
+		require.Equal(t, "true", testEval(`(`+subject+`).is_a?("ANY")`).Inspect(),
+			"%s should be ANY", subject)
+	}
+}
+
+// TestKnownObjectTypesAreComplete guards the list is_a? validates against. A
+// type missing from it would make is_a? report a real type name as unknown.
+func TestKnownObjectTypesAreComplete(t *testing.T) {
+	known := make(map[string]bool)
+	for _, name := range object.KnownObjectTypes() {
+		known[name] = true
+	}
+
+	for objType := range object.ListObjectMethods() {
+		name := string(objType)
+		if name == "*" {
+			continue
+		}
+		if !known[name] {
+			t.Errorf("%s registers methods but is not in KnownObjectTypes()", name)
+		}
+	}
+
+	// Every group name has to stay out of the type list, or is_a? would resolve
+	// it twice and the two answers could differ.
+	for _, group := range object.TypeGroupNames() {
+		if known[group] {
+			t.Errorf("type group %q is also listed as an object type", group)
+		}
+	}
+}


### PR DESCRIPTION
Type groups were visible only in signatures and error messages. These two methods let a program ask.

```js
🚀 > 1.type_groups()
=> ["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
🚀 > def() end.type_groups()
=> ["ANY"]
🚀 > "a".is_a?("HASHABLE")
=> true
🚀 > nil.is_a?("HASHABLE")
=> false
```

## `is_a?` covers types and groups with one question

```js
🚀 > "a".is_a?("STRING")     // a type
=> true
🚀 > "a".is_a?("HASHABLE")   // a group
=> true
```

That falls out of the existing design rather than being bolted on: `Argument.Check` already resolves a name as either a group or a concrete type in one namespace, so `is_a?` delegates to it.

```
Arg(HASHABLE  ).Check("a") = true    Arg(STRING ).Check("a") = true
Arg(COMPARABLE).Check("a") = true    Arg(INTEGER).Check("a") = false
```

What a value says about itself and what a method will accept therefore cannot drift apart — same code path, not two copies.

## An unknown name errors

| Call | Result |
| --- | --- |
| `"a".is_a?("HASHABLE")` | `true` |
| `"a".is_a?("INTEGER")` | `false` |
| `"a".is_a?("HASHBALE")` | `ERROR: unknown type or type group: HASHBALE` |
| `"a".is_a?("string")` | `ERROR: unknown type or type group: string` |
| `"a".is_a?(1)` | `ERROR: wrong argument type on position 1: got=INTEGER, want=STRING` |

A typo answering `false` would read like a real result, which is the worst way for a predicate to fail. Names are exact, matching `type()`, which answers in upper case.

This needed a list of the type names — a type name is not otherwise enumerable, so there was no way to tell an unknown name from one that merely does not match. `TestKnownObjectTypesAreComplete` checks that every type registering methods appears in it, and that no group name has crept in, which would let `is_a?` resolve one name two ways.

## `type_groups`

| Type | Groups |
| --- | --- |
| `STRING` | `ANY` `COMPARABLE` `HASHABLE` `INTEGERABLE` `STRINGABLE` |
| `INTEGER`, `FLOAT` | all six |
| `BOOLEAN` | `ANY` `HASHABLE` `INTEGERABLE` `STRINGABLE` |
| `ARRAY`, `HASH` | `ANY` `HASHABLE` `STRINGABLE` |
| `NIL`, `MATRIX` | `ANY` `STRINGABLE` |
| `FUNCTION` | `ANY` |

Sorted, for the same reason `methods()` is — read out of the map, the order differed between runs. `FUNCTION` belonging to nothing but `ANY` is exactly why the element checks in `join`, `sum`, `uniq` and `sort` exist.

## Verification

| Check | Result |
| --- | --- |
| `go test ./...` | green |
| documented examples | 162 (2 new), 0 mismatches |
| tracked `.rl` files vs a `main` binary | 42/42 byte-identical |
| `yarn build` | succeeds |
| `GOOS=js GOARCH=wasm go build` | succeeds |

Tests pin the group list per type against the membership table on the Types page, and walk every type against every group to check `is_a?` and `type_groups()` agree — plus two invariants that hold whatever the types are: a value is always its own type, and always `ANY`.

Mutation-tested: dropping the unknown-name error, restricting `is_a?` to groups only, making it always true, dropping a group from `type_groups`, and returning it unsorted are each caught.

Docs: both methods documented in `object.yml`, so they appear on every literal page, and an "Asking a value" section on the Types page.