### PR TITLE
fix: report failure with a non-zero exit code

### DIFF
--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -29,3 +29,40 @@ gpgcheck=0
 Download from [releases](https://github.com/Flipez/rocket-lang/releases).
 
 There is also a [Visual Studio Code Extension](https://marketplace.visualstudio.com/items?itemName=Flipez.rocket-lang-support) available. Just search for `rocket-lang` in the extension menu.
+
+## Running a program
+
+```
+rocket-lang program.rl        # run a file
+rocket-lang -e 'puts("hi")'   # run the code given
+rocket-lang                   # start the REPL
+```
+
+### Exit codes
+
+> 👉 Before `0.24` everything exited `0`, including a crash
+
+| | Exit code |
+| --- | --- |
+| the program ran | `0` |
+| an error nothing handled | `1` |
+| the program did not parse | `1` |
+| the file could not be read | `1` |
+| `OS.exit(n)` or `OS.raise(n, …)` | `n` |
+
+So `rocket-lang build.rl && deploy.sh` no longer runs the deploy after a crash.
+
+An error the program handles is not a failure — `begin`/`rescue` succeeding
+exits `0`, and so does a conversion answering `nil`, which is what `nil` is for:
+
+```js
+begin
+  1 / 0
+rescue e
+  puts("handled")
+end
+// exits 0
+```
+
+Diagnostics — a parse error, an unreadable file — go to standard error. The
+program's own output, and the value it ends on, go to standard output.

--- a/main.go
+++ b/main.go
@@ -24,6 +24,15 @@ var subcommands = map[string]func([]string, io.Writer, io.Writer) int{
 	"planet": planet.Command,
 }
 
+// The process reports whether the program ran. Nothing did before: an uncaught
+// error, a parse error and a missing file all exited 0, so anything scripting
+// the interpreter -- a shell pipeline, CI -- could not tell success from
+// failure, and `rocket-lang typo.rl` said nothing at all.
+const (
+	exitOK      = 0
+	exitFailure = 1
+)
+
 func main() {
 	if len(os.Args) > 1 {
 		if run, ok := subcommands[os.Args[1]]; ok {
@@ -51,18 +60,29 @@ func main() {
 	}
 
 	if len(*exec) > 0 {
-		runProgram(*exec, "")
-		return
+		os.Exit(runProgram(*exec, ""))
 	}
 
 	if len(os.Args) == 1 {
 		repl.Start(os.Stdin, os.Stdout)
-	} else {
-		file, err := utilities.ReadFile(os.Args[1])
-		if err == nil {
-			runProgram(string(file), os.Args[1])
-		}
+
+		return
 	}
+
+	os.Exit(runFile(os.Args[1]))
+}
+
+// runFile runs a program from disk. A file that cannot be read is reported
+// rather than passed over in silence, which is what the missing else did.
+func runFile(path string) int {
+	file, err := utilities.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "rocket-lang: cannot read %s: %s\n", path, err)
+
+		return exitFailure
+	}
+
+	return runProgram(string(file), path)
 }
 
 // configureSearchPath appends the current project's planet directory to the
@@ -91,7 +111,7 @@ func configureSearchPath() {
 	}
 }
 
-func runProgram(input string, file string) {
+func runProgram(input string, file string) int {
 	env := object.NewEnvironment()
 	l := lexer.New(input, file)
 	p := parser.New(l)
@@ -99,19 +119,32 @@ func runProgram(input string, file string) {
 	program := p.ParseProgram()
 	if len(p.Errors()) > 0 {
 		printParserErrors(p.Errors())
-		return
+
+		return exitFailure
 	}
 
 	evaluated := evaluator.Eval(program, env)
-	if evaluated != nil {
-		fmt.Println(evaluated.Inspect())
+	if evaluated == nil {
+		return exitOK
 	}
+
+	// The program's final value is printed whatever it is, because that is what
+	// the interpreter does with a value. An error being that value means nothing
+	// handled it -- an error aborts the rest of the program and becomes its
+	// result -- so the process reports failure.
+	fmt.Println(evaluated.Inspect())
+
+	if object.IsError(evaluated) {
+		return exitFailure
+	}
+
+	return exitOK
 }
 
 func printParserErrors(errors []string) {
-	fmt.Println("🔥 Great, you broke it!")
-	fmt.Println(" parser errors:")
+	fmt.Fprintln(os.Stderr, "🔥 Great, you broke it!")
+	fmt.Fprintln(os.Stderr, " parser errors:")
 	for _, msg := range errors {
-		fmt.Printf("\t %s\n", msg)
+		fmt.Fprintf(os.Stderr, "\t %s\n", msg)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -58,3 +58,87 @@ func TestRocketlangCode(t *testing.T) {
 		}
 	}
 }
+
+// TestExitCodes covers what the process reports. Nothing did before: an
+// uncaught error, a parse error and a missing file all exited 0, so
+// `rocket-lang build.rl && deploy` ran the deploy after a crash.
+func TestExitCodes(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   int
+	}{
+		{"a program that runs", `puts("fine")`, exitOK},
+		{"a program with no output", `a = 1`, exitOK},
+		// An empty program evaluates to nothing at all, which is a different
+		// branch from evaluating to a value.
+		{"an empty program", ``, exitOK},
+		{"only a comment", `// nothing here`, exitOK},
+		// An error aborts the rest of the program and becomes its result, so
+		// the result being an error means nothing handled it.
+		{"an uncaught error", `nil.no_such_method()`, exitFailure},
+		{"an uncaught error part way through", `puts("before")` + "\n" + `nil.nope()`, exitFailure},
+		{"a parse error", `def f(`, exitFailure},
+		// A rescued error is handled, so the program succeeded.
+		{"a rescued error", "begin\n  1 / 0\nrescue e\n  puts(\"handled\")\nend", exitOK},
+		// A failed conversion answers nil rather than erroring, so it is not a
+		// failure -- which is the distinction nil was introduced for.
+		{"a failed conversion", `puts("abc".to_i())`, exitOK},
+		// An error stored in a variable was handled by the program deciding to
+		// keep it, and is not the final value.
+		{"an error that is not the last value", "begin\n  nil.nope()\nrescue e\nend\nputs(\"after\")", exitOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := captureRun(t, func() int { return runProgram(tt.source, "test") })
+
+			if got != tt.want {
+				t.Errorf("exit code %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRunFileReportsAMissingFile covers the case that was silent: no output at
+// all and a successful exit.
+func TestRunFileReportsAMissingFile(t *testing.T) {
+	code := captureRun(t, func() int { return runFile(filepath.Join(t.TempDir(), "nope.rl")) })
+
+	if code != exitFailure {
+		t.Errorf("a missing file should fail, got exit %d", code)
+	}
+}
+
+// TestRunFileRunsAFile checks the ordinary path still works through runFile.
+func TestRunFileRunsAFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ok.rl")
+	if err := os.WriteFile(path, []byte(`puts("hello")`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if code := captureRun(t, func() int { return runFile(path) }); code != exitOK {
+		t.Errorf("a readable program should succeed, got exit %d", code)
+	}
+}
+
+// captureRun runs fn with stdout and stderr sent to a temporary file, so a test
+// does not print the diagnostics it is provoking, and returns fn's exit code.
+func captureRun(t *testing.T, fn func() int) int {
+	t.Helper()
+
+	sink, err := os.CreateTemp(t.TempDir(), "output")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	originalOut, originalErr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = sink, sink
+
+	defer func() {
+		os.Stdout, os.Stderr = originalOut, originalErr
+		sink.Close()
+	}()
+
+	return fn()
+}


### PR DESCRIPTION
Nothing reported failure. `rocket-lang build.rl && deploy.sh` ran the deploy after a crash, and `rocket-lang typo.rl` said nothing at all.

| | Before | After |
| --- | --- | --- |
| clean program | 0 | 0 |
| uncaught error | **0** | 1 |
| parse error | **0** | 1 |
| unreadable file | **0**, and completely silent | 1, naming the file |
| `OS.exit(n)` / `OS.raise(n, …)` | n | n |

The silence came from the read being wrapped with no `else`:

```go
file, err := utilities.ReadFile(os.Args[1])
if err == nil {
    runProgram(string(file), os.Args[1])
}                                          // ← no else
```

## How

`runProgram` returns a code and `main` exits with it. The pattern was already in the same file — subcommands do `os.Exit(run(...))` at `main.go:30`.

**An error being the program's final value is the signal**, because an error aborts the rest of the program and becomes its result. That gives the right answers to the interesting cases:

| Program | Exit | Why |
| --- | --- | --- |
| `begin 1/0 rescue e ... end` | 0 | handled |
| `puts("abc".to_i())` | 0 | a failed conversion answers `nil`, which is the distinction `nil` was introduced for in #285 |
| `puts("before")` then `nil.nope()` | 1 | the error is the result |
| empty program | 0 | evaluates to nothing, a separate branch |

## Streams

Diagnostics moved to **standard error** — a parse error and an unreadable file are not the program's output. The value the program *ends on* stays on standard output, because that is what the interpreter does with a value, and the one existing test expectation containing an `ERROR` is such a value, so it is unaffected.

## Verification

Checked against everything in the repository that runs programs:

| Check | Result |
| --- | --- |
| `go test ./...` | green, 10 packages |
| `coverage.sh` (what CI runs) | passes |
| tracked `.rl` files | 112 succeed and print the same as before; **8 that end in an error now exit 1** |
| the 39 exercises | all pass |
| 189 documented examples | unchanged |
| `gofmt`, `go vet` | clean |

The 8 newly-failing files are the ones that should: `fixtures/parser_error.rl`, `fixtures/cycle_a.rl` and `cycle_b.rl` (circular-import fixtures), `examples/len_out_of_range.rl`, `examples/misc/foreach-error.rl`, `tests/while.rl` (ends in division by zero) and `fixtures/export_module.rl`. CI runs `go test` rather than the interpreter, so nothing there depended on the old behaviour.

**Six mutations, all caught**: making an uncaught error, a parse error, an unreadable file or an empty program exit 0 again; making a clean program fail; making everything fail.

## Two notes

While sweeping the `.rl` files, one output difference turned out **not** to be from this change: `exercises/13_capstone/02_report.rl` prints an array of hashes, and the key order differs run to run on both binaries. That is B2 (hash insertion order) demonstrating itself.

`examples/aoc/2018/day1.rl` takes ~39s on the old binary too, so a `timeout 25` in my sweep produced a 124 — pre-existing slowness, not a regression.

The install guide gains a "Running a program" section with the exit-code table, every claim in it verified against the built binary.