### PR TITLE
feat(evaluator): call a callable stored in a hash as a method

### DIFF
--- a/docs/docs/literals/hash.md
+++ b/docs/docs/literals/hash.md
@@ -22,6 +22,67 @@ respectively.
 
 Reading a key that is not present returns `nil`.
 
+## Calling a value stored in a hash
+
+> 👉 Introduced in `0.24`
+
+A value under a name can be read with a dot, and a **callable** value under a
+name can be *called* with one:
+
+```js
+h = {"double": def(x) return x * 2 end}
+
+puts(h.double(21))     // 42
+puts(h["double"](21))  // the same thing
+```
+
+That makes a hash of functions read like the object it already is. The functions
+close over the locals of whatever built the hash, so the state is private and
+each one is independent:
+
+```js
+def new_account(owner, balance)
+  return {
+    "owner":    owner,
+    "deposit":  def(n) balance = balance + n return balance end,
+    "describe": def() return owner + ": " + balance.to_s() end
+  }
+end
+
+a = new_account("robert", 100)
+b = new_account("someone", 0)
+
+puts(a.deposit(50))   // 150
+puts(a.describe())    // "robert: 150"
+puts(b.describe())    // "someone: 0"
+puts(a.owner)         // "robert" -- plain data, read the same way
+```
+
+A real hash method always wins, so a hash of data cannot take over `size` or
+`keys`. The stored value is still reachable by index:
+
+```js
+h = {"size": def() return 99 end}
+
+puts(h.size())      // 1  -- the hash method
+puts(h["size"]())   // 99 -- the stored function
+```
+
+A name holding something that cannot be called says so, and a name that is not
+there at all reports a missing method as before:
+
+```js
+h = {"n": 1}
+
+h.n()      // ERROR: `n` is not callable for HASH, it is INTEGER
+h.other()  // ERROR: undefined method `.other()` for HASH
+```
+
+This is not a class. The hash is still a `HASH`, so `type()` says `HASH`,
+`methods()` lists the hash's own methods rather than the stored ones, and there
+is no `self` or inheritance. What it adds is the call syntax for a pattern the
+language could already express.
+
 
 
 ```js

--- a/docs/literals/hash.yml
+++ b/docs/literals/hash.yml
@@ -19,6 +19,67 @@ description: |
   respectively.
 
   Reading a key that is not present returns `nil`.
+
+  ## Calling a value stored in a hash
+
+  > 👉 Introduced in `0.24`
+
+  A value under a name can be read with a dot, and a **callable** value under a
+  name can be *called* with one:
+
+  ```js
+  h = {"double": def(x) return x * 2 end}
+
+  puts(h.double(21))     // 42
+  puts(h["double"](21))  // the same thing
+  ```
+
+  That makes a hash of functions read like the object it already is. The functions
+  close over the locals of whatever built the hash, so the state is private and
+  each one is independent:
+
+  ```js
+  def new_account(owner, balance)
+    return {
+      "owner":    owner,
+      "deposit":  def(n) balance = balance + n return balance end,
+      "describe": def() return owner + ": " + balance.to_s() end
+    }
+  end
+
+  a = new_account("robert", 100)
+  b = new_account("someone", 0)
+
+  puts(a.deposit(50))   // 150
+  puts(a.describe())    // "robert: 150"
+  puts(b.describe())    // "someone: 0"
+  puts(a.owner)         // "robert" -- plain data, read the same way
+  ```
+
+  A real hash method always wins, so a hash of data cannot take over `size` or
+  `keys`. The stored value is still reachable by index:
+
+  ```js
+  h = {"size": def() return 99 end}
+
+  puts(h.size())      // 1  -- the hash method
+  puts(h["size"]())   // 99 -- the stored function
+  ```
+
+  A name holding something that cannot be called says so, and a name that is not
+  there at all reports a missing method as before:
+
+  ```js
+  h = {"n": 1}
+
+  h.n()      // ERROR: `n` is not callable for HASH, it is INTEGER
+  h.other()  // ERROR: undefined method `.other()` for HASH
+  ```
+
+  This is not a class. The hash is still a `HASH`, so `type()` says `HASH`,
+  `methods()` lists the hash's own methods rather than the stored ones, and there
+  is no `self` or inheritance. What it adds is the call syntax for a pattern the
+  language could already express.
 example: |
   people = [{"name": "Anna", "age": 24}, {"name": "Bob", "age": 99}];
 

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -1305,3 +1305,95 @@ func TestFunctionArityAcceptsExactMatch(t *testing.T) {
 	testIntegerObject(t, testEval(`def none() return 7 end none()`), 7)
 	testIntegerObject(t, testEval(`f = def(a) return a end f(9)`), 9)
 }
+
+// TestCallableHashMembers covers calling a callable stored in a hash as though
+// it were a method. A hash of functions closing over a constructor's locals is
+// already an object with private state; before this it had to be called as
+// h["deposit"](50), which was the only thing that did not read like one.
+func TestCallableHashMembers(t *testing.T) {
+	constructor := `
+def new_account(owner, balance)
+  return {
+    "owner":    owner,
+    "deposit":  def(n) balance = balance + n return balance end,
+    "describe": def() return owner + ": " + balance.to_s() end
+  }
+end
+`
+
+	tests := []struct {
+		input    string
+		expected any
+	}{
+		{constructor + `a = new_account("r", 100); a.deposit(50)`, 150},
+		{constructor + `a = new_account("r", 100); a.deposit(50); a.describe()`, "r: 150"},
+		// Plain data under a name still reads as data, which already worked.
+		{constructor + `a = new_account("r", 100); a.owner`, "r"},
+
+		// The state is the constructor's locals, so instances are independent.
+		{constructor + `a = new_account("r", 1); b = new_account("s", 2); a.deposit(10); b.describe()`, "s: 2"},
+
+		// A real Hash method wins over a key of the same name, so a hash of
+		// data cannot hijack size() or keys(). The key is still reachable by
+		// index.
+		{`h = {"size": def() return 99 end}; h.size()`, 1},
+		{`h = {"size": def() return 99 end}; h["size"]()`, 99},
+		{`h = {"keys": def() return "hijacked" end}; h.keys().size()`, 1},
+
+		// A builtin is callable, so it can be stored and called too.
+		{`h = {"f": def(x) return x * 2 end}; h.f(21)`, 42},
+
+		// Nesting works, because each step is an ordinary value.
+		{`inner = {"go": def() return "deep" end}; outer = {"inner": inner}; outer.inner.go()`, "deep"},
+
+		// Arity and errors come from the function, reported as anywhere else.
+		{`h = {"f": def(x) return x end}; h.f()`, "to few arguments: got=0, want=1"},
+
+		// A name holding something uncallable says so, rather than claiming the
+		// method does not exist.
+		{`h = {"f": 1}; h.f()`, "`f` is not callable for HASH, it is INTEGER"},
+		{`h = {"f": nil}; h.f()`, "`f` is not callable for HASH, it is NIL"},
+		{`h = {"f": [1]}; h.f()`, "`f` is not callable for HASH, it is ARRAY"},
+
+		// A name that is not there at all keeps the old message, which is the
+		// more useful one: the method does not exist.
+		{`h = {}; h.nope()`, "undefined method `.nope()` for HASH"},
+		{`h = {"f": 1}; h.other()`, "undefined method `.other()` for HASH"},
+
+		// No other type gained a fallback.
+		{`a = [1]; a.nope()`, "undefined method `.nope()` for ARRAY"},
+		{`"a".nope()`, "undefined method `.nope()` for STRING"},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+
+		switch expected := tt.expected.(type) {
+		case int:
+			integer, ok := evaluated.(*object.Integer)
+			if !ok {
+				t.Errorf("input %q: not an Integer. got=%T (%+v)", tt.input, evaluated, evaluated)
+				continue
+			}
+			if integer.Value != expected {
+				t.Errorf("input %q: got=%d, want=%d", tt.input, integer.Value, expected)
+			}
+		case string:
+			if str, ok := evaluated.(*object.String); ok {
+				if str.Value != expected {
+					t.Errorf("input %q: got=%q, want=%q", tt.input, str.Value, expected)
+				}
+				continue
+			}
+
+			errObj, ok := evaluated.(*object.Error)
+			if !ok {
+				t.Errorf("input %q: not a String or Error. got=%T (%+v)", tt.input, evaluated, evaluated)
+				continue
+			}
+			if !strings.Contains(errObj.Message, expected) {
+				t.Errorf("input %q: error %q does not contain %q", tt.input, errObj.Message, expected)
+			}
+		}
+	}
+}

--- a/evaluator/object_call.go
+++ b/evaluator/object_call.go
@@ -34,5 +34,25 @@ func evalObjectCall(call *ast.ObjectCall, env *object.Environment) object.Object
 		return ret
 	}
 
+	// A hash is a namespace as well as a collection, so a callable stored under
+	// a name can be called as a method. That is what makes the closure-and-hash
+	// pattern read like the object it already is: a hash of functions closing
+	// over a constructor's locals had to be called as h["deposit"](50).
+	//
+	// This runs only after InvokeMethod found nothing, so a real Hash method
+	// always wins and a hash of data -- from JSON, say -- cannot hijack size()
+	// or keys().
+	if hash, isHash := obj.(*object.Hash); isHash {
+		name := method.Callable.String()
+
+		if member, found := hash.Get(name); found {
+			if !object.InGroup(object.CALLABLE, member) {
+				return object.NewErrorFormat("%s:%d:%d: `%s` is not callable for HASH, it is %s", call.StartToken.File, call.StartToken.LineNumber, call.StartToken.LinePosition, name, member.Type())
+			}
+
+			return applyFunction(member, args, env)
+		}
+	}
+
 	return object.NewErrorFormat("%s:%d:%d: undefined method `.%s()` for %s", call.StartToken.File, call.StartToken.LineNumber, call.StartToken.LinePosition, method.Callable.String(), obj.Type())
 }


### PR DESCRIPTION
A hash of functions closing over a constructor's locals is already an object — private state, independent instances, methods that can see it. The only thing that did not read like one was the call.

| | Before | Now |
| --- | --- | --- |
| call a stored function | `a["deposit"](50)` | `a.deposit(50)` |
| read a stored value | `a.owner` | unchanged |
| a real hash method | `a.size()` | unchanged |

```js
def new_account(owner, balance)
  return {
    "owner":    owner,
    "deposit":  def(n) balance = balance + n return balance end,
    "describe": def() return owner + ": " + balance.to_s() end
  }
end

a = new_account("robert", 100)
b = new_account("someone", 0)

a.deposit(50)     // => 150
a.describe()      // => "robert: 150"
b.describe()      // => "someone: 0"   -- independent
a.owner           // => "robert"       -- plain data, unchanged
```

## How

`evalObjectCall` already had exactly this shape for a user module: resolve the member from the namespace, apply it as a function. A hash is a namespace too, so it gets the same treatment — about 15 lines.

The fallback runs **only after `InvokeMethod` found nothing**, so a real hash method always wins and a hash of data cannot take over `size()` or `keys()`. The stored value stays reachable by index:

```js
h = {"size": def() return 99 end}
h.size()      // 1  -- the hash method
h["size"]()   // 99 -- the stored function
```

## Errors

| Call | Result |
| --- | --- |
| `h = {"n": 1}; h.n()` | `` `n` is not callable for HASH, it is INTEGER `` |
| `h = {}; h.nope()` | `undefined method `.nope()` for HASH` — the old message, which is the more useful one |
| `h = {"f": def(x) end}; h.f()` | `to few arguments: got=0, want=1` — from the function, as anywhere else |

A name that exists but holds something uncallable is worth distinguishing from a name that is not there at all: the first is a mistake about the value, the second about the method.

## What this is not

Deliberately not a class. The hash is still a `HASH`:

```js
c.type()              // "HASH", not "Counter"
c.is_a?("Counter")    // ERROR: unknown type or type group
c.methods()           // the hash's 23 methods, not the stored ones
```

No `self`, no shared method table (each constructor call allocates fresh closures), no inheritance. It is the call syntax for a pattern the language could already express — worth having on its own, and also the cheapest way to learn whether what people want is classes or just this.

## Verification

| Check | Result |
| --- | --- |
| `go test ./...` | green |
| documented examples | 189, 0 mismatches |
| tracked `.rl` files vs a `main` binary | 42/42 byte-identical |
| `yarn build` | succeeds |
| `GOOS=js GOARCH=wasm go build` | succeeds |

Mutation-tested, all caught: removing the fallback; running it *before* real methods (so a key could shadow `size`); skipping the callability check; letting a missing key fall into the fallback instead of reporting a missing method.

Docs: a new section on the Hash page, with every example verified against the interpreter, including the explicit note that this is not a class.