### PR TITLE
fix: count characters, not bytes, in strings outside ASCII

### DIFF
--- a/evaluator/assign.go
+++ b/evaluator/assign.go
@@ -86,27 +86,35 @@ func evalSingleAssign(name ast.Expression, evaluated object.Object, env *object.
 				return object.NewError(err)
 			}
 
-			if l := len(o.Value); int(math.Abs(float64(idx))) >= l {
+			// Characters, not bytes, so that assigning into a string agrees
+			// with indexing it and with size(). Counting bytes made the length
+			// of "тест" eight and let an assignment land inside a character.
+			runes := []rune(o.Value)
+
+			if l := len(runes); int(math.Abs(float64(idx))) >= l {
 				return object.NewErrorFormat(
 					"index out of range, got %d but string is only %d long", idx, l,
 				)
 			}
 
 			if idx < 0 {
-				idx = len(o.Value) + idx
+				idx = len(runes) + idx
 			}
 
 			strEval, ok := evaluated.(*object.String)
 			if !ok {
 				return object.NewErrorFormat("expected STRING object, got %s", evaluated.Type())
 			}
-			if l := len(strEval.Value); l != 1 {
+
+			replacement := []rune(strEval.Value)
+			if l := len(replacement); l != 1 {
 				return object.NewErrorFormat(
 					"expected STRING object to have a length of 1, got %d", l,
 				)
 			}
 
-			o.Value = o.Value[:idx] + strEval.Value + o.Value[idx+1:]
+			runes[idx] = replacement[0]
+			o.Value = string(runes)
 		default:
 			return object.NewErrorFormat("expected object to be indexable")
 		}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -1545,3 +1545,86 @@ func runProgramFile(t *testing.T, path string) (string, object.Object) {
 
 	return <-collected, result
 }
+
+// TestNonASCIIIndexing covers indexing, slicing and assigning into a string
+// outside ASCII. Those three walked bytes while size(), reverse() and the rest
+// counted characters, so "тест"[0] answered a single byte -- half a character.
+func TestNonASCIIIndexing(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected any
+	}{
+		// Indexing.
+		{`s = "тест"; s[0]`, "т"},
+		{`s = "тест"; s[1]`, "е"},
+		{`s = "тест"; s[-1]`, "т"},
+		{`s = "тест"; s[3]`, "т"},
+		{`s = "こんにちは"; s[0]`, "こ"},
+		{`s = "café"; s[3]`, "é"},
+
+		// Slicing.
+		{`s = "тест"; s[:2]`, "те"},
+		{`s = "тест"; s[2:]`, "ст"},
+		{`s = "тест"; s[1:3]`, "ес"},
+
+		// Assigning into one.
+		{`s = "тест"; s[0] = "Т"; s`, "Тест"},
+		{`s = "abc"; s[1] = "ä"; s`, "aäc"},
+		{`s = "тест"; s[0] = "Т"; s.size()`, 4},
+
+		// The bounds are in characters too, so the length in the message
+		// matches what size() answers.
+		{`s = "тест"; s[4] = "x"`, "index out of range, got 4 but string is only 4 long"},
+
+		// ASCII is unchanged, which the documented example depends on.
+		{`s = "abcdef"; s[2]`, "c"},
+		{`s = "abcdef"; s[-2]`, "e"},
+		{`s = "abcdef"; s[:2]`, "ab"},
+		{`s = "abcdef"; s[2:]`, "cdef"},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+
+		switch expected := tt.expected.(type) {
+		case int:
+			testIntegerObject(t, evaluated, expected)
+		case string:
+			if str, ok := evaluated.(*object.String); ok {
+				testStringObject(t, str, expected)
+				continue
+			}
+
+			errObj, ok := evaluated.(*object.Error)
+			if !ok {
+				t.Errorf("input %q: not a String or Error, got %T", tt.input, evaluated)
+				continue
+			}
+			if !strings.Contains(errObj.Message, expected) {
+				t.Errorf("input %q: error %q does not contain %q", tt.input, errObj.Message, expected)
+			}
+		}
+	}
+}
+
+// TestStringOperationsAgreeOnLength walks every string method and operation
+// that counts, and checks they all count characters. Any one of them counting
+// bytes puts it out of step with the others, which is how this began.
+func TestStringOperationsAgreeOnLength(t *testing.T) {
+	for _, sample := range []string{`"тест"`, `"こんにちは"`, `"café"`, `"plain"`, `"a👍b"`} {
+		size := testEval(sample + ".size()")
+		ascii := testEval(sample + ".ascii().size()")
+		reversed := testEval(sample + ".reverse().size()")
+		sliced := testEval(sample + "[0:1].size()")
+
+		if size.Inspect() != ascii.Inspect() {
+			t.Errorf("%s: size() is %s but ascii() has %s entries", sample, size.Inspect(), ascii.Inspect())
+		}
+		if size.Inspect() != reversed.Inspect() {
+			t.Errorf("%s: size() is %s but reverse() is %s long", sample, size.Inspect(), reversed.Inspect())
+		}
+		if sliced.Inspect() != "1" {
+			t.Errorf("%s: a one-character slice is %s characters long", sample, sliced.Inspect())
+		}
+	}
+}

--- a/evaluator/index.go
+++ b/evaluator/index.go
@@ -86,15 +86,19 @@ func evalBuiltinModuleIndexExpression(module, index object.Object) object.Object
 }
 
 func evalStringIndexExpression(left, index object.Object) object.Object {
-	obj := left.(*object.String)
-	max := len(obj.Value) - 1
+	// Characters, not bytes. Indexing the string directly cuts a multi-byte
+	// character in half: "тест"[0] answered a single byte, which is not a
+	// character at all. size(), reverse() and the rest have always counted
+	// characters, so indexing has to agree with them.
+	runes := []rune(left.(*object.String).Value)
+	max := len(runes) - 1
 	idx := transformIndex(index.(*object.Integer).Value, max)
 
 	if idx > max {
 		return object.NIL
 	}
 
-	return object.NewString(string(obj.Value[idx]))
+	return object.NewString(string(runes[idx]))
 }
 
 func evalMatrixIndexExpression(left, index object.Object) object.Object {
@@ -119,29 +123,31 @@ func evalMatrixIndexExpression(left, index object.Object) object.Object {
 }
 
 func evalStringRangeIndexExpression(left, firstIndex, secondIndex object.Object) object.Object {
-	obj := left.(*object.String)
-	max := len(obj.Value) - 1
+	// Characters, for the same reason as evalStringIndexExpression: slicing the
+	// bytes of "тест" landed between the halves of a character.
+	runes := []rune(left.(*object.String).Value)
+	max := len(runes) - 1
 
 	if firstIndex == nil && secondIndex == nil {
-		return object.NewString(obj.Value)
+		return object.NewString(string(runes))
 	} else if firstIndex != nil && secondIndex != nil {
 		first := transformIndex(firstIndex.(*object.Integer).Value, max)
 		second := transformIndex(secondIndex.(*object.Integer).Value, max)
 
 		if first <= max && second <= max && first <= second {
-			return object.NewString(obj.Value[first:second])
+			return object.NewString(string(runes[first:second]))
 		}
 	} else if firstIndex != nil && secondIndex == nil {
 		first := transformIndex(firstIndex.(*object.Integer).Value, max)
 
 		if first <= max {
-			return object.NewString(obj.Value[first:])
+			return object.NewString(string(runes[first:]))
 		}
 	} else if firstIndex == nil && secondIndex != nil {
 		second := transformIndex(secondIndex.(*object.Integer).Value, max)
 
 		if second <= max {
-			return object.NewString(obj.Value[:second])
+			return object.NewString(string(runes[:second]))
 		}
 	}
 

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -224,7 +224,15 @@ func (l *Lexer) NextToken() token.Token {
 }
 
 func (l *Lexer) readDoubleQuoteString() string {
-	var escapedString string
+	// Collected as bytes, and turned into a string once at the end.
+	//
+	// Appending string(l.ch) instead looks equivalent and is not: l.ch is a
+	// byte, and string(aByte) converts its numeric value to a rune and encodes
+	// that. So each byte of a multi-byte character became a character of its
+	// own -- "тест" arrived as eight characters holding the values of its eight
+	// UTF-8 bytes, which is why size() answered 8 and reverse() and chop() cut
+	// characters in half.
+	var out []byte
 
 	for {
 		l.readChar()
@@ -234,31 +242,32 @@ func (l *Lexer) readDoubleQuoteString() string {
 			switch nextCh {
 			case '"':
 				l.readChar()
-				escapedString += "\""
+				out = append(out, '"')
 			case 'n':
 				l.readChar()
-				escapedString += "\n"
+				out = append(out, '\n')
 			case 't':
 				l.readChar()
-				escapedString += "\t"
+				out = append(out, '\t')
 			case 'r':
 				l.readChar()
-				escapedString += "\r"
+				out = append(out, '\r')
 			case '\\':
 				l.readChar()
-				escapedString += "\\"
+				out = append(out, '\\')
 			default:
-				// If not a recognized escape sequence, keep the backslash
-				escapedString += string(l.ch)
+				// Not an escape sequence anyone recognises, so keep what is
+				// there, backslash included.
+				out = append(out, l.ch)
 			}
 		} else if l.ch == '"' || l.ch == 0 {
 			break
 		} else {
-			escapedString += string(l.ch)
+			out = append(out, l.ch)
 		}
 	}
 
-	return escapedString
+	return string(out)
 }
 
 func (l *Lexer) readSingleQuoteString() string {
@@ -273,14 +282,17 @@ func (l *Lexer) readSingleQuoteString() string {
 }
 
 func (l *Lexer) readIdentifier() string {
-	id := ""
+	// Bytes, for the same reason as readDoubleQuoteString. A name outside ASCII
+	// was mangled the same way, and only worked because its definition and its
+	// uses were mangled identically -- so it matched itself while being wrong.
+	var id []byte
 
 	for l.isIdentifier(l.ch) {
-		id += string(l.ch)
+		id = append(id, l.ch)
 		l.readChar()
 	}
 
-	return id
+	return string(id)
 }
 
 func (l *Lexer) isNewline() bool {

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -160,3 +160,91 @@ func TestNextToken(t *testing.T) {
 		}
 	}
 }
+
+// TestNonASCIIStrings covers what a double-quoted literal outside ASCII used to
+// become. l.ch is a byte, and appending string(l.ch) converts its numeric value
+// to a rune and encodes that -- so every byte of a multi-byte character became a
+// character of its own, and "тест" arrived as eight characters holding the
+// values of its eight UTF-8 bytes.
+//
+// A single-quoted literal was always right, because it slices the input rather
+// than rebuilding it. That the two disagreed is what gives the game away.
+func TestNonASCIIStrings(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"cyrillic", `"тест"`, "тест"},
+		{"cjk", `"こんにちは"`, "こんにちは"},
+		{"accents", `"café"`, "café"},
+		{"an emoji inside a string", `"a👍b"`, "a👍b"},
+		{"mixed with escapes", `"т\tе"`, "т\tе"},
+		{"escapes still work", `"a\tb\nc\"d\\e"`, "a\tb\nc\"d\\e"},
+		{"ascii is unchanged", `"plain"`, "plain"},
+		{"empty", `""`, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tok := New(tt.input, "test").NextToken()
+
+			if tok.Type != token.STRING {
+				t.Fatalf("token type %s, want STRING", tok.Type)
+			}
+			if tok.Literal != tt.want {
+				t.Errorf("literal %q, want %q", tok.Literal, tt.want)
+			}
+			if len([]rune(tok.Literal)) != len([]rune(tt.want)) {
+				t.Errorf("%d characters, want %d", len([]rune(tok.Literal)), len([]rune(tt.want)))
+			}
+		})
+	}
+}
+
+// TestQuotingStylesAgree checks the two kinds of literal produce the same
+// string. They did not: '...' sliced the input and "..." rebuilt it wrongly.
+func TestQuotingStylesAgree(t *testing.T) {
+	for _, content := range []string{"тест", "こんにちは", "café", "plain", "a👍b"} {
+		double := New(`"`+content+`"`, "test").NextToken()
+		single := New(`'`+content+`'`, "test").NextToken()
+
+		if double.Literal != single.Literal {
+			t.Errorf("%q: double-quoted gave %q, single-quoted gave %q", content, double.Literal, single.Literal)
+		}
+	}
+}
+
+// TestNonASCIIIdentifier covers the same mistake in readIdentifier. It only ever
+// worked because a name and its uses were mangled identically, so it matched
+// itself while being wrong.
+func TestNonASCIIIdentifier(t *testing.T) {
+	tok := New("föö", "test").NextToken()
+
+	if tok.Type != token.IDENT {
+		t.Fatalf("token type %s, want IDENT", tok.Type)
+	}
+	if tok.Literal != "föö" {
+		t.Errorf("literal %q, want %q", tok.Literal, "föö")
+	}
+}
+
+// TestEmojiTokensStillWork guards the emoji handling, which assembles a
+// character from its bytes and is the one place that was already deliberate
+// about multi-byte input.
+func TestEmojiTokensStillWork(t *testing.T) {
+	tests := []struct {
+		input string
+		want  token.TokenType
+	}{
+		{"👍", token.TRUE},
+		{"👎", token.FALSE},
+		{"➕", token.PLUS},
+	}
+
+	for _, tt := range tests {
+		if tok := New(tt.input, "test").NextToken(); tok.Type != tt.want {
+			t.Errorf("%s lexed as %s, want %s", tt.input, tok.Type, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
`"тест".size()` answered **8**. The four characters had become eight, each holding the value of one of the string's UTF-8 bytes.

| | Before | After |
| --- | --- | --- |
| `"тест".size()` | `8` | `4` |
| `"тест".reverse()` | mangled | `тсет` |
| `"тест".chop()` | cut a character in half | `тес` |
| `"тест".ascii()` | `[209, 130, 208, 181, ...]` -- the bytes | `[1090, 1077, 1089, 1090]` |
| `"тест".upcase()` | mangled | `ТЕСТ` |
| `"тест"[0]` | half a character | `т` |
| `"тест"[:2]` | `т` | `те` |
| `s[0] = "Т"` | corrupted the string | `Тест` |

## The cause was one expression

`l.ch` is a `byte`, and `readDoubleQuoteString` built the literal with:

```go
escapedString += string(l.ch)
```

`string(aByte)` converts the *numeric value* to a rune and encodes that. So every byte became a character of its own -- textbook mojibake, and the **data was wrong**, not merely miscounted. Four runes in, eight runes out, each holding one of the original bytes.

**What pointed at it:** a single-quoted literal was always correct -- `'тест'.size()` was `4` -- because `readSingleQuoteString` *slices* the input instead of rebuilding it. Two spellings of the same string disagreeing is what localised the bug to one function.

`readIdentifier` had the same mistake, and got away with it because a name and its uses were mangled identically, so it matched itself while being wrong.

Both collect bytes now and convert once.

## Fixing the lexer exposed a second problem

Indexing, slicing and assigning into a string all walked **bytes**, in `evaluator/index.go` and `evaluator/assign.go`. Previously everything was consistently mangled; with the literal correct, `"тест"[0]` returned half a character while `size()` counted four.

All three operate on runes now, so everything that counts agrees -- which a test asserts directly across `size()`, `ascii()`, `reverse()` and slicing. The out-of-range message counts characters too, so the length it reports matches what `size()` answers.

## What is deliberately not here

Converting the whole lexer to runes. It would give better error columns on lines containing non-ASCII, since `positionInLine` counts bytes, and would let the emoji byte-assembly hack go. Neither is the reported defect, and the surgical fix carries far less risk in a file this central.

## Verification

| Check | Result |
| --- | --- |
| `go test ./...` | green, 10 packages |
| `coverage.sh` (what CI runs) | passes |
| `gofmt`, `go vet` | clean |
| tracked `.rl` files | same output **and** same exit code, except the two noted below |
| the 39 exercises | all pass |
| 189 documented examples | unchanged |
| emoji tokens | still lex correctly |
| escapes `\t` `\n` `\"` `\\` | unchanged |
| CJK, accents, an emoji inside a string | all correct |

**Four mutations, all caught**: widening bytes again in the string literal or the identifier, and walking bytes again in indexing or in assignment.

Two files differ between the old and new binaries and neither is from this change: `exercises/08_functions/03_closures.rl` and `13_capstone/02_report.rl` end on a hash and **differ from themselves run to run** -- B2, hash insertion order, demonstrating itself. I confirmed that by running one binary four times.

One process note: my first mutation attempt was `string([]rune(string(out)))`, which is an identity round trip, so its "survived" result was meaningless. The real mutation reproduces `size()` answering 8, and is caught.
