### PR TITLE
fix(docs): re-land the broken-link fix lost in #308's merge

### DIFF
--- a/docs/blog/releases/2022-07-02-release-0.16.md
+++ b/docs/blog/releases/2022-07-02-release-0.16.md
@@ -9,13 +9,13 @@ tags: [release]
 The `HTTP` builtin has been added which allows to create a builtin webserver
 and handle incoming requests.
 
-See [HTTP](/docs/builtins/http) for more information.
+See [HTTP](/docs/literals/http) for more information.
 
 ### Add Ability to marshal Objects to JSON Strings
 You can now use `.to_json()` to various objects in order to convert them to
 their JSON respresentation.
 
-See [JSON](/docs/builtins/json) for more information.
+See [JSON](/docs/builtins/JSON) for more information.
 
 ### Support for Next and Break
 Within a loop you can now use `break` and `next` for complex control flows.

--- a/docs/blog/releases/2022-07-25-release-0.18.md
+++ b/docs/blog/releases/2022-07-25-release-0.18.md
@@ -16,7 +16,7 @@ It is now possible to parse a string via the `JSON` literal and creating an Rock
 => ["test", 123.0]
 ```
 
-See [JSON](/docs/builtins/json) for more information.
+See [JSON](/docs/builtins/JSON) for more information.
 
 ### Support for Single Quotes (`'`)
 You can now use single-quotes to create a string additionally to the already existing double-quotes. This allows more flexibility in creating rich content like json.

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -11,8 +11,18 @@ const config = {
   tagline: '',
   url: 'https://rocket-lang.org',
   baseUrl: '/',
-  onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
+  // 'throw' is Docusaurus' own default, and the reason this is back: under
+  // 'warn' three blog links to /docs/builtins/json and /docs/builtins/http
+  // -- the generated pages are JSON.md and HTTP.md -- warned on every single
+  // build and were dead for years. A warning nobody reads is not a check.
+  onBrokenLinks: 'throw',
+  markdown: {
+    hooks: {
+      // Moved here from the top level, which Docusaurus deprecates and drops
+      // in v4. 'throw' for the same reason as onBrokenLinks above.
+      onBrokenMarkdownLinks: 'throw',
+    },
+  },
   favicon: 'img/favicon.ico',
   // Even if you don't use internalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want


### PR DESCRIPTION
This is a **re-land**. It was the second commit of #308 (`17d99ab`), and it did not make it into `main`: the squash merge took only the first commit, so `f7c57cc` contains 5 files where the branch had 8.

The commit still existed on `origin/fix/homepage-examples`, so this is a clean cherry-pick, unchanged.

**How I noticed:** building the docs while working on B8, the warning was back:

```
[WARNING] Docusaurus found broken links!
[WARNING] The `siteConfig.onBrokenMarkdownLinks` config option is deprecated
```

Which is a small irony -- the whole point of the commit is that a warning nobody reads is not a check.

## What it contains

Three blog links pointed at `/docs/builtins/json` and `/docs/builtins/http`; the generated pages are `JSON.md` and `HTTP.md`, so all three were dead.

| Blog post | Was | Now | Why |
| --- | --- | --- | --- |
| 0.16, HTTP | `/docs/builtins/http` | `/docs/literals/http` | the paragraph describes handling requests; `handle()`/`listen()` are on the HTTP **object**, and `/docs/builtins/HTTP` documents only `new()` |
| 0.16, JSON | `/docs/builtins/json` | `/docs/builtins/JSON` | `JSON.parse` is a module function |
| 0.18, JSON | `/docs/builtins/json` | `/docs/builtins/JSON` | same |

`onBrokenLinks` is back to `'throw'` (Docusaurus' own default) so this cannot silently return, and `onBrokenMarkdownLinks` moved to `markdown.hooks`, where Docusaurus 4 expects it.

## Verification

`yarn build` passes with `throw`, and the warnings are down to two pre-existing ones unrelated to links (blog posts without truncation markers, and the summary that reports them).

The guard was mutation-tested when the commit was first written: reverting one link to lowercase fails the build with exit 1.
