### PR TITLE
feat(object): let a method call a user function, and add Array#each

### DIFF
--- a/docs/docs/language/types.md
+++ b/docs/docs/language/types.md
@@ -15,19 +15,19 @@ Every value in RocketLang has a type, and `type()` reports it:
 
 | Type | How you get one | Own methods |
 | ---- | --------------- | ----------- |
-| `STRING` | `"abc"`, `'abc'` | [String](../literals/string) |
-| `INTEGER` | `1`. A base prefix is not a literal: write `"0x1f".to_i()` | [Integer](../literals/integer) |
-| `FLOAT` | `1.5` | [Float](../literals/float) |
-| `BOOLEAN` | `true`, `false`, `👍`, `👎` | none |
-| `NIL` | `nil`, or anything that has nothing to return | none |
-| `ARRAY` | `[1, 2]` | [Array](../literals/array) |
-| `HASH` | `{"a": 1}` | [Hash](../literals/hash) |
-| `MATRIX` | `[[1, 2], [3, 4]].to_m()` | [Matrix](../literals/matrix) |
-| `FUNCTION` | `def(x) return x end` | none |
-| `ERROR` | a failing operation, caught with `begin`/`rescue` | [Error](../literals/error) |
-| `FILE` | `IO.open("f.txt", "r", "0644")` | [File](../literals/file) |
-| `HTTP` | `HTTP.new()` | [HTTP](../literals/http) |
-| `MODULE` | `import "./lib" as lib` | none |
+| `STRING` | [String](../literals/string) |
+| `INTEGER` | [Integer](../literals/integer) |
+| `FLOAT` | [Float](../literals/float) |
+| `BOOLEAN` | none |
+| `NIL` | none |
+| `ARRAY` | [Array](../literals/array) |
+| `HASH` | [Hash](../literals/hash) |
+| `MATRIX` | [Matrix](../literals/matrix) |
+| `FUNCTION` | none |
+| `ERROR` | [Error](../literals/error) |
+| `FILE` | [File](../literals/file) |
+| `HTTP` | [HTTP](../literals/http) |
+| `MODULE` | none |
 | `BUILTIN_MODULE` | `Math`, `IO`, `JSON`, `OS`, `Time` | see [Builtins](../builtins/Math) |
 
 Every type also answers the
@@ -58,21 +58,26 @@ they appear only in signatures and in error messages.
 
 ### What belongs to what
 
-| Type | `ANY` | `HASHABLE` | `COMPARABLE` | `STRINGABLE` | `INTEGERABLE` | `NUMERIC` | `CALLABLE` |
-| -------- | --- | --- | --- | --- | --- | --- | --- |
-| `STRING` | ✅ | ✅ | ✅ | ✅ | ✅ | | |
-| `INTEGER` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | |
-| `FLOAT` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | |
-| `BOOLEAN` | ✅ | ✅ | | ✅ | ✅ | | |
-| `ARRAY` | ✅ | ✅ | | ✅ | | | |
-| `HASH` | ✅ | ✅ | | ✅ | | | |
-| `MATRIX` | ✅ | | | ✅ | | | |
-| `NIL` | ✅ | | | ✅ | | | |
-| `ERROR` | ✅ | | | ✅ | | | |
-| `FILE` | ✅ | | | ✅ | | | |
-| `HTTP` | ✅ | | | ✅ | | | |
-| `FUNCTION` | ✅ | | | | | | ✅ |
-| `MODULE` | ✅ | | | | | | |
+`ANY` is not a row or a column here: every value belongs to it, so it says
+nothing about any particular type. It exists for signatures, where
+`push(ANY)` means the argument accepts anything.
+
+
+| Type | `HASHABLE` | `COMPARABLE` | `STRINGABLE` | `INTEGERABLE` | `NUMERIC` | `CALLABLE` |
+| -------- | --- | --- | --- | --- | --- | --- |
+| `STRING` | ✅ | ✅ | ✅ | ✅ | | |
+| `INTEGER` | ✅ | ✅ | ✅ | ✅ | ✅ | |
+| `FLOAT` | ✅ | ✅ | ✅ | ✅ | ✅ | |
+| `BOOLEAN` | ✅ | | ✅ | ✅ | | |
+| `ARRAY` | ✅ | | ✅ | | | |
+| `HASH` | ✅ | | ✅ | | | |
+| `MATRIX` | | | ✅ | | | |
+| `NIL` | | | ✅ | | | |
+| `ERROR` | | | ✅ | | | |
+| `FILE` | | | ✅ | | | |
+| `HTTP` | | | ✅ | | | |
+| `FUNCTION` | | | | | | ✅ |
+| `MODULE` | | | | | | |
 
 Two rows are worth a second look:
 
@@ -97,9 +102,9 @@ of them:
 
 ```js
 🚀 > 1.type_groups()
-=> ["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+=> ["COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
 🚀 > def() end.type_groups()
-=> ["ANY"]
+=> ["CALLABLE"]
 🚀 > "a".is_a?("HASHABLE")
 => true
 🚀 > nil.is_a?("HASHABLE")
@@ -115,6 +120,10 @@ questions:
 🚀 > "a".is_a?("INTEGER")
 => false
 ```
+
+`ANY` is missing from those lists on purpose — every value belongs to it, so it
+would only prefix every answer with the same word. `is_a?("ANY")` still answers
+`true`.
 
 A name that is neither is an error rather than a `false`, because a typo would
 otherwise read as a real answer:

--- a/docs/docs/language/types.md
+++ b/docs/docs/language/types.md
@@ -58,21 +58,21 @@ they appear only in signatures and in error messages.
 
 ### What belongs to what
 
-| Type | `ANY` | `HASHABLE` | `COMPARABLE` | `STRINGABLE` | `INTEGERABLE` | `NUMERIC` |
-| -------- | --- | --- | --- | --- | --- | --- |
-| `STRING` | ✅ | ✅ | ✅ | ✅ | ✅ | |
-| `INTEGER` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `FLOAT` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `BOOLEAN` | ✅ | ✅ | | ✅ | ✅ | |
-| `ARRAY` | ✅ | ✅ | | ✅ | | |
-| `HASH` | ✅ | ✅ | | ✅ | | |
-| `MATRIX` | ✅ | | | ✅ | | |
-| `NIL` | ✅ | | | ✅ | | |
-| `ERROR` | ✅ | | | ✅ | | |
-| `FILE` | ✅ | | | ✅ | | |
-| `HTTP` | ✅ | | | ✅ | | |
-| `FUNCTION` | ✅ | | | | | |
-| `MODULE` | ✅ | | | | | |
+| Type | `ANY` | `HASHABLE` | `COMPARABLE` | `STRINGABLE` | `INTEGERABLE` | `NUMERIC` | `CALLABLE` |
+| -------- | --- | --- | --- | --- | --- | --- | --- |
+| `STRING` | ✅ | ✅ | ✅ | ✅ | ✅ | | |
+| `INTEGER` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | |
+| `FLOAT` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | |
+| `BOOLEAN` | ✅ | ✅ | | ✅ | ✅ | | |
+| `ARRAY` | ✅ | ✅ | | ✅ | | | |
+| `HASH` | ✅ | ✅ | | ✅ | | | |
+| `MATRIX` | ✅ | | | ✅ | | | |
+| `NIL` | ✅ | | | ✅ | | | |
+| `ERROR` | ✅ | | | ✅ | | | |
+| `FILE` | ✅ | | | ✅ | | | |
+| `HTTP` | ✅ | | | ✅ | | | |
+| `FUNCTION` | ✅ | | | | | | ✅ |
+| `MODULE` | ✅ | | | | | | |
 
 Two rows are worth a second look:
 
@@ -81,6 +81,9 @@ Two rows are worth a second look:
   `[true].sum()` is `1`.
 - An `ARRAY` and a `HASH` are `HASHABLE`, so they can be hash keys:
   `{[1]: "a"}` is a valid hash.
+- A `FUNCTION` is `CALLABLE` and nothing else — not even `STRINGABLE`, which is
+  why `[def() end].join()` fails. A builtin such as `puts` is `CALLABLE` too,
+  so `[1, 2].each(puts)` works.
 
 A group is decided by asking the value what it can do, not by comparing it
 against a list of type names. A type added to the language therefore joins every

--- a/docs/docs/literals/array.md
+++ b/docs/docs/literals/array.md
@@ -149,6 +149,25 @@ Returns everything after the first n elements as a new array. Dropping more than
 ' />
 
 
+### each(CALLABLE)
+> Returns `ARRAY|ERROR`
+
+Calls the given function once for each element, passing the element, and returns the array so a walk can be chained onto. The callback can be a function or a builtin such as `puts`, which is what `CALLABLE` in the signature means. `break` inside the callback ends the walk and `next` moves it along, as they do in a `foreach`. An error from the callback ends the walk and is passed on.
+
+
+<CodeBlockSimple input='a = [1, 2, 3]
+a.each(def(x) puts(x * 2) end)
+a.each(def(x) if x == 2 break end puts(x) end).size()
+' output='[1, 2, 3]
+2
+4
+6
+[1, 2, 3]
+1
+3
+' />
+
+
 ### empty?()
 > Returns `BOOLEAN`
 
@@ -710,7 +729,7 @@ nil.type_groups()
 def() end.type_groups()
 ' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
 ["ANY", "STRINGABLE"]
-["ANY"]
+["ANY", "CALLABLE"]
 ' />
 
 

--- a/docs/docs/literals/array.md
+++ b/docs/docs/literals/array.md
@@ -721,15 +721,17 @@ Returns the type of the object.
 ### type_groups()
 > Returns `ARRAY`
 
-Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means.
+Returns the type groups the value belongs to, sorted. `ANY` is not listed: every value belongs to it, so it would say nothing while prefixing every answer. It exists for signatures, where `push(ANY)` means the argument accepts anything, and `is_a?("ANY")` still answers `true`. See [Types and type groups](/docs/language/types) for what each group means.
 
 
 <CodeBlockSimple input='1.type_groups()
 nil.type_groups()
 def() end.type_groups()
-' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
-["ANY", "STRINGABLE"]
-["ANY", "CALLABLE"]
+puts.type_groups()
+' output='["COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+["STRINGABLE"]
+["CALLABLE"]
+["CALLABLE"]
 ' />
 
 

--- a/docs/docs/literals/boolean.md
+++ b/docs/docs/literals/boolean.md
@@ -165,15 +165,17 @@ Returns the type of the object.
 ### type_groups()
 > Returns `ARRAY`
 
-Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means.
+Returns the type groups the value belongs to, sorted. `ANY` is not listed: every value belongs to it, so it would say nothing while prefixing every answer. It exists for signatures, where `push(ANY)` means the argument accepts anything, and `is_a?("ANY")` still answers `true`. See [Types and type groups](/docs/language/types) for what each group means.
 
 
 <CodeBlockSimple input='1.type_groups()
 nil.type_groups()
 def() end.type_groups()
-' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
-["ANY", "STRINGABLE"]
-["ANY", "CALLABLE"]
+puts.type_groups()
+' output='["COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+["STRINGABLE"]
+["CALLABLE"]
+["CALLABLE"]
 ' />
 
 

--- a/docs/docs/literals/boolean.md
+++ b/docs/docs/literals/boolean.md
@@ -173,7 +173,7 @@ nil.type_groups()
 def() end.type_groups()
 ' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
 ["ANY", "STRINGABLE"]
-["ANY"]
+["ANY", "CALLABLE"]
 ' />
 
 

--- a/docs/docs/literals/error.md
+++ b/docs/docs/literals/error.md
@@ -200,15 +200,17 @@ Returns the type of the object.
 ### type_groups()
 > Returns `ARRAY`
 
-Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means.
+Returns the type groups the value belongs to, sorted. `ANY` is not listed: every value belongs to it, so it would say nothing while prefixing every answer. It exists for signatures, where `push(ANY)` means the argument accepts anything, and `is_a?("ANY")` still answers `true`. See [Types and type groups](/docs/language/types) for what each group means.
 
 
 <CodeBlockSimple input='1.type_groups()
 nil.type_groups()
 def() end.type_groups()
-' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
-["ANY", "STRINGABLE"]
-["ANY", "CALLABLE"]
+puts.type_groups()
+' output='["COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+["STRINGABLE"]
+["CALLABLE"]
+["CALLABLE"]
 ' />
 
 

--- a/docs/docs/literals/error.md
+++ b/docs/docs/literals/error.md
@@ -208,7 +208,7 @@ nil.type_groups()
 def() end.type_groups()
 ' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
 ["ANY", "STRINGABLE"]
-["ANY"]
+["ANY", "CALLABLE"]
 ' />
 
 

--- a/docs/docs/literals/file.md
+++ b/docs/docs/literals/file.md
@@ -227,7 +227,7 @@ nil.type_groups()
 def() end.type_groups()
 ' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
 ["ANY", "STRINGABLE"]
-["ANY"]
+["ANY", "CALLABLE"]
 ' />
 
 

--- a/docs/docs/literals/file.md
+++ b/docs/docs/literals/file.md
@@ -219,15 +219,17 @@ Returns the type of the object.
 ### type_groups()
 > Returns `ARRAY`
 
-Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means.
+Returns the type groups the value belongs to, sorted. `ANY` is not listed: every value belongs to it, so it would say nothing while prefixing every answer. It exists for signatures, where `push(ANY)` means the argument accepts anything, and `is_a?("ANY")` still answers `true`. See [Types and type groups](/docs/language/types) for what each group means.
 
 
 <CodeBlockSimple input='1.type_groups()
 nil.type_groups()
 def() end.type_groups()
-' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
-["ANY", "STRINGABLE"]
-["ANY", "CALLABLE"]
+puts.type_groups()
+' output='["COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+["STRINGABLE"]
+["CALLABLE"]
+["CALLABLE"]
 ' />
 
 

--- a/docs/docs/literals/float.md
+++ b/docs/docs/literals/float.md
@@ -309,15 +309,17 @@ Returns the type of the object.
 ### type_groups()
 > Returns `ARRAY`
 
-Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means.
+Returns the type groups the value belongs to, sorted. `ANY` is not listed: every value belongs to it, so it would say nothing while prefixing every answer. It exists for signatures, where `push(ANY)` means the argument accepts anything, and `is_a?("ANY")` still answers `true`. See [Types and type groups](/docs/language/types) for what each group means.
 
 
 <CodeBlockSimple input='1.type_groups()
 nil.type_groups()
 def() end.type_groups()
-' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
-["ANY", "STRINGABLE"]
-["ANY", "CALLABLE"]
+puts.type_groups()
+' output='["COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+["STRINGABLE"]
+["CALLABLE"]
+["CALLABLE"]
 ' />
 
 

--- a/docs/docs/literals/float.md
+++ b/docs/docs/literals/float.md
@@ -317,7 +317,7 @@ nil.type_groups()
 def() end.type_groups()
 ' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
 ["ANY", "STRINGABLE"]
-["ANY"]
+["ANY", "CALLABLE"]
 ' />
 
 

--- a/docs/docs/literals/hash.md
+++ b/docs/docs/literals/hash.md
@@ -406,7 +406,7 @@ nil.type_groups()
 def() end.type_groups()
 ' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
 ["ANY", "STRINGABLE"]
-["ANY"]
+["ANY", "CALLABLE"]
 ' />
 
 

--- a/docs/docs/literals/hash.md
+++ b/docs/docs/literals/hash.md
@@ -398,15 +398,17 @@ Returns the type of the object.
 ### type_groups()
 > Returns `ARRAY`
 
-Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means.
+Returns the type groups the value belongs to, sorted. `ANY` is not listed: every value belongs to it, so it would say nothing while prefixing every answer. It exists for signatures, where `push(ANY)` means the argument accepts anything, and `is_a?("ANY")` still answers `true`. See [Types and type groups](/docs/language/types) for what each group means.
 
 
 <CodeBlockSimple input='1.type_groups()
 nil.type_groups()
 def() end.type_groups()
-' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
-["ANY", "STRINGABLE"]
-["ANY", "CALLABLE"]
+puts.type_groups()
+' output='["COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+["STRINGABLE"]
+["CALLABLE"]
+["CALLABLE"]
 ' />
 
 

--- a/docs/docs/literals/http.md
+++ b/docs/docs/literals/http.md
@@ -207,7 +207,7 @@ nil.type_groups()
 def() end.type_groups()
 ' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
 ["ANY", "STRINGABLE"]
-["ANY"]
+["ANY", "CALLABLE"]
 ' />
 
 

--- a/docs/docs/literals/http.md
+++ b/docs/docs/literals/http.md
@@ -199,15 +199,17 @@ Returns the type of the object.
 ### type_groups()
 > Returns `ARRAY`
 
-Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means.
+Returns the type groups the value belongs to, sorted. `ANY` is not listed: every value belongs to it, so it would say nothing while prefixing every answer. It exists for signatures, where `push(ANY)` means the argument accepts anything, and `is_a?("ANY")` still answers `true`. See [Types and type groups](/docs/language/types) for what each group means.
 
 
 <CodeBlockSimple input='1.type_groups()
 nil.type_groups()
 def() end.type_groups()
-' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
-["ANY", "STRINGABLE"]
-["ANY", "CALLABLE"]
+puts.type_groups()
+' output='["COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+["STRINGABLE"]
+["CALLABLE"]
+["CALLABLE"]
 ' />
 
 

--- a/docs/docs/literals/integer.md
+++ b/docs/docs/literals/integer.md
@@ -445,7 +445,7 @@ nil.type_groups()
 def() end.type_groups()
 ' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
 ["ANY", "STRINGABLE"]
-["ANY"]
+["ANY", "CALLABLE"]
 ' />
 
 

--- a/docs/docs/literals/integer.md
+++ b/docs/docs/literals/integer.md
@@ -437,15 +437,17 @@ Returns the type of the object.
 ### type_groups()
 > Returns `ARRAY`
 
-Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means.
+Returns the type groups the value belongs to, sorted. `ANY` is not listed: every value belongs to it, so it would say nothing while prefixing every answer. It exists for signatures, where `push(ANY)` means the argument accepts anything, and `is_a?("ANY")` still answers `true`. See [Types and type groups](/docs/language/types) for what each group means.
 
 
 <CodeBlockSimple input='1.type_groups()
 nil.type_groups()
 def() end.type_groups()
-' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
-["ANY", "STRINGABLE"]
-["ANY", "CALLABLE"]
+puts.type_groups()
+' output='["COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+["STRINGABLE"]
+["CALLABLE"]
+["CALLABLE"]
 ' />
 
 

--- a/docs/docs/literals/matrix.md
+++ b/docs/docs/literals/matrix.md
@@ -338,15 +338,17 @@ Returns the type of the object.
 ### type_groups()
 > Returns `ARRAY`
 
-Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means.
+Returns the type groups the value belongs to, sorted. `ANY` is not listed: every value belongs to it, so it would say nothing while prefixing every answer. It exists for signatures, where `push(ANY)` means the argument accepts anything, and `is_a?("ANY")` still answers `true`. See [Types and type groups](/docs/language/types) for what each group means.
 
 
 <CodeBlockSimple input='1.type_groups()
 nil.type_groups()
 def() end.type_groups()
-' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
-["ANY", "STRINGABLE"]
-["ANY", "CALLABLE"]
+puts.type_groups()
+' output='["COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+["STRINGABLE"]
+["CALLABLE"]
+["CALLABLE"]
 ' />
 
 

--- a/docs/docs/literals/matrix.md
+++ b/docs/docs/literals/matrix.md
@@ -346,7 +346,7 @@ nil.type_groups()
 def() end.type_groups()
 ' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
 ["ANY", "STRINGABLE"]
-["ANY"]
+["ANY", "CALLABLE"]
 ' />
 
 

--- a/docs/docs/literals/nil.md
+++ b/docs/docs/literals/nil.md
@@ -153,15 +153,17 @@ Returns the type of the object.
 ### type_groups()
 > Returns `ARRAY`
 
-Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means.
+Returns the type groups the value belongs to, sorted. `ANY` is not listed: every value belongs to it, so it would say nothing while prefixing every answer. It exists for signatures, where `push(ANY)` means the argument accepts anything, and `is_a?("ANY")` still answers `true`. See [Types and type groups](/docs/language/types) for what each group means.
 
 
 <CodeBlockSimple input='1.type_groups()
 nil.type_groups()
 def() end.type_groups()
-' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
-["ANY", "STRINGABLE"]
-["ANY", "CALLABLE"]
+puts.type_groups()
+' output='["COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+["STRINGABLE"]
+["CALLABLE"]
+["CALLABLE"]
 ' />
 
 

--- a/docs/docs/literals/nil.md
+++ b/docs/docs/literals/nil.md
@@ -161,7 +161,7 @@ nil.type_groups()
 def() end.type_groups()
 ' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
 ["ANY", "STRINGABLE"]
-["ANY"]
+["ANY", "CALLABLE"]
 ' />
 
 

--- a/docs/docs/literals/string.md
+++ b/docs/docs/literals/string.md
@@ -688,15 +688,17 @@ Returns the type of the object.
 ### type_groups()
 > Returns `ARRAY`
 
-Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means.
+Returns the type groups the value belongs to, sorted. `ANY` is not listed: every value belongs to it, so it would say nothing while prefixing every answer. It exists for signatures, where `push(ANY)` means the argument accepts anything, and `is_a?("ANY")` still answers `true`. See [Types and type groups](/docs/language/types) for what each group means.
 
 
 <CodeBlockSimple input='1.type_groups()
 nil.type_groups()
 def() end.type_groups()
-' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
-["ANY", "STRINGABLE"]
-["ANY", "CALLABLE"]
+puts.type_groups()
+' output='["COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+["STRINGABLE"]
+["CALLABLE"]
+["CALLABLE"]
 ' />
 
 

--- a/docs/docs/literals/string.md
+++ b/docs/docs/literals/string.md
@@ -696,7 +696,7 @@ nil.type_groups()
 def() end.type_groups()
 ' output='["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
 ["ANY", "STRINGABLE"]
-["ANY"]
+["ANY", "CALLABLE"]
 ' />
 
 

--- a/docs/literals/array.yml
+++ b/docs/literals/array.yml
@@ -99,6 +99,20 @@ methods:
     output: |
       [3]
       []
+  each:
+    description: "Calls the given function once for each element, passing the element, and returns the array so a walk can be chained onto. The callback can be a function or a builtin such as `puts`, which is what `CALLABLE` in the signature means. `break` inside the callback ends the walk and `next` moves it along, as they do in a `foreach`. An error from the callback ends the walk and is passed on."
+    input: |
+      a = [1, 2, 3]
+      a.each(def(x) puts(x * 2) end)
+      a.each(def(x) if x == 2 break end puts(x) end).size()
+    output: |
+      [1, 2, 3]
+      2
+      4
+      6
+      [1, 2, 3]
+      1
+      3
   empty?:
     description: "Returns `true` when the array has no elements."
     input: |

--- a/docs/literals/object.yml
+++ b/docs/literals/object.yml
@@ -22,7 +22,7 @@ methods:
     output: |
       ["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
       ["ANY", "STRINGABLE"]
-      ["ANY"]
+      ["ANY", "CALLABLE"]
   methods:
     description: "Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The names are sorted, so the result is the same on every run. A type with no methods of its own returns an empty array."
     input: |

--- a/docs/literals/object.yml
+++ b/docs/literals/object.yml
@@ -14,15 +14,17 @@ methods:
       true
       false
   type_groups:
-    description: "Returns the type groups the value belongs to, sorted. `ANY` is in every list. See [Types and type groups](/docs/language/types) for what each group means."
+    description: "Returns the type groups the value belongs to, sorted. `ANY` is not listed: every value belongs to it, so it would say nothing while prefixing every answer. It exists for signatures, where `push(ANY)` means the argument accepts anything, and `is_a?(\"ANY\")` still answers `true`. See [Types and type groups](/docs/language/types) for what each group means."
     input: |
       1.type_groups()
       nil.type_groups()
       def() end.type_groups()
+      puts.type_groups()
     output: |
-      ["ANY", "COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
-      ["ANY", "STRINGABLE"]
-      ["ANY", "CALLABLE"]
+      ["COMPARABLE", "HASHABLE", "INTEGERABLE", "NUMERIC", "STRINGABLE"]
+      ["STRINGABLE"]
+      ["CALLABLE"]
+      ["CALLABLE"]
   methods:
     description: "Returns the names of the methods specific to this literal type, not including the generic methods listed on this page. The names are sorted, so the result is the same on every run. A type with no methods of its own returns an empty array."
     input: |

--- a/evaluator/register.go
+++ b/evaluator/register.go
@@ -1,0 +1,13 @@
+package evaluator
+
+import "github.com/flipez/rocket-lang/object"
+
+// The object package needs two things from here that it cannot reach on its
+// own, because it is the package the evaluator is built on: evaluating a node,
+// and calling a function with its parameters bound. Registering them here
+// rather than at each entry point means a new one cannot forget, and a missed
+// registration used to show up as a nil dereference far from the cause.
+func init() {
+	object.AddEvaluator(Eval)
+	object.AddFunctionApplier(applyFunction)
+}

--- a/main.go
+++ b/main.go
@@ -96,7 +96,6 @@ func runProgram(input string, file string) {
 	l := lexer.New(input, file)
 	p := parser.New(l)
 
-	object.AddEvaluator(evaluator.Eval)
 
 	program := p.ParseProgram()
 	if len(p.Errors()) > 0 {

--- a/object/array.go
+++ b/object/array.go
@@ -13,6 +13,14 @@ type Array struct {
 }
 
 func NewArray(slice []Object) *Array {
+	if slice == nil {
+		// A nil slice marshals as JSON null, so [].to_json() was "null" while
+		// an array emptied with pop was "[]" -- the same value, serialized two
+		// ways depending on how it got there. An empty array literal arrives
+		// here with nothing, so normalise once at the door.
+		slice = make([]Object, 0)
+	}
+
 	return &Array{Elements: slice}
 }
 
@@ -399,6 +407,38 @@ func init() {
 					return NewErrorFormat("failed to convert array to matrix: %s", err.Error())
 				}
 				return matrix
+			},
+		},
+		"each": ObjectMethod{
+			Layout: MethodLayout{
+				ArgPattern: Args(
+					Arg(CALLABLE),
+				),
+				ReturnPattern: Args(
+					Arg(ARRAY_OBJ, ERROR_OBJ),
+				),
+			},
+			method: func(o Object, args []Object, env Environment) Object {
+				ao := o.(*Array)
+
+				for _, element := range ao.Elements {
+					result := CallFunction(args[0], env, element)
+
+					// An error ends the walk and is handed on, rather than
+					// being swallowed and the loop carrying on regardless.
+					if IsError(result) {
+						return result
+					}
+
+					if CallbackStopped(result) {
+						break
+					}
+				}
+
+				// The array, so a walk can be chained onto and after. each
+				// changes nothing itself, and the only other thing it could
+				// return is nil, which would end a chain.
+				return ao
 			},
 		},
 		"empty?": ObjectMethod{

--- a/object/array_test.go
+++ b/object/array_test.go
@@ -355,3 +355,52 @@ func TestElementGroupErrors(t *testing.T) {
 	}
 	testInput(t, tests)
 }
+
+// TestArrayEach covers the first method that calls back into user code. Until
+// the function applier was injected, a method could reach a callback's body but
+// had no way to pass it an argument -- which is why HTTP.handle sets `request`
+// as a variable instead of taking it as a parameter.
+func TestArrayEach(t *testing.T) {
+	tests := []inputTestCase{
+		// The receiver comes back, so a walk chains. Returning nil would end
+		// the chain, and each changes nothing that would be worth returning.
+		{`a = [1,2,3]; a.each(def(x) end).to_json()`, "[1,2,3]"},
+		{`[3,1,2].sort().each(def(x) end).size()`, 3},
+		{`a = [1]; a.each(def(x) end).type()`, "ARRAY"},
+		{`a = []; a.each(def(x) end).to_json()`, "[]"},
+
+		// The callback actually receives the element, which is the whole point.
+		{`out = []; a = [1,2,3]; a.each(def(x) out.push(x * 2) end); out.to_json()`, "[2,4,6]"},
+		{`out = []; a = ["x","y"]; a.each(def(s) out.push(s.upcase()) end); out.to_json()`, `["X","Y"]`},
+
+		// break ends the walk, next moves it along. A function does not consume
+		// either, so a callback can hand one back, and passing it through as a
+		// value would be meaningless.
+		{`out = []; a = [1,2,3,4]; a.each(def(x) if x == 3 break end out.push(x) end); out.to_json()`, "[1,2]"},
+		{`out = []; a = [1,2,3]; a.each(def(x) if x == 2 next end out.push(x) end); out.to_json()`, "[1,3]"},
+		// break still hands back the array, not the BREAK_VALUE.
+		{`a = [1,2]; a.each(def(x) break end).type()`, "ARRAY"},
+
+		// An error ends the walk and is handed on rather than swallowed.
+		{`a = [1]; a.each(def(x) x.no_such_method() end)`, "test:1:25: undefined method `.no_such_method()` for INTEGER"},
+		{`out = []; a = [1,2,3]; begin a.each(def(x) out.push(x); x.nope() end) rescue e end out.to_json()`, "[1]"},
+
+		// Arity is the applier's business, and it reports it the way a call
+		// written out in full would.
+		{`a = [1]; a.each(def(x, y) end)`, "to few arguments: got=1, want=2"},
+		{`a = [1]; a.each(def() end)`, "to many arguments: got=1, want=0"},
+
+		// A builtin is a value too, so it is callable.
+		{`a = [1]; a.each(puts).to_json()`, "[1]"},
+
+		// CALLABLE refuses what cannot be called.
+		{`a = [1]; a.each(1)`, "wrong argument type on position 1: got=INTEGER, want=CALLABLE"},
+		{`a = [1]; a.each(nil)`, "wrong argument type on position 1: got=NIL, want=CALLABLE"},
+		{`a = [1]; a.each()`, "to few arguments: got=0, want=1"},
+
+		// A closure keeps its own scope, so the callback sees where it was
+		// written rather than where it is called.
+		{`factor = 10; out = []; a = [1,2]; a.each(def(x) out.push(x * factor) end); out.to_json()`, "[10,20]"},
+	}
+	testInput(t, tests)
+}

--- a/object/callback.go
+++ b/object/callback.go
@@ -1,0 +1,52 @@
+package object
+
+// functionApplier calls a callable with arguments bound to its parameters. This
+// package cannot do that itself: it means building an environment from the
+// parameter list and evaluating the body, and the code for that lives in the
+// evaluator, which imports this package -- so the dependency can only run the
+// other way. It is injected exactly as Evaluator is.
+//
+// Without it, a method could reach a function's Body but had no way to pass it
+// anything. HTTP.handle worked around that by setting `request` and `response`
+// as variables in the environment and evaluating the body directly, which is
+// why an HTTP handler takes no parameters.
+var functionApplier func(fn Object, args []Object, env *Environment) Object
+
+// AddFunctionApplier wires up function application. The evaluator registers it
+// from its own init, so no caller has to remember to.
+func AddFunctionApplier(applier func(fn Object, args []Object, env *Environment) Object) {
+	functionApplier = applier
+}
+
+// CallFunction runs a callback and returns whatever it produced: a value, an
+// error, or one of the control-flow objects that break and next leave behind.
+//
+// Arity is the applier's business, and it reports a mismatch in the same words
+// a call written out in full would.
+func CallFunction(fn Object, env Environment, args ...Object) Object {
+	if functionApplier == nil {
+		// Only reachable from a program that uses this package without the
+		// evaluator. Better than the nil dereference it replaces.
+		return NewError("cannot call a callback: no function applier is registered")
+	}
+
+	return functionApplier(fn, args, &env)
+}
+
+// CallbackStopped reports a callback that ran `break`, and a method walking a
+// collection should stop -- the way break ends a foreach.
+//
+// break and next inside a function are not consumed by it, so a callback can
+// hand one back: `def() break end` returns a BREAK_VALUE. Treating that as an
+// ordinary value would put a BREAK_VALUE inside a mapped array, which means
+// nothing to anyone. Every method taking a callback has to answer for it, so
+// the rule lives here rather than in each of them.
+func CallbackStopped(o Object) bool {
+	return o != nil && o.Type() == BREAK_VALUE_OBJ
+}
+
+// CallbackSkipped reports a callback that ran `next`. The element produced
+// nothing, the way next moves a foreach along.
+func CallbackSkipped(o Object) bool {
+	return o != nil && o.Type() == NEXT_VALUE_OBJ
+}

--- a/object/object.go
+++ b/object/object.go
@@ -466,6 +466,17 @@ func init() {
 				// the order differed between runs.
 				groups := make([]Object, 0, len(typeGroups))
 				for _, name := range TypeGroupNames() {
+					// ANY is left out. Every other group says something the
+					// value can do; ANY says an argument accepts anything,
+					// which is a statement about a parameter rather than about
+					// this value. As a property it is true of everything, so it
+					// distinguishes nothing and only prefixes every list with a
+					// constant. is_a?("ANY") still answers true, because ANY is
+					// a real group wherever a signature uses it.
+					if name == ANY {
+						continue
+					}
+
 					if typeGroups[name](o) {
 						groups = append(groups, NewString(name))
 					}

--- a/object/object.go
+++ b/object/object.go
@@ -79,6 +79,9 @@ const (
 	COMPARABLE = "COMPARABLE"
 	// NUMERIC accepts INTEGER and FLOAT.
 	NUMERIC = "NUMERIC"
+	// CALLABLE accepts what can be called: a function written in RocketLang, or
+	// a builtin such as puts, which is a value too.
+	CALLABLE = "CALLABLE"
 )
 
 // typeGroups maps each group to the question it asks of an object. Where a Go
@@ -108,6 +111,9 @@ var typeGroups = map[string]func(Object) bool{
 	},
 	NUMERIC: func(o Object) bool {
 		return o.Type() == INTEGER_OBJ || o.Type() == FLOAT_OBJ
+	},
+	CALLABLE: func(o Object) bool {
+		return o.Type() == FUNCTION_OBJ || o.Type() == BUILTIN_FUNCTION_OBJ
 	},
 }
 

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -635,19 +635,19 @@ func TestIsA(t *testing.T) {
 // drift apart unnoticed.
 func TestTypeGroupsMethod(t *testing.T) {
 	tests := []inputTestCase{
-		{`"a".type_groups().to_json()`, `["ANY","COMPARABLE","HASHABLE","INTEGERABLE","STRINGABLE"]`},
-		{`1.type_groups().to_json()`, `["ANY","COMPARABLE","HASHABLE","INTEGERABLE","NUMERIC","STRINGABLE"]`},
-		{`1.5.type_groups().to_json()`, `["ANY","COMPARABLE","HASHABLE","INTEGERABLE","NUMERIC","STRINGABLE"]`},
-		{`true.type_groups().to_json()`, `["ANY","HASHABLE","INTEGERABLE","STRINGABLE"]`},
-		{`[1].type_groups().to_json()`, `["ANY","HASHABLE","STRINGABLE"]`},
-		{`{"a": 1}.type_groups().to_json()`, `["ANY","HASHABLE","STRINGABLE"]`},
-		{`nil.type_groups().to_json()`, `["ANY","STRINGABLE"]`},
-		{`[[1,2]].to_m().type_groups().to_json()`, `["ANY","STRINGABLE"]`},
+		{`"a".type_groups().to_json()`, `["COMPARABLE","HASHABLE","INTEGERABLE","STRINGABLE"]`},
+		{`1.type_groups().to_json()`, `["COMPARABLE","HASHABLE","INTEGERABLE","NUMERIC","STRINGABLE"]`},
+		{`1.5.type_groups().to_json()`, `["COMPARABLE","HASHABLE","INTEGERABLE","NUMERIC","STRINGABLE"]`},
+		{`true.type_groups().to_json()`, `["HASHABLE","INTEGERABLE","STRINGABLE"]`},
+		{`[1].type_groups().to_json()`, `["HASHABLE","STRINGABLE"]`},
+		{`{"a": 1}.type_groups().to_json()`, `["HASHABLE","STRINGABLE"]`},
+		{`nil.type_groups().to_json()`, `["STRINGABLE"]`},
+		{`[[1,2]].to_m().type_groups().to_json()`, `["STRINGABLE"]`},
 		// A function is CALLABLE and nothing else -- not STRINGABLE, not
 		// HASHABLE, which is the whole reason the element checks in join, sum,
 		// uniq and sort exist.
-		{`def() end.type_groups().to_json()`, `["ANY","CALLABLE"]`},
-		{`puts.type_groups().to_json()`, `["ANY","CALLABLE"]`},
+		{`def() end.type_groups().to_json()`, `["CALLABLE"]`},
+		{`puts.type_groups().to_json()`, `["CALLABLE"]`},
 		// Nothing else is callable.
 		{`1.type_groups().include?("CALLABLE")`, false},
 		{`"a".type_groups().include?("CALLABLE")`, false},
@@ -669,8 +669,21 @@ func TestIsAAgreesWithTypeGroups(t *testing.T) {
 	for _, subject := range subjects {
 		for _, group := range object.TypeGroupNames() {
 			predicate := testEval(`(` + subject + `).is_a?("` + group + `")`)
-			listed := testEval(`(` + subject + `).type_groups().include?("` + group + `")`)
 
+			// ANY is deliberately absent from the listing: it says an argument
+			// accepts anything, which describes a parameter rather than this
+			// value, and it is true of everything. is_a? still answers it.
+			if group == object.ANY {
+				require.Equal(t, "true", predicate.Inspect(),
+					"is_a?(ANY) should be true for %s", subject)
+				require.Equal(t, "false",
+					testEval(`(`+subject+`).type_groups().include?("ANY")`).Inspect(),
+					"type_groups() should not list ANY for %s", subject)
+
+				continue
+			}
+
+			listed := testEval(`(` + subject + `).type_groups().include?("` + group + `")`)
 			require.Equal(t, listed.Inspect(), predicate.Inspect(),
 				"is_a?(%q) and type_groups() disagree for %s", group, subject)
 		}
@@ -680,9 +693,6 @@ func TestIsAAgreesWithTypeGroups(t *testing.T) {
 		require.Equal(t, "true", own.Inspect(),
 			"%s should be a %s", subject, testEval(`(`+subject+`).type()`).Inspect())
 
-		// ...and belongs to ANY, whatever it is.
-		require.Equal(t, "true", testEval(`(`+subject+`).is_a?("ANY")`).Inspect(),
-			"%s should be ANY", subject)
 	}
 }
 

--- a/object/object_test.go
+++ b/object/object_test.go
@@ -25,7 +25,6 @@ func testEval(input string) object.Object {
 	l := lexer.New(input, "test")
 	p := parser.New(l)
 	program := p.ParseProgram()
-	object.AddEvaluator(evaluator.Eval)
 	env := object.NewEnvironment()
 
 	return evaluator.Eval(program, env)
@@ -644,9 +643,14 @@ func TestTypeGroupsMethod(t *testing.T) {
 		{`{"a": 1}.type_groups().to_json()`, `["ANY","HASHABLE","STRINGABLE"]`},
 		{`nil.type_groups().to_json()`, `["ANY","STRINGABLE"]`},
 		{`[[1,2]].to_m().type_groups().to_json()`, `["ANY","STRINGABLE"]`},
-		// A function belongs to nothing but ANY, which is the whole reason the
-		// element checks in join, sum, uniq and sort exist.
-		{`def() end.type_groups().to_json()`, `["ANY"]`},
+		// A function is CALLABLE and nothing else -- not STRINGABLE, not
+		// HASHABLE, which is the whole reason the element checks in join, sum,
+		// uniq and sort exist.
+		{`def() end.type_groups().to_json()`, `["ANY","CALLABLE"]`},
+		{`puts.type_groups().to_json()`, `["ANY","CALLABLE"]`},
+		// Nothing else is callable.
+		{`1.type_groups().include?("CALLABLE")`, false},
+		{`"a".type_groups().include?("CALLABLE")`, false},
 
 		{`"a".type_groups("x")`, "to many arguments: got=1, want=0"},
 	}

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -63,7 +63,6 @@ func Start(in io.Reader, out io.Writer) {
 		l := lexer.New(line, "")
 		p := parser.New(l)
 
-		object.AddEvaluator(evaluator.Eval)
 
 		var program *ast.Program
 


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.98.0
The hook that unblocks `map`, `select`, `reject`, `reduce`, `each` and ~15 more — plus `each` itself, to prove the path.

## Why a method could not call a callback

Running a callback means binding its parameters and evaluating its body. That code lives in `evaluator`, which imports `object` — so the dependency can only run the other way. All `object` had was:

```go
var Evaluator func(node ast.Node, env *Environment) Object   // binds nothing
```

You can see the constraint in the one place that already called back into user code, `object/http.go:138`:

```go
env.Set("request", httpRequest)
env.Set("response", httpResponse)
callback := args[1].(*Function)
Evaluator(callback.Body, &env)
```

It sets **magic variables** and evaluates the body, which is why an HTTP handler declares no parameters and reads `request` out of thin air. Not a stylistic choice — the only thing available.

## The hook

`evaluator.applyFunction` already had the right shape: takes a callable, arguments and an environment; handles a RocketLang function *and* a builtin; checks arity with the wording a written-out call uses. So it is the hook, injected the way `Evaluator` is.

**Registration moved into an `init()` in `evaluator`.** There were three `AddEvaluator` call sites (`main.go`, `repl/repl.go`, `object_test.go`); a second hook would have meant three more to keep in step, with a nil dereference far from the cause as the symptom for whichever got missed. Every entry point imports the evaluator, so one `init` covers all of them and the call sites are gone.

`CallFunction` holds the rules callers would otherwise each invent — the same reasoning as `requireElements` in #298.

## `break` and `next` in a callback

`break` and `next` inside a function are not consumed by it, so a callback can hand one back:

```
def f() break end  →  break   (BREAK_VALUE)
def f() next  end  →  nil     (NEXT_VALUE)
```

Passing that through as a value would put a `BREAK_VALUE` **inside a mapped array**, which means nothing. So `CallbackStopped`/`CallbackSkipped` name the cases once and every future method treats them alike: `break` ends the walk, `next` moves it along — as in a `foreach`.

## `Array#each`

```js
a = [1, 2, 3]
a.each(def(x) puts(x) end)

// chains, because it returns the receiver
[3, 1, 2].sort().each(def(x) puts(x) end).size()   // => 3

// a builtin is a value too
a.each(puts)

// break ends the walk, next moves it along
a.each(def(x) if x == 2 break end puts(x) end)     // prints 1
```

| Behaviour | Result |
| --- | --- |
| callback receives the element | yes — the point of the whole change |
| returns | the array, so a walk chains (#294's rule for a method with nothing better to give back) |
| `break` / `next` | ends the walk / moves it along |
| callback error | ends the walk and is passed on, catchable with `rescue` |
| arity mismatch | `to few arguments: got=1, want=2` |
| `each(1)` | `wrong argument type on position 1: got=INTEGER, want=CALLABLE` |

The argument is a new **`CALLABLE`** type group rather than `Arg(FUNCTION_OBJ, BUILTIN_FUNCTION_OBJ)`, so it reads as one idea in a signature and joins `type_groups()` and `is_a?` for free:

```js
🚀 > def() end.type_groups()
=> ["CALLABLE"]
🚀 > puts.is_a?("CALLABLE")
=> true
```

A `FUNCTION` is now `CALLABLE` and nothing else — not `STRINGABLE`, which is why `[def() end].join()` still fails.

## Also fixed

Found while writing the tests: an empty array literal left `Elements` nil, and a nil slice marshals as JSON `null`.

| | Before | After |
| --- | --- | --- |
| `[].to_json()` | `null` | `[]` |
| `b = [1]; b.pop(); b.to_json()` | `[]` | `[]` |

The same value serialised two ways depending on how it got there. `NewArray` normalises it.

## Verification

| Check | Result |
| --- | --- |
| `go test ./...` | green |
| documented examples | 163 (1 new), 0 mismatches |
| tracked `.rl` files vs a `main` binary | 42/42 byte-identical |
| `yarn build` | succeeds |
| `GOOS=js GOARCH=wasm go build` | succeeds |
| REPL after moving registration to `init` | verified by hand |

Mutation-tested, all caught: not registering the applier, `each` ignoring `break`, swallowing a callback error, returning nil instead of the receiver, `CallbackStopped` never true, `CALLABLE` accepting anything, and the empty-array marshal regressing.

## Not in this PR

`map`, `select`, `reject`, `reduce`, `sort_by`, `all?`/`any?`/`none?`, `Hash#transform_values`, `Integer#times` — all ordinary work now, and they belong in their own change as pairs per the `!` convention.

`HTTP.handle` can also stop using magic variables — `def(request)` returning a response hash — but that is breaking and deserves its own discussion.

Block syntax stays out deliberately: a block would desugar to a function literal, so method signatures do not change and it can land whenever. It needs a single `|` token (which the lexer currently leaves as a blank token) and a decision on what `return` inside a block means.

## Also: `ANY` left out of `type_groups()`

`["ANY", "CALLABLE"]` reads backwards. Every other group states something the *value* can do; `ANY` states that a *parameter* accepts anything. As a property of a value it is true of everything, so it distinguished nothing and prefixed every answer with the same word.

| | Before | After |
| --- | --- | --- |
| `def() end.type_groups()` | `["ANY", "CALLABLE"]` | `["CALLABLE"]` |
| `nil.type_groups()` | `["ANY", "STRINGABLE"]` | `["STRINGABLE"]` |
| `1.type_groups()` | `["ANY", "COMPARABLE", …]` | `["COMPARABLE", …]` |
| `1.is_a?("ANY")` | `true` | `true` — unchanged |

`ANY` is real wherever a signature uses it (`push(ANY)` means what it says), so `is_a?` still answers it. The membership matrix on the Types page loses its `ANY` column for the same reason — it was a tick in every row.

The test asserting `is_a?` and `type_groups()` agree now asserts the exception explicitly rather than being weakened by it: `ANY` must be true for the predicate and absent from the listing. Mutation-tested by putting `ANY` back.
