### PR TITLE
feat(object): add the methods the function applier unlocked

### DIFF
--- a/docs/docs/language/methods.md
+++ b/docs/docs/language/methods.md
@@ -31,6 +31,55 @@ Those names are **type groups**; see
 [Types and type groups](./types#type-groups) for what each one accepts and which
 types belong to it.
 
+## Methods that take a callback
+
+A callback is a function literal, since there is no separate block syntax:
+
+```js
+🚀 > [1, 2, 3].map(def(x) x * 2 end)
+=> [2, 4, 6]
+🚀 > [1, 2, 3, 4].select(def(x) x % 2 == 0 end)
+=> [2, 4]
+🚀 > [1, 2, 3].reduce(0, def(sum, x) sum + x end)
+=> 6
+```
+
+A builtin is a value too, so it can be the callback:
+
+```js
+🚀 > [1, 2].each(puts)
+1
+2
+=> [1, 2]
+```
+
+Every one of them treats the callback's answer the same way:
+
+| In the callback | Effect |
+| --------------- | ------ |
+| a value | used — what that means is the method's business |
+| `break` | the walk ends here, and the answer covers what was walked |
+| `next` | the element contributed nothing: a `nil` from `map`, a no from `select` |
+| an error | the walk ends and the error is passed on |
+
+```js
+🚀 > [1, 2, 3, 4].map(def(x) if x == 3 break end x end)
+=> [1, 2]
+🚀 > [1, 2, 3].map(def(x) if x == 2 next end x end)
+=> [1, nil, 3]
+```
+
+`break` and `next` behave as they do in a `foreach`. Note that `return` inside
+the callback returns from the *callback*, since it is an ordinary function —
+there is no enclosing method to return from.
+
+Only `false` and `nil` are no, so `select` keeps a `0` and an empty string:
+
+```js
+🚀 > [1, 2].select(def(x) 0 end)
+=> [1, 2]
+```
+
 ## Methods ending in `!`
 
 A method whose name ends in `!` changes the value it is called on. The plain

--- a/docs/docs/language/types.md
+++ b/docs/docs/language/types.md
@@ -50,11 +50,12 @@ they appear only in signatures and in error messages.
 | Group | Means | Where it appears |
 | ----- | ----- | ---------------- |
 | `ANY` | any value at all | `push`, `unshift`, `insert`, `include?`, `index`, `rindex`, `count` and `delete` on an `ARRAY`; the fallback of `HASH.get` and `fetch`; `format`; `puts` |
-| `HASHABLE` | can be used as a hash key | the key argument of `HASH.get`, `fetch`, `delete` and `include?`; the elements of `ARRAY.uniq` |
-| `COMPARABLE` | can be ordered against its own kind | the elements of `ARRAY.sort`, `min` and `max` |
+| `HASHABLE` | can be used as a hash key | the key argument of `HASH.get`, `fetch`, `delete` and `include?`; the elements of `ARRAY.uniq`; what `HASH.transform_keys` answers |
+| `COMPARABLE` | can be ordered against its own kind | the elements of `ARRAY.sort`, `min` and `max`; what `ARRAY.sort_by`, `min_by` and `max_by` answer |
 | `STRINGABLE` | has a string form | the elements of `ARRAY.join` |
 | `INTEGERABLE` | can be read as an integer | the elements of `ARRAY.sum` |
 | `NUMERIC` | a number | the value argument of `MATRIX.set` |
+| `CALLABLE` | a function, or a builtin such as `puts` — both are values | every callback: `ARRAY.each`, `map`, `select`, `reject`, `reduce`, `all?`, `sort_by`, `min_by`; `HASH.each`, `select`, `transform_values`, `transform_keys`; `INTEGER.times`, `upto`, `downto` |
 
 ### What belongs to what
 

--- a/docs/docs/literals/array.md
+++ b/docs/docs/literals/array.md
@@ -27,6 +27,40 @@ puts(a[1:-2])
 
 ## Literal Specific Methods
 
+### all?(CALLABLE)
+> Returns `BOOLEAN|ERROR`
+
+Returns `true` when the callback says yes to every element, and for an empty array.
+
+
+<CodeBlockSimple input='a = [1, 2, 3]
+a.all?(def(x) x > 0 end)
+a.all?(def(x) x > 2 end)
+[].all?(def(x) false end)
+' output='[1, 2, 3]
+true
+false
+true
+' />
+
+
+### any?(CALLABLE)
+> Returns `BOOLEAN|ERROR`
+
+Returns `true` when the callback says yes to at least one element, and `false` for an empty array.
+
+
+<CodeBlockSimple input='a = [1, 2, 3]
+a.any?(def(x) x > 2 end)
+a.any?(def(x) x > 9 end)
+[].any?(def(x) true end)
+' output='[1, 2, 3]
+true
+false
+false
+' />
+
+
 ### clear()
 > Returns `ARRAY`
 
@@ -289,6 +323,36 @@ Returns the last element of the array.
 ' />
 
 
+### map(CALLABLE)
+> Returns `ARRAY|ERROR`
+
+Returns a new array holding what the callback answered for each element. The callback can be a function or a builtin, which is what `CALLABLE` in the signature means. `break` in the callback ends the walk and `next` means the element contributed nothing, as in a `foreach`. An error from the callback ends the walk and is passed on. A `next` contributes `nil`, so the length is kept. Use `map!` to replace the elements in place.
+
+
+<CodeBlockSimple input='a = [1, 2, 3]
+a.map(def(x) x * 2 end)
+a
+' output='[1, 2, 3]
+[2, 4, 6]
+[1, 2, 3]
+' />
+
+
+### map!(CALLABLE)
+> Returns `ARRAY|ERROR`
+
+Replaces each element with what the callback answered and returns the array, so calls can be chained.
+
+
+<CodeBlockSimple input='a = [1, 2, 3]
+a.map!(def(x) x * 2 end)
+a
+' output='[1, 2, 3]
+[2, 4, 6]
+[2, 4, 6]
+' />
+
+
 ### max()
 > Returns `ANY`
 
@@ -299,6 +363,19 @@ Returns the largest element, or `nil` for an empty array. Takes the same element
 [].max()
 ' output='3
 nil
+' />
+
+
+### max_by(CALLABLE)
+> Returns `ANY`
+
+Returns the element with the largest answer from the callback, or `nil` for an empty array.
+
+
+<CodeBlockSimple input='a = ["ccc", "a", "bb"]
+a.max_by(def(w) w.size() end)
+' output='["ccc", "a", "bb"]
+"ccc"
 ' />
 
 
@@ -314,6 +391,36 @@ Returns the smallest element, or `nil` for an empty array. The elements have to 
 ' output='1
 "a"
 nil
+' />
+
+
+### min_by(CALLABLE)
+> Returns `ANY`
+
+Returns the element with the smallest answer from the callback, or `nil` for an empty array.
+
+
+<CodeBlockSimple input='a = ["ccc", "a", "bb"]
+a.min_by(def(w) w.size() end)
+[].min_by(def(x) x end)
+' output='["ccc", "a", "bb"]
+"a"
+nil
+' />
+
+
+### none?(CALLABLE)
+> Returns `BOOLEAN|ERROR`
+
+Returns `true` when the callback says yes to no element, and for an empty array.
+
+
+<CodeBlockSimple input='a = [1, 2, 3]
+a.none?(def(x) x > 9 end)
+a.none?(def(x) x > 2 end)
+' output='[1, 2, 3]
+true
+false
 ' />
 
 
@@ -344,6 +451,53 @@ d
 ' output='[1, 2, 3]
 [1, 2, 3, "a"]
 [1, 2, 3, "a"]
+' />
+
+
+### reduce(ANY, CALLABLE)
+> Returns `ANY`
+
+Folds the array into a single value. The callback receives what has been carried so far and the element, and answers with the next carried value. The starting value is required: Ruby lets you leave it out and uses the first element, which then makes an empty array a special case.
+
+
+<CodeBlockSimple input='a = [1, 2, 3]
+a.reduce(0, def(sum, x) sum + x end)
+a.reduce(1, def(product, x) product * x end)
+[].reduce(7, def(sum, x) sum + x end)
+' output='[1, 2, 3]
+6
+6
+7
+' />
+
+
+### reject(CALLABLE)
+> Returns `ARRAY|ERROR`
+
+Returns a new array of the elements the callback said no to -- the mirror of `select`. Use `reject!` to filter in place.
+
+
+<CodeBlockSimple input='a = [1, 2, 3, 4]
+a.reject(def(x) x % 2 == 0 end)
+a
+' output='[1, 2, 3, 4]
+[1, 3]
+[1, 2, 3, 4]
+' />
+
+
+### reject!(CALLABLE)
+> Returns `ARRAY|ERROR`
+
+Drops the elements the callback said yes to and returns the array, so calls can be chained.
+
+
+<CodeBlockSimple input='a = [1, 2, 3, 4]
+a.reject!(def(x) x % 2 == 0 end)
+a
+' output='[1, 2, 3, 4]
+[1, 3]
+[1, 3]
 ' />
 
 
@@ -424,6 +578,36 @@ a
 ' />
 
 
+### select(CALLABLE)
+> Returns `ARRAY|ERROR`
+
+Returns a new array of the elements the callback said yes to. Only `false` and `nil` are no, so `0` and `""` are yes. The callback can be a function or a builtin, which is what `CALLABLE` in the signature means. Use `select!` to filter in place.
+
+
+<CodeBlockSimple input='a = [1, 2, 3, 4]
+a.select(def(x) x % 2 == 0 end)
+a
+' output='[1, 2, 3, 4]
+[2, 4]
+[1, 2, 3, 4]
+' />
+
+
+### select!(CALLABLE)
+> Returns `ARRAY|ERROR`
+
+Keeps only the elements the callback said yes to and returns the array, so calls can be chained.
+
+
+<CodeBlockSimple input='a = [1, 2, 3, 4]
+a.select!(def(x) x % 2 == 0 end)
+a
+' output='[1, 2, 3, 4]
+[2, 4]
+[2, 4]
+' />
+
+
 ### shift()
 > Returns `ANY`
 
@@ -488,6 +672,36 @@ b
 ' output='[3.4, 3.1, 2.0]
 [2.0, 3.1, 3.4]
 [2.0, 3.1, 3.4]
+' />
+
+
+### sort_by(CALLABLE)
+> Returns `ARRAY|ERROR`
+
+Returns a new array ordered by what the callback answers for each element. The answers have to satisfy what `sort` requires of elements -- all `COMPARABLE` and all the same one -- and are reported the same way. Use `sort_by!` to sort in place.
+
+
+<CodeBlockSimple input='a = ["ccc", "a", "bb"]
+a.sort_by(def(w) w.size() end)
+a
+' output='["ccc", "a", "bb"]
+["a", "bb", "ccc"]
+["ccc", "a", "bb"]
+' />
+
+
+### sort_by!(CALLABLE)
+> Returns `ARRAY|ERROR`
+
+Orders the array by what the callback answers and returns it, so calls can be chained.
+
+
+<CodeBlockSimple input='a = ["ccc", "a", "bb"]
+a.sort_by!(def(w) w.size() end)
+a
+' output='["ccc", "a", "bb"]
+["a", "bb", "ccc"]
+["a", "bb", "ccc"]
 ' />
 
 

--- a/docs/docs/literals/hash.md
+++ b/docs/docs/literals/hash.md
@@ -114,6 +114,20 @@ nil
 ' />
 
 
+### each(CALLABLE)
+> Returns `HASH|ERROR`
+
+Calls the callback once per entry with the key and the value, and returns the hash so calls can be chained. The order the entries arrive in is **not** defined and differs between runs, the same caveat `keys` carries -- use it for a side effect per entry, not to build something ordered.
+
+
+<CodeBlockSimple input='h = {"a": 1}
+h.each(def(key, value) puts(key + "=" + value.to_s()) end)
+' output='{"a": 1}
+a=1
+{"a": 1}
+' />
+
+
 ### empty?()
 > Returns `BOOLEAN`
 
@@ -226,6 +240,70 @@ h.size()
 ' />
 
 
+### reject(CALLABLE)
+> Returns `HASH|ERROR`
+
+Returns a new hash of the entries the callback said no to -- the mirror of `select`. Use `reject!` to filter in place.
+
+
+<CodeBlockSimple input='h = {"a": 1}
+h["b"] = 2
+h.reject(def(k, v) v > 1 end).size()
+' output='{"a": 1}
+2
+1
+' />
+
+
+### reject!(CALLABLE)
+> Returns `HASH|ERROR`
+
+Drops the entries the callback said yes to and returns the hash, so calls can be chained.
+
+
+<CodeBlockSimple input='h = {"a": 1}
+h["b"] = 2
+h.reject!(def(k, v) v > 1 end).size()
+' output='{"a": 1}
+2
+1
+' />
+
+
+### select(CALLABLE)
+> Returns `HASH|ERROR`
+
+Returns a new hash of the entries the callback said yes to. The callback receives the key and the value. Only `false` and `nil` are no. Use `select!` to filter in place.
+
+
+<CodeBlockSimple input='h = {"a": 1}
+h["b"] = 2
+h.select(def(k, v) v > 1 end).size()
+h.size()
+' output='{"a": 1}
+2
+1
+2
+' />
+
+
+### select!(CALLABLE)
+> Returns `HASH|ERROR`
+
+Keeps only the entries the callback said yes to and returns the hash, so calls can be chained.
+
+
+<CodeBlockSimple input='h = {"a": 1}
+h["b"] = 2
+h.select!(def(k, v) v > 1 end).size()
+h.size()
+' output='{"a": 1}
+2
+1
+1
+' />
+
+
 ### size()
 > Returns `INTEGER`
 
@@ -238,6 +316,60 @@ h.size()
 ' output='{"a": 1}
 1
 0
+' />
+
+
+### transform_keys(CALLABLE)
+> Returns `HASH|ERROR`
+
+Returns a new hash with each key replaced by what the callback answered for it. A new key still has to be `HASHABLE`, and two keys answering the same collapse into one entry -- which of them survives is not defined. Use `transform_keys!` to replace them in place.
+
+
+<CodeBlockSimple input='h = {"a": 1}
+h.transform_keys(def(k) k.upcase() end).get("A", 0)
+' output='{"a": 1}
+1
+' />
+
+
+### transform_keys!(CALLABLE)
+> Returns `HASH|ERROR`
+
+Replaces each key with what the callback answered and returns the hash, so calls can be chained.
+
+
+<CodeBlockSimple input='h = {"a": 1}
+h.transform_keys!(def(k) k.upcase() end).get("A", 0)
+' output='{"a": 1}
+1
+' />
+
+
+### transform_values(CALLABLE)
+> Returns `HASH|ERROR`
+
+Returns a new hash with each value replaced by what the callback answered for it. The keys are untouched. Use `transform_values!` to replace them in place.
+
+
+<CodeBlockSimple input='h = {"a": 1}
+h.transform_values(def(v) v * 10 end).get("a", 0)
+h.get("a", 0)
+' output='{"a": 1}
+10
+1
+' />
+
+
+### transform_values!(CALLABLE)
+> Returns `HASH|ERROR`
+
+Replaces each value with what the callback answered and returns the hash, so calls can be chained.
+
+
+<CodeBlockSimple input='h = {"a": 1}
+h.transform_values!(def(v) v * 10 end).get("a", 0)
+' output='{"a": 1}
+10
 ' />
 
 

--- a/docs/docs/literals/integer.md
+++ b/docs/docs/literals/integer.md
@@ -115,6 +115,20 @@ Returns the quotient and the remainder as a two-element array. Both follow the `
 ' />
 
 
+### downto(INTEGER, CALLABLE)
+> Returns `INTEGER|ERROR`
+
+Calls the callback with each integer from the receiver down to the given limit, inclusive at both ends, and returns the receiver. A limit above the receiver calls nothing.
+
+
+<CodeBlockSimple input='3.downto(1, def(i) puts(i) end)
+' output='3
+2
+1
+3
+' />
+
+
 ### even?()
 > Returns `BOOLEAN`
 
@@ -256,6 +270,22 @@ Returns the next integer, keeping the base of the receiver.
 ' />
 
 
+### times(CALLABLE)
+> Returns `INTEGER|ERROR`
+
+Calls the callback with each integer from `0` up to one less than the receiver, and returns the receiver so calls can be chained. A count of zero or less calls nothing rather than erroring, which makes it safe to hand a computed count. The counter keeps the receiver's base.
+
+
+<CodeBlockSimple input='3.times(def(i) puts(i) end)
+0.times(def(i) puts("never") end)
+' output='0
+1
+2
+3
+0
+' />
+
+
 ### to_base(INTEGER)
 > Returns `INTEGER`
 
@@ -277,6 +307,22 @@ Drops the last digits, rounding toward zero, given a negative digit count. No ar
 (0 - 555).truncate(0 - 1)
 ' output='550
 -550
+' />
+
+
+### upto(INTEGER, CALLABLE)
+> Returns `INTEGER|ERROR`
+
+Calls the callback with each integer from the receiver up to the given limit, inclusive at both ends, and returns the receiver. A limit below the receiver calls nothing.
+
+
+<CodeBlockSimple input='1.upto(3, def(i) puts(i) end)
+3.upto(1, def(i) puts("never") end)
+' output='1
+2
+3
+1
+3
 ' />
 
 

--- a/docs/literals/array.yml
+++ b/docs/literals/array.yml
@@ -377,3 +377,147 @@ methods:
       [2, 3]
       [1, 2, 3]
       [1, 2, 3]
+  map:
+    description: "Returns a new array holding what the callback answered for each element. The callback can be a function or a builtin, which is what `CALLABLE` in the signature means. `break` in the callback ends the walk and `next` means the element contributed nothing, as in a `foreach`. An error from the callback ends the walk and is passed on. A `next` contributes `nil`, so the length is kept. Use `map!` to replace the elements in place."
+    input: |
+      a = [1, 2, 3]
+      a.map(def(x) x * 2 end)
+      a
+    output: |
+      [1, 2, 3]
+      [2, 4, 6]
+      [1, 2, 3]
+  map!:
+    description: "Replaces each element with what the callback answered and returns the array, so calls can be chained."
+    input: |
+      a = [1, 2, 3]
+      a.map!(def(x) x * 2 end)
+      a
+    output: |
+      [1, 2, 3]
+      [2, 4, 6]
+      [2, 4, 6]
+  select:
+    description: "Returns a new array of the elements the callback said yes to. Only `false` and `nil` are no, so `0` and `\"\"` are yes. The callback can be a function or a builtin, which is what `CALLABLE` in the signature means. Use `select!` to filter in place."
+    input: |
+      a = [1, 2, 3, 4]
+      a.select(def(x) x % 2 == 0 end)
+      a
+    output: |
+      [1, 2, 3, 4]
+      [2, 4]
+      [1, 2, 3, 4]
+  select!:
+    description: "Keeps only the elements the callback said yes to and returns the array, so calls can be chained."
+    input: |
+      a = [1, 2, 3, 4]
+      a.select!(def(x) x % 2 == 0 end)
+      a
+    output: |
+      [1, 2, 3, 4]
+      [2, 4]
+      [2, 4]
+  reject:
+    description: "Returns a new array of the elements the callback said no to -- the mirror of `select`. Use `reject!` to filter in place."
+    input: |
+      a = [1, 2, 3, 4]
+      a.reject(def(x) x % 2 == 0 end)
+      a
+    output: |
+      [1, 2, 3, 4]
+      [1, 3]
+      [1, 2, 3, 4]
+  reject!:
+    description: "Drops the elements the callback said yes to and returns the array, so calls can be chained."
+    input: |
+      a = [1, 2, 3, 4]
+      a.reject!(def(x) x % 2 == 0 end)
+      a
+    output: |
+      [1, 2, 3, 4]
+      [1, 3]
+      [1, 3]
+  reduce:
+    description: "Folds the array into a single value. The callback receives what has been carried so far and the element, and answers with the next carried value. The starting value is required: Ruby lets you leave it out and uses the first element, which then makes an empty array a special case."
+    input: |
+      a = [1, 2, 3]
+      a.reduce(0, def(sum, x) sum + x end)
+      a.reduce(1, def(product, x) product * x end)
+      [].reduce(7, def(sum, x) sum + x end)
+    output: |
+      [1, 2, 3]
+      6
+      6
+      7
+  all?:
+    description: "Returns `true` when the callback says yes to every element, and for an empty array."
+    input: |
+      a = [1, 2, 3]
+      a.all?(def(x) x > 0 end)
+      a.all?(def(x) x > 2 end)
+      [].all?(def(x) false end)
+    output: |
+      [1, 2, 3]
+      true
+      false
+      true
+  any?:
+    description: "Returns `true` when the callback says yes to at least one element, and `false` for an empty array."
+    input: |
+      a = [1, 2, 3]
+      a.any?(def(x) x > 2 end)
+      a.any?(def(x) x > 9 end)
+      [].any?(def(x) true end)
+    output: |
+      [1, 2, 3]
+      true
+      false
+      false
+  none?:
+    description: "Returns `true` when the callback says yes to no element, and for an empty array."
+    input: |
+      a = [1, 2, 3]
+      a.none?(def(x) x > 9 end)
+      a.none?(def(x) x > 2 end)
+    output: |
+      [1, 2, 3]
+      true
+      false
+  sort_by:
+    description: "Returns a new array ordered by what the callback answers for each element. The answers have to satisfy what `sort` requires of elements -- all `COMPARABLE` and all the same one -- and are reported the same way. Use `sort_by!` to sort in place."
+    input: |
+      a = ["ccc", "a", "bb"]
+      a.sort_by(def(w) w.size() end)
+      a
+    output: |
+      ["ccc", "a", "bb"]
+      ["a", "bb", "ccc"]
+      ["ccc", "a", "bb"]
+  sort_by!:
+    description: "Orders the array by what the callback answers and returns it, so calls can be chained."
+    input: |
+      a = ["ccc", "a", "bb"]
+      a.sort_by!(def(w) w.size() end)
+      a
+    output: |
+      ["ccc", "a", "bb"]
+      ["a", "bb", "ccc"]
+      ["a", "bb", "ccc"]
+  min_by:
+    description: "Returns the element with the smallest answer from the callback, or `nil` for an empty array."
+    input: |
+      a = ["ccc", "a", "bb"]
+      a.min_by(def(w) w.size() end)
+      [].min_by(def(x) x end)
+    output: |
+      ["ccc", "a", "bb"]
+      "a"
+      nil
+  max_by:
+    description: "Returns the element with the largest answer from the callback, or `nil` for an empty array."
+    input: |
+      a = ["ccc", "a", "bb"]
+      a.max_by(def(w) w.size() end)
+    output: |
+      ["ccc", "a", "bb"]
+      "ccc"

--- a/docs/literals/hash.yml
+++ b/docs/literals/hash.yml
@@ -175,3 +175,90 @@ methods:
     output: |
       ["1"]
       ["1", "2"]
+  each:
+    description: "Calls the callback once per entry with the key and the value, and returns the hash so calls can be chained. The order the entries arrive in is **not** defined and differs between runs, the same caveat `keys` carries -- use it for a side effect per entry, not to build something ordered."
+    input: |
+      h = {"a": 1}
+      h.each(def(key, value) puts(key + "=" + value.to_s()) end)
+    output: |
+      {"a": 1}
+      a=1
+      {"a": 1}
+  select:
+    description: "Returns a new hash of the entries the callback said yes to. The callback receives the key and the value. Only `false` and `nil` are no. Use `select!` to filter in place."
+    input: |
+      h = {"a": 1}
+      h["b"] = 2
+      h.select(def(k, v) v > 1 end).size()
+      h.size()
+    output: |
+      {"a": 1}
+      2
+      1
+      2
+  select!:
+    description: "Keeps only the entries the callback said yes to and returns the hash, so calls can be chained."
+    input: |
+      h = {"a": 1}
+      h["b"] = 2
+      h.select!(def(k, v) v > 1 end).size()
+      h.size()
+    output: |
+      {"a": 1}
+      2
+      1
+      1
+  reject:
+    description: "Returns a new hash of the entries the callback said no to -- the mirror of `select`. Use `reject!` to filter in place."
+    input: |
+      h = {"a": 1}
+      h["b"] = 2
+      h.reject(def(k, v) v > 1 end).size()
+    output: |
+      {"a": 1}
+      2
+      1
+  reject!:
+    description: "Drops the entries the callback said yes to and returns the hash, so calls can be chained."
+    input: |
+      h = {"a": 1}
+      h["b"] = 2
+      h.reject!(def(k, v) v > 1 end).size()
+    output: |
+      {"a": 1}
+      2
+      1
+  transform_values:
+    description: "Returns a new hash with each value replaced by what the callback answered for it. The keys are untouched. Use `transform_values!` to replace them in place."
+    input: |
+      h = {"a": 1}
+      h.transform_values(def(v) v * 10 end).get("a", 0)
+      h.get("a", 0)
+    output: |
+      {"a": 1}
+      10
+      1
+  transform_values!:
+    description: "Replaces each value with what the callback answered and returns the hash, so calls can be chained."
+    input: |
+      h = {"a": 1}
+      h.transform_values!(def(v) v * 10 end).get("a", 0)
+    output: |
+      {"a": 1}
+      10
+  transform_keys:
+    description: "Returns a new hash with each key replaced by what the callback answered for it. A new key still has to be `HASHABLE`, and two keys answering the same collapse into one entry -- which of them survives is not defined. Use `transform_keys!` to replace them in place."
+    input: |
+      h = {"a": 1}
+      h.transform_keys(def(k) k.upcase() end).get("A", 0)
+    output: |
+      {"a": 1}
+      1
+  transform_keys!:
+    description: "Replaces each key with what the callback answered and returns the hash, so calls can be chained."
+    input: |
+      h = {"a": 1}
+      h.transform_keys!(def(k) k.upcase() end).get("A", 0)
+    output: |
+      {"a": 1}
+      1

--- a/docs/literals/integer.yml
+++ b/docs/literals/integer.yml
@@ -179,3 +179,34 @@ methods:
     output: |
       true
       false
+  times:
+    description: "Calls the callback with each integer from `0` up to one less than the receiver, and returns the receiver so calls can be chained. A count of zero or less calls nothing rather than erroring, which makes it safe to hand a computed count. The counter keeps the receiver's base."
+    input: |
+      3.times(def(i) puts(i) end)
+      0.times(def(i) puts("never") end)
+    output: |
+      0
+      1
+      2
+      3
+      0
+  upto:
+    description: "Calls the callback with each integer from the receiver up to the given limit, inclusive at both ends, and returns the receiver. A limit below the receiver calls nothing."
+    input: |
+      1.upto(3, def(i) puts(i) end)
+      3.upto(1, def(i) puts("never") end)
+    output: |
+      1
+      2
+      3
+      1
+      3
+  downto:
+    description: "Calls the callback with each integer from the receiver down to the given limit, inclusive at both ends, and returns the receiver. A limit above the receiver calls nothing."
+    input: |
+      3.downto(1, def(i) puts(i) end)
+    output: |
+      3
+      2
+      1
+      3

--- a/object/array.go
+++ b/object/array.go
@@ -409,6 +409,41 @@ func init() {
 				return matrix
 			},
 		},
+		"reduce": ObjectMethod{
+			Layout: MethodLayout{
+				ArgPattern: Args(
+					Arg(ANY),
+					Arg(CALLABLE),
+				),
+				ReturnPattern: Args(
+					Arg(ANY),
+				),
+			},
+			method: func(o Object, args []Object, env Environment) Object {
+				// The starting value is required. Ruby lets you leave it out
+				// and uses the first element, which then makes the result of an
+				// empty array a special case; asking for it keeps one rule.
+				carried := args[0]
+
+				for _, element := range o.(*Array).Elements {
+					result := CallFunction(args[1], env, carried, element)
+
+					switch ClassifyCallback(result) {
+					case Failed:
+						return result
+					case StopWalk:
+						return carried
+					case SkipElement:
+						// Contributed nothing, so carry on unchanged.
+						continue
+					default:
+						carried = result
+					}
+				}
+
+				return carried
+			},
+		},
 		"each": ObjectMethod{
 			Layout: MethodLayout{
 				ArgPattern: Args(
@@ -754,6 +789,31 @@ func init() {
 
 		return flattenElements(elements, depth), nil
 	})
+	arrayCallbackPair("map", mappedElements)
+	arrayCallbackPair("sort_by", func(elements []Object, fn Object, env Environment) ([]Object, Object) {
+		keys, err, count := callbackKeys(elements, fn, env)
+		if err != nil {
+			return nil, err
+		}
+
+		return sortedByKeys(elements, keys, count)
+	})
+	arrayCallbackPair("select", func(elements []Object, fn Object, env Environment) ([]Object, Object) {
+		return filteredElements(elements, fn, env, true)
+	})
+	arrayCallbackPair("reject", func(elements []Object, fn Object, env Environment) ([]Object, Object) {
+		return filteredElements(elements, fn, env, false)
+	})
+
+	// An empty array is all yeses and no yeses at once, which is what these
+	// answer: all? is true, any? false, none? true.
+	arrayPredicate("all?", func(yes, total int) bool { return yes == total })
+	arrayPredicate("any?", func(yes, _ int) bool { return yes > 0 })
+	arrayPredicate("none?", func(yes, _ int) bool { return yes == 0 })
+
+	arrayExtremeBy("min_by", true)
+	arrayExtremeBy("max_by", false)
+
 	arrayPair("rotate", Args(OptArg(INTEGER_OBJ)), func(elements []Object, args []Object) ([]Object, Object) {
 		by := 1
 		if len(args) > 0 {
@@ -927,6 +987,241 @@ func requireElements(elements []Object, group string) Object {
 	}
 
 	return nil
+}
+
+// arrayCallbackPair registers a method taking a callback and its in-place
+// counterpart, built from one transformation -- the same arrangement as
+// arrayPair, so a pure method and its ! form cannot drift.
+func arrayCallbackPair(name string, transform func(elements []Object, fn Object, env Environment) ([]Object, Object)) {
+	layout := MethodLayout{
+		ArgPattern:    Args(Arg(CALLABLE)),
+		ReturnPattern: Args(Arg(ARRAY_OBJ, ERROR_OBJ)),
+	}
+
+	objectMethods[ARRAY_OBJ][name] = ObjectMethod{
+		Layout: layout,
+		method: func(o Object, args []Object, env Environment) Object {
+			elements, err := transform(o.(*Array).Elements, args[0], env)
+			if err != nil {
+				return err
+			}
+
+			return NewArray(elements)
+		},
+	}
+
+	objectMethods[ARRAY_OBJ][name+"!"] = ObjectMethod{
+		Layout: layout,
+		method: func(o Object, args []Object, env Environment) Object {
+			ao := o.(*Array)
+
+			elements, err := transform(ao.Elements, args[0], env)
+			if err != nil {
+				return err
+			}
+			ao.Elements = elements
+
+			return ao
+		},
+	}
+}
+
+// mappedElements applies fn to every element. `next` contributes nil, keeping
+// the length, which is what Ruby's map does; `break` returns what was collected
+// so far rather than discarding it.
+func mappedElements(elements []Object, fn Object, env Environment) ([]Object, Object) {
+	out := make([]Object, 0, len(elements))
+
+	for _, element := range elements {
+		result := CallFunction(fn, env, element)
+
+		switch ClassifyCallback(result) {
+		case Failed:
+			return nil, result
+		case StopWalk:
+			return out, nil
+		case SkipElement:
+			out = append(out, NIL)
+		default:
+			out = append(out, result)
+		}
+	}
+
+	return out, nil
+}
+
+// filteredElements keeps the elements the callback answers for. keep says which
+// way round: select keeps a yes, reject keeps a no. Truthiness is the language's
+// own -- only false and nil are false, so 0 and "" are yeses.
+func filteredElements(elements []Object, fn Object, env Environment, keep bool) ([]Object, Object) {
+	out := make([]Object, 0, len(elements))
+
+	for _, element := range elements {
+		result := CallFunction(fn, env, element)
+
+		switch ClassifyCallback(result) {
+		case Failed:
+			return nil, result
+		case StopWalk:
+			return out, nil
+		case SkipElement:
+			// Contributed nothing, which is a no either way round.
+			continue
+		default:
+			if IsTruthy(result) == keep {
+				out = append(out, element)
+			}
+		}
+	}
+
+	return out, nil
+}
+
+// arrayPredicate registers a method answering a question about every element.
+// verdict decides from the count of yeses and the total.
+func arrayPredicate(name string, verdict func(yes, total int) bool) {
+	objectMethods[ARRAY_OBJ][name] = ObjectMethod{
+		Layout: MethodLayout{
+			ArgPattern:    Args(Arg(CALLABLE)),
+			ReturnPattern: Args(Arg(BOOLEAN_OBJ, ERROR_OBJ)),
+		},
+		method: func(o Object, args []Object, env Environment) Object {
+			elements := o.(*Array).Elements
+			yes, seen := 0, 0
+
+			for _, element := range elements {
+				result := CallFunction(args[0], env, element)
+
+				switch ClassifyCallback(result) {
+				case Failed:
+					return result
+				case StopWalk:
+					// The answer covers what was walked, as break ends a
+					// foreach rather than voiding it.
+					if verdict(yes, seen) {
+						return TRUE
+					}
+
+					return FALSE
+				case SkipElement:
+					seen++
+				default:
+					seen++
+					if IsTruthy(result) {
+						yes++
+					}
+				}
+			}
+
+			if verdict(yes, seen) {
+				return TRUE
+			}
+
+			return FALSE
+		},
+	}
+}
+
+// callbackKeys applies fn to every element and returns one key per element. The
+// second value is an error, the third how far the walk got, which is short of
+// the whole array when the callback broke out.
+func callbackKeys(elements []Object, fn Object, env Environment) ([]Object, Object, int) {
+	keys := make([]Object, 0, len(elements))
+
+	for _, element := range elements {
+		result := CallFunction(fn, env, element)
+
+		switch ClassifyCallback(result) {
+		case Failed:
+			return nil, result, 0
+		case StopWalk:
+			return keys, nil, len(keys)
+		case SkipElement:
+			keys = append(keys, NIL)
+		default:
+			keys = append(keys, result)
+		}
+	}
+
+	return keys, nil, len(keys)
+}
+
+// sortedByKeys orders the first count elements by their keys. The keys have to
+// satisfy what sort requires of elements, and they are reported the same way.
+func sortedByKeys(elements, keys []Object, count int) ([]Object, Object) {
+	if err := requireElements(keys[:count], COMPARABLE); err != nil {
+		return nil, err
+	}
+	if count > 0 {
+		wanted := keys[0].Type()
+		for i, key := range keys[:count] {
+			if key.Type() != wanted {
+				return nil, NewErrorFormat("keys must all be one %s type, got %s at 0 and %s at %d", COMPARABLE, wanted, key.Type(), i)
+			}
+		}
+	}
+
+	order := make([]int, count)
+	for i := range order {
+		order[i] = i
+	}
+	sort.SliceStable(order, func(a, b int) bool {
+		return compareKeys(keys[order[a]], keys[order[b]])
+	})
+
+	out := make([]Object, count)
+	for i, idx := range order {
+		out[i] = elements[idx]
+	}
+
+	return out, nil
+}
+
+// compareKeys reports whether left sorts before right. The callers have already
+// established that both are the same COMPARABLE type.
+func compareKeys(left, right Object) bool {
+	switch left.Type() {
+	case INTEGER_OBJ:
+		return left.(*Integer).Value < right.(*Integer).Value
+	case FLOAT_OBJ:
+		return left.(*Float).Value < right.(*Float).Value
+	case STRING_OBJ:
+		return left.(*String).Value < right.(*String).Value
+	default:
+		return false
+	}
+}
+
+// arrayExtremeBy registers min_by or max_by.
+func arrayExtremeBy(name string, min bool) {
+	objectMethods[ARRAY_OBJ][name] = ObjectMethod{
+		Layout: MethodLayout{
+			ArgPattern:    Args(Arg(CALLABLE)),
+			ReturnPattern: Args(Arg(ANY)),
+		},
+		method: func(o Object, args []Object, env Environment) Object {
+			elements := o.(*Array).Elements
+
+			keys, err, count := callbackKeys(elements, args[0], env)
+			if err != nil {
+				return err
+			}
+			if count == 0 {
+				return NIL
+			}
+
+			ordered, err := sortedByKeys(elements, keys, count)
+			if err != nil {
+				return err
+			}
+
+			if min {
+				return ordered[0]
+			}
+
+			return ordered[len(ordered)-1]
+		},
+	}
 }
 
 // reversedElements returns a reversed copy, leaving src untouched.

--- a/object/array_test.go
+++ b/object/array_test.go
@@ -404,3 +404,82 @@ func TestArrayEach(t *testing.T) {
 	}
 	testInput(t, tests)
 }
+
+// TestArrayCallbackMethods covers the methods unlocked by the function applier.
+// They all share one set of rules for what a callback's return means, so the
+// cases that matter are the shared ones: break, next, an error, and arity.
+func TestArrayCallbackMethods(t *testing.T) {
+	tests := []inputTestCase{
+		{`a = [1,2,3]; a.map(def(x) x * 2 end).to_json()`, "[2,4,6]"},
+		{`a = [1,2,3,4]; a.select(def(x) x % 2 == 0 end).to_json()`, "[2,4]"},
+		{`a = [1,2,3,4]; a.reject(def(x) x % 2 == 0 end).to_json()`, "[1,3]"},
+		// Only false and nil are false, so 0 and "" are yeses -- the language's
+		// own truthiness, the same as if and while use.
+		{`a = [1,2]; a.select(def(x) 0 end).to_json()`, "[1,2]"},
+		{`a = [1,2]; a.select(def(x) "" end).to_json()`, "[1,2]"},
+		{`a = [1,2]; a.select(def(x) nil end).to_json()`, "[]"},
+
+		{`a = [1,2,3]; a.reduce(0, def(sum, x) sum + x end)`, 6},
+		{`a = [1,2,3]; a.reduce(1, def(p, x) p * x end)`, 6},
+		{`a = [1,2]; a.reduce("", def(s, x) s + x.to_s() end)`, "12"},
+		// An empty array answers with the starting value, which is why it is
+		// required rather than taken from the first element.
+		{`a = []; a.reduce(7, def(sum, x) sum + x end)`, 7},
+
+		{`a = [1,2,3]; a.all?(def(x) x > 0 end)`, true},
+		{`a = [1,2,3]; a.all?(def(x) x > 2 end)`, false},
+		{`a = [1,2,3]; a.any?(def(x) x > 2 end)`, true},
+		{`a = [1,2,3]; a.any?(def(x) x > 9 end)`, false},
+		{`a = [1,2,3]; a.none?(def(x) x > 9 end)`, true},
+		{`a = [1,2,3]; a.none?(def(x) x > 2 end)`, false},
+		// An empty array is every element and no element at once.
+		{`a = []; a.all?(def(x) false end)`, true},
+		{`a = []; a.any?(def(x) true end)`, false},
+		{`a = []; a.none?(def(x) true end)`, true},
+
+		{`a = ["ccc","a","bb"]; a.sort_by(def(w) w.size() end).to_json()`, `["a","bb","ccc"]`},
+		{`a = ["ccc","a","bb"]; a.min_by(def(w) w.size() end)`, "a"},
+		{`a = ["ccc","a","bb"]; a.max_by(def(w) w.size() end)`, "ccc"},
+		{`a = []; a.min_by(def(x) x end)`, nil},
+		{`a = []; a.max_by(def(x) x end)`, nil},
+		// The keys have to satisfy what sort requires of elements, and they are
+		// reported the same way.
+		{`a = ["a","b"]; a.sort_by(def(w) nil end)`, "element 0 is not COMPARABLE, got NIL"},
+		{`a = ["a","b"]; a.sort_by(def(w) if w == "a" 1 else "x" end end)`, "keys must all be one COMPARABLE type, got INTEGER at 0 and STRING at 1"},
+
+		// break ends the walk and the answer covers what was walked. next means
+		// the element contributed nothing, which for map is a nil and for a
+		// filter is a no.
+		{`a = [1,2,3,4]; a.map(def(x) if x == 3 break end x end).to_json()`, "[1,2]"},
+		{`a = [1,2,3]; a.map(def(x) if x == 2 next end x end).to_json()`, "[1,null,3]"},
+		{`a = [1,2,3,4]; a.select(def(x) if x == 3 break end true end).to_json()`, "[1,2]"},
+		{`a = [1,2,3]; a.select(def(x) if x == 2 next end true end).to_json()`, "[1,3]"},
+		{`a = [1,2,3]; a.reduce(0, def(sum, x) if x == 3 break end sum + x end)`, 3},
+		{`a = [1,2,3]; a.reduce(0, def(sum, x) if x == 2 next end sum + x end)`, 4},
+		{`a = [1,2,3]; a.all?(def(x) if x == 3 break end x > 0 end)`, true},
+
+		// The pure form leaves the receiver alone, the ! form changes it.
+		{`a = [1,2]; a.map(def(x) x * 2 end); a.to_json()`, "[1,2]"},
+		{`a = [1,2]; a.map!(def(x) x * 2 end); a.to_json()`, "[2,4]"},
+		{`a = [1,2,3]; a.select!(def(x) x > 1 end); a.to_json()`, "[2,3]"},
+		{`a = [1,2,3]; a.reject!(def(x) x > 1 end); a.to_json()`, "[1]"},
+		{`a = ["ccc","a"]; a.sort_by!(def(w) w.size() end); a.to_json()`, `["a","ccc"]`},
+		{`a = [1,2]; a.map!(def(x) x end).type()`, "ARRAY"},
+
+		// An error from a callback ends the walk and is passed on.
+		{`a = [1]; a.map(def(x) x.nope() end)`, "test:1:24: undefined method `.nope()` for INTEGER"},
+		{`a = [1]; a.select(def(x) x.nope() end)`, "test:1:27: undefined method `.nope()` for INTEGER"},
+		{`a = [1]; a.reduce(0, def(s, x) x.nope() end)`, "test:1:33: undefined method `.nope()` for INTEGER"},
+
+		// Arity and callability are reported the same way everywhere.
+		{`a = [1]; a.map(def(x, y) end)`, "to few arguments: got=1, want=2"},
+		{`a = [1]; a.reduce(0, def(x) end)`, "to many arguments: got=2, want=1"},
+		{`a = [1]; a.map(1)`, "wrong argument type on position 1: got=INTEGER, want=CALLABLE"},
+		{`a = [1]; a.reduce(0, "x")`, "wrong argument type on position 2: got=STRING, want=CALLABLE"},
+
+		// Chaining is the point of having them as methods.
+		{`a = [1,2,3,4,5]; a.select(def(x) x % 2 == 1 end).map(def(x) x * x end).sum()`, 35},
+		{`a = [1,2,3]; a.map(def(x) x * 2 end).select(def(x) x > 2 end).reduce(0, def(s, x) s + x end)`, 10},
+	}
+	testInput(t, tests)
+}

--- a/object/callback.go
+++ b/object/callback.go
@@ -50,3 +50,36 @@ func CallbackStopped(o Object) bool {
 func CallbackSkipped(o Object) bool {
 	return o != nil && o.Type() == NEXT_VALUE_OBJ
 }
+
+// CallbackAction says what a method should do with what a callback returned.
+// Every method that takes one faces the same four cases, so they are named once
+// here rather than re-derived in each of them.
+type CallbackAction int
+
+const (
+	// UseValue is an ordinary result.
+	UseValue CallbackAction = iota
+	// SkipElement means the callback ran `next`: this element contributes
+	// nothing. For a method building a list that is a nil entry; for one
+	// filtering, it is a no.
+	SkipElement
+	// StopWalk means the callback ran `break`: iteration ends here and the
+	// answer reflects what was processed, the way break ends a foreach.
+	StopWalk
+	// Failed means the callback errored, and the error is the result.
+	Failed
+)
+
+// ClassifyCallback reads a callback's return value as one of the four actions.
+func ClassifyCallback(result Object) CallbackAction {
+	switch {
+	case IsError(result):
+		return Failed
+	case CallbackStopped(result):
+		return StopWalk
+	case CallbackSkipped(result):
+		return SkipElement
+	default:
+		return UseValue
+	}
+}

--- a/object/hash.go
+++ b/object/hash.go
@@ -193,6 +193,36 @@ func init() {
 				return args[1]
 			},
 		},
+		"each": ObjectMethod{
+			Layout: MethodLayout{
+				ArgPattern: Args(
+					Arg(CALLABLE),
+				),
+				ReturnPattern: Args(
+					Arg(HASH_OBJ, ERROR_OBJ),
+				),
+			},
+			method: func(o Object, args []Object, env Environment) Object {
+				h := o.(*Hash)
+
+				// The order the entries arrive in is not defined and differs
+				// between runs, the same caveat keys() carries. Use it for a
+				// side effect on each entry, not to build something ordered.
+				for _, pair := range h.Pairs {
+					result := CallFunction(args[0], env, pair.Key, pair.Value)
+
+					if IsError(result) {
+						return result
+					}
+
+					if CallbackStopped(result) {
+						break
+					}
+				}
+
+				return h
+			},
+		},
 		"size": ObjectMethod{
 			Layout: MethodLayout{
 				ReturnPattern: Args(
@@ -312,6 +342,59 @@ func init() {
 		},
 	}
 
+	hashCallbackPair("select", func(pairs map[HashKey]HashPair, fn Object, env Environment) (map[HashKey]HashPair, Object) {
+		return filteredPairs(pairs, fn, env, true)
+	})
+	hashCallbackPair("reject", func(pairs map[HashKey]HashPair, fn Object, env Environment) (map[HashKey]HashPair, Object) {
+		return filteredPairs(pairs, fn, env, false)
+	})
+	hashCallbackPair("transform_values", func(pairs map[HashKey]HashPair, fn Object, env Environment) (map[HashKey]HashPair, Object) {
+		out := make(map[HashKey]HashPair, len(pairs))
+
+		for hashed, pair := range pairs {
+			result := CallFunction(fn, env, pair.Value)
+
+			switch ClassifyCallback(result) {
+			case Failed:
+				return nil, result
+			case StopWalk:
+				return out, nil
+			case SkipElement:
+				out[hashed] = HashPair{Key: pair.Key, Value: NIL}
+			default:
+				out[hashed] = HashPair{Key: pair.Key, Value: result}
+			}
+		}
+
+		return out, nil
+	})
+	hashCallbackPair("transform_keys", func(pairs map[HashKey]HashPair, fn Object, env Environment) (map[HashKey]HashPair, Object) {
+		out := make(map[HashKey]HashPair, len(pairs))
+
+		for _, pair := range pairs {
+			result := CallFunction(fn, env, pair.Key)
+
+			switch ClassifyCallback(result) {
+			case Failed:
+				return nil, result
+			case StopWalk:
+				return out, nil
+			case SkipElement:
+				return nil, NewError("a key cannot be nothing: the callback of transform_keys ran next")
+			}
+
+			// A new key still has to be usable as one, and two keys mapping to
+			// the same one collapse -- which of them survives is not defined.
+			hashed, err := hashKeyOf(result)
+			if err != nil {
+				return nil, err
+			}
+			out[hashed] = HashPair{Key: result, Value: pair.Value}
+		}
+
+		return out, nil
+	})
+
 	hashPair("merge", Args(Arg(HASH_OBJ)), func(pairs map[HashKey]HashPair, args []Object) (map[HashKey]HashPair, Object) {
 		merged := copyPairs(pairs)
 		// The argument wins on a clash, as it does in Ruby.
@@ -332,6 +415,67 @@ func init() {
 
 		return kept, nil
 	})
+}
+
+// hashCallbackPair registers a method taking a callback and its in-place
+// counterpart, the same arrangement as hashPair.
+func hashCallbackPair(name string, transform func(pairs map[HashKey]HashPair, fn Object, env Environment) (map[HashKey]HashPair, Object)) {
+	layout := MethodLayout{
+		ArgPattern:    Args(Arg(CALLABLE)),
+		ReturnPattern: Args(Arg(HASH_OBJ, ERROR_OBJ)),
+	}
+
+	objectMethods[HASH_OBJ][name] = ObjectMethod{
+		Layout: layout,
+		method: func(o Object, args []Object, env Environment) Object {
+			pairs, err := transform(o.(*Hash).Pairs, args[0], env)
+			if err != nil {
+				return err
+			}
+
+			return NewHash(pairs)
+		},
+	}
+
+	objectMethods[HASH_OBJ][name+"!"] = ObjectMethod{
+		Layout: layout,
+		method: func(o Object, args []Object, env Environment) Object {
+			h := o.(*Hash)
+
+			pairs, err := transform(h.Pairs, args[0], env)
+			if err != nil {
+				return err
+			}
+			h.Pairs = pairs
+
+			return h
+		},
+	}
+}
+
+// filteredPairs keeps the entries the callback answers for, which way round
+// decided by keep -- select keeps a yes, reject keeps a no.
+func filteredPairs(pairs map[HashKey]HashPair, fn Object, env Environment, keep bool) (map[HashKey]HashPair, Object) {
+	out := make(map[HashKey]HashPair, len(pairs))
+
+	for hashed, pair := range pairs {
+		result := CallFunction(fn, env, pair.Key, pair.Value)
+
+		switch ClassifyCallback(result) {
+		case Failed:
+			return nil, result
+		case StopWalk:
+			return out, nil
+		case SkipElement:
+			continue
+		default:
+			if IsTruthy(result) == keep {
+				out[hashed] = pair
+			}
+		}
+	}
+
+	return out, nil
 }
 
 // hashPair registers a method and its in-place counterpart from one

--- a/object/hash_test.go
+++ b/object/hash_test.go
@@ -165,3 +165,44 @@ func TestHashBangPairsAreComplete(t *testing.T) {
 	}
 	testInput(t, tests)
 }
+
+// TestHashCallbackMethods covers the Hash methods unlocked by the function
+// applier. The order entries arrive in is not defined, so nothing here depends
+// on it -- select and reject answer with a hash, and the counts are what matter.
+func TestHashCallbackMethods(t *testing.T) {
+	tests := []inputTestCase{
+		// select and reject receive the key and the value.
+		{`h = {"a": 1, "b": 2, "c": 3}; h.select(def(k, v) v > 1 end).size()`, 2},
+		{`h = {"a": 1, "b": 2, "c": 3}; h.reject(def(k, v) v > 1 end).size()`, 1},
+		{`h = {"a": 1}; h.select(def(k, v) k == "a" end).size()`, 1},
+		{`h = {"a": 1, "b": 2}; h.select(def(k, v) v > 1 end); h.size()`, 2},
+		{`h = {"a": 1, "b": 2}; h.select!(def(k, v) v > 1 end); h.size()`, 1},
+
+		// transform_values receives the value, transform_keys the key.
+		{`h = {"a": 1}; h.transform_values(def(v) v * 10 end).get("a", 0)`, 10},
+		{`h = {"a": 1}; h.transform_values(def(v) v * 10 end); h.get("a", 0)`, 1},
+		{`h = {"a": 1}; h.transform_values!(def(v) v * 10 end); h.get("a", 0)`, 10},
+		{`h = {"a": 1}; h.transform_keys(def(k) k.upcase() end).get("A", 0)`, 1},
+		{`h = {"a": 1}; h.transform_keys(def(k) k.upcase() end); h.get("a", 0)`, 1},
+		{`h = {"a": 1}; h.transform_keys!(def(k) k.upcase() end); h.get("A", 0)`, 1},
+		// A new key still has to be usable as one.
+		{`h = {"a": 1}; h.transform_keys(def(k) nil end)`, "unusable as hash key: NIL"},
+		{`h = {"a": 1}; h.transform_keys(def(k) next end)`, "a key cannot be nothing: the callback of transform_keys ran next"},
+
+		// each hands back the hash, so it chains, and receives both halves.
+		{`h = {"a": 1}; h.each(def(k, v) end).size()`, 1},
+		{`h = {"a": 1}; h.each(def(k, v) end).type()`, "HASH"},
+		{`out = []; h = {"a": 1}; h.each(def(k, v) out.push(k) end); out.to_json()`, `["a"]`},
+		{`out = []; h = {"a": 1}; h.each(def(k, v) out.push(v) end); out.to_json()`, "[1]"},
+		{`h = {"a": 1}; h.each(def(k, v) break end).size()`, 1},
+
+		// Arity is checked against what the method passes.
+		{`h = {"a": 1}; h.each(def(k) end)`, "to many arguments: got=2, want=1"},
+		{`h = {"a": 1}; h.transform_values(def(v, extra) end)`, "to few arguments: got=1, want=2"},
+		{`h = {"a": 1}; h.each(1)`, "wrong argument type on position 1: got=INTEGER, want=CALLABLE"},
+
+		// An error from a callback is passed on.
+		{`h = {"a": 1}; h.transform_values(def(v) v.nope() end)`, "test:1:42: undefined method `.nope()` for INTEGER"},
+	}
+	testInput(t, tests)
+}

--- a/object/integer.go
+++ b/object/integer.go
@@ -75,6 +75,36 @@ func init() {
 				return NewIntegerWithBase(o.(*Integer).Value, args[0].(*Integer).Value)
 			},
 		},
+		"times": ObjectMethod{
+			Layout: MethodLayout{
+				ArgPattern: Args(
+					Arg(CALLABLE),
+				),
+				ReturnPattern: Args(
+					Arg(INTEGER_OBJ, ERROR_OBJ),
+				),
+			},
+			method: func(o Object, args []Object, env Environment) Object {
+				i := o.(*Integer)
+
+				// 0 to n-1, so 3.times sees 0, 1, 2. A count of zero or less
+				// calls nothing rather than erroring, which is what makes it
+				// safe to hand a computed count.
+				for counter := 0; counter < i.Value; counter++ {
+					result := CallFunction(args[0], env, NewIntegerWithBase(counter, i.Base))
+
+					if IsError(result) {
+						return result
+					}
+
+					if CallbackStopped(result) {
+						break
+					}
+				}
+
+				return i
+			},
+		},
 		"chr": ObjectMethod{
 			Layout: MethodLayout{
 				ReturnPattern: Args(
@@ -299,11 +329,54 @@ func init() {
 		return value / factor * factor
 	})
 
+	integerWalk("upto", false)
+	integerWalk("downto", true)
+
 	integerPredicate("even?", func(value int) bool { return value%2 == 0 })
 	integerPredicate("odd?", func(value int) bool { return value%2 != 0 })
 	integerPredicate("zero?", func(value int) bool { return value == 0 })
 	integerPredicate("positive?", func(value int) bool { return value > 0 })
 	integerPredicate("negative?", func(value int) bool { return value < 0 })
+}
+
+// integerWalk registers upto or downto. Both hand back the receiver so a walk
+// can be chained onto, the way Array#each does.
+func integerWalk(name string, down bool) {
+	objectMethods[INTEGER_OBJ][name] = ObjectMethod{
+		Layout: MethodLayout{
+			ArgPattern:    Args(Arg(INTEGER_OBJ), Arg(CALLABLE)),
+			ReturnPattern: Args(Arg(INTEGER_OBJ, ERROR_OBJ)),
+		},
+		method: func(o Object, args []Object, env Environment) Object {
+			i := o.(*Integer)
+			limit := args[0].(*Integer)
+
+			if err := requireSameBase(i, limit); err != nil {
+				return err
+			}
+
+			step := 1
+			if down {
+				step = -1
+			}
+
+			// Inclusive at both ends, as Ruby's are: 1.upto(3) sees 1, 2, 3. A
+			// limit on the wrong side calls nothing instead of running away.
+			for counter := i.Value; (down && counter >= limit.Value) || (!down && counter <= limit.Value); counter += step {
+				result := CallFunction(args[1], env, NewIntegerWithBase(counter, i.Base))
+
+				if IsError(result) {
+					return result
+				}
+
+				if CallbackStopped(result) {
+					break
+				}
+			}
+
+			return i
+		},
+	}
 }
 
 // integerPredicate registers a method returning a BOOLEAN about the value.

--- a/object/integer_test.go
+++ b/object/integer_test.go
@@ -175,3 +175,42 @@ func TestIntegerRubyMethods(t *testing.T) {
 	}
 	testInput(t, tests)
 }
+
+// TestIntegerCallbackMethods covers times, upto and downto. All three hand back
+// the receiver so a walk chains, the way Array#each does.
+func TestIntegerCallbackMethods(t *testing.T) {
+	tests := []inputTestCase{
+		// times counts 0 to n-1, so 3.times sees 0, 1, 2.
+		{`out = []; 3.times(def(i) out.push(i) end); out.to_json()`, "[0,1,2]"},
+		{`3.times(def(i) end)`, 3},
+		{`3.times(def(i) end).type()`, "INTEGER"},
+		// A count of zero or less calls nothing rather than erroring, which is
+		// what makes it safe to hand a computed count.
+		{`out = []; 0.times(def(i) out.push(i) end); out.to_json()`, "[]"},
+		{`out = []; (0 - 3).times(def(i) out.push(i) end); out.to_json()`, "[]"},
+
+		// upto and downto are inclusive at both ends.
+		{`out = []; 1.upto(3, def(i) out.push(i) end); out.to_json()`, "[1,2,3]"},
+		{`out = []; 3.downto(1, def(i) out.push(i) end); out.to_json()`, "[3,2,1]"},
+		{`out = []; 2.upto(2, def(i) out.push(i) end); out.to_json()`, "[2]"},
+		// A limit on the wrong side calls nothing instead of running away.
+		{`out = []; 3.upto(1, def(i) out.push(i) end); out.to_json()`, "[]"},
+		{`out = []; 1.downto(3, def(i) out.push(i) end); out.to_json()`, "[]"},
+		{`1.upto(3, def(i) end)`, 1},
+
+		{`out = []; 9.times(def(i) if i == 3 break end out.push(i) end); out.to_json()`, "[0,1,2]"},
+		{`out = []; 1.upto(9, def(i) if i == 3 break end out.push(i) end); out.to_json()`, "[1,2]"},
+
+		// The counter keeps the receiver's base, and upto refuses a limit of
+		// another base for the same reason the infix operators do.
+		{`"0x10".to_i().times(def(i) end).base()`, 16},
+		{`out = []; "0b10".to_i().times(def(i) out.push(i.base()) end); out.to_json()`, "[2,2]"},
+		{`"0x10".to_i().upto(4, def(i) end)`, "infix operation with unequal base not allowed"},
+
+		{`3.times(def(i) i.nope() end)`, "test:1:17: undefined method `.nope()` for INTEGER"},
+		{`3.times(def(i, j) end)`, "to few arguments: got=1, want=2"},
+		{`3.times(1)`, "wrong argument type on position 1: got=INTEGER, want=CALLABLE"},
+		{`1.upto(3)`, "to few arguments: got=1, want=2"},
+	}
+	testInput(t, tests)
+}


### PR DESCRIPTION
22 methods that needed a callback and could not have one until #300.

| Type | Added |
| --- | --- |
| `ARRAY` | `map/!` `select/!` `reject/!` `sort_by/!` `reduce` `all?` `any?` `none?` `min_by` `max_by` |
| `HASH` | `each` `select/!` `reject/!` `transform_values/!` `transform_keys/!` |
| `INTEGER` | `times` `upto` `downto` |

Method counts: `ARRAY` 38→52, `HASH` 14→23, `INTEGER` 21→24.

## What it looks like

The example from the design discussion — 24 lines of loops and five throwaway accumulators becomes four lines, with byte-identical output:

```js
active = servers.select(def(s) s.get("active", false) end)

names   = active.map(def(s) s.get("name", "") end).sort()
total   = active.reduce(0, def(sum, s) sum + s.get("memory", 0) end)
biggest = active.max_by(def(s) s.get("memory", 0) end).get("name", "")
```

## One set of rules, named once

Every method faces the same four cases with a callback's return value, so they live in `ClassifyCallback` rather than being re-derived 22 times:

| In the callback | Effect |
| --- | --- |
| a value | used — what that means is the method's business |
| `break` | walk ends here; the answer covers what was walked |
| `next` | the element contributed nothing |
| an error | walk ends, error passed on |

```js
[1,2,3,4].map(def(x) if x == 3 break end x end)   // => [1, 2]
[1,2,3].map(def(x) if x == 2 next end x end)      // => [1, nil, 3]
```

"Contributed nothing" is the only per-method part: a `nil` from `map`, keeping the length as Ruby does, and a no from `select`.

Pure and in-place halves come from one transformation via `arrayCallbackPair`/`hashCallbackPair` — the arrangement `arrayPair`/`hashPair` already use — so a pair cannot drift.

## Decisions worth naming

- **`reduce` requires a starting value.** Ruby lets you omit it and takes the first element, which then makes an empty array a special case. Asking for it keeps one rule: `[].reduce(7, …)` is `7`.
- **Truthiness is the language's own**, so `select` keeps a `0` and an empty string. Differs from Python; matches what `if` and `while` already do.
- **`times` counts 0 to n-1; `upto`/`downto` are inclusive at both ends.** A count of zero or less, or a limit on the wrong side, calls nothing rather than erroring — which is what makes a computed bound safe to pass.
- **`times`/`upto`/`downto` hand back the receiver** so a walk chains, as `Array#each` does. `upto` refuses a limit of another base, as the infix operators do.
- **`sort_by`/`min_by`/`max_by` require of their keys exactly what `sort` requires of elements**, and report it the same way: `element 0 is not COMPARABLE, got NIL`, `keys must all be one COMPARABLE type, got INTEGER at 0 and STRING at 1`.
- **`Hash#each` receives the key and the value**, and its order is undefined — the caveat `keys()` already carries, documented on the method. Anything order-dependent (`Hash#map` to an array, `to_a`) is left out until a hash keeps insertion order.
- **`count` with a callback is left out.** `count(ANY)` already counts occurrences of a value, and a function *is* a value, so a callback form would silently change what an existing call means. `select(fn).size()` covers it.

## Verification

| Check | Result |
| --- | --- |
| `go test ./...` | green |
| documented examples, 6 runs each | **189** (up from 163), 0 mismatches, 0 nondeterministic |
| tracked `.rl` files vs a `main` binary | 42/42 byte-identical |
| `yarn build` | succeeds |
| `GOOS=js GOARCH=wasm go build` | succeeds |
| documented vs actual method sets | `ARRAY` 52/52, `HASH` 23/23, `INTEGER` 24/24 |

**13 mutations, all caught**: `ClassifyCallback` never reporting `Failed` or `StopWalk`; `map` dropping a `next` element instead of nil; `select` keeping everything; `reject` behaving like `select`; `reduce` ignoring the callback result; `all?` behaving like `any?`; `sort_by` ignoring the keys; `min_by` returning the max; `times` counting 1..n; `upto` exclusive at the end; `transform_keys` skipping the key check; `Hash#each` passing only the key.

## Two documentation problems found

- **Three Hash examples were nondeterministic on their own first line** — not the results, but the echo of a multi-entry hash literal, whose order is undefined. They build the second entry by assignment instead, so the example is stable.
- **The `CALLABLE` row was missing from the groups table** on the Types page. A regex-based edit in #300 that removed the `ANY` column dropped it, and nothing checked the table listed every group. Restored, and I now verify the table against the groups the binary reports.