### PR TITLE
fix: finish removing curly-brace blocks

### DIFF
--- a/docs/blog/releases/2022-07-02-release-0.16.md
+++ b/docs/blog/releases/2022-07-02-release-0.16.md
@@ -62,13 +62,13 @@ Contribution by [RaphaelPour](https://github.com/RaphaelPour)
 An Integer can now be iterated.
 
 ```js
-🚀 > foreach i in 5 { puts(i) }
+🚀 > foreach i in 5 puts(i) end
 0
 1
 2
 3
 4
-=> 5
+=> nil
 ```
 
 ### Support for Modulo Operator

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -200,7 +200,7 @@ func TestErrorHandling(t *testing.T) {
 			`, "unknown operator: BOOLEAN + BOOLEAN",
 		},
 		{`"Hello" - "World"`, "unknown operator: STRING - STRING"},
-		{`{"name": "Monkey"}[def(x) { x }];`, "unusable as hash key: FUNCTION"},
+		{`{"name": "Monkey"}[def(x) x end];`, "unusable as hash key: FUNCTION"},
 		{"🔥 != 👍", "test:1:1: identifier not found: IDENT"},
 		{"5 % 0", "division by zero not allowed"},
 		{"5 % 0 ? true : false", "division by zero not allowed"},

--- a/parser/block.go
+++ b/parser/block.go
@@ -15,7 +15,12 @@ func (p *Parser) parseBlock() *ast.Block {
 
 	p.nextToken()
 
-	for !p.curTokenIs(token.RBRACE) && !p.curTokenIs(token.EOF) && !p.curTokenIs(token.END) && !p.curTokenIs(token.ELSE) && !p.curTokenIs(token.ELIF) && !p.curTokenIs(token.RESCUE) {
+	// `}` is deliberately not a terminator. Curly-brace blocks were removed in
+	// #89, before v0.16.0, but this check was left behind -- so a `}` still
+	// closed a block while `{` no longer opened one. A stray `}` therefore stood
+	// in for a missing `end` and the program ran, with the block ending somewhere
+	// the reader had no reason to expect.
+	for !p.curTokenIs(token.EOF) && !p.curTokenIs(token.END) && !p.curTokenIs(token.ELSE) && !p.curTokenIs(token.ELIF) && !p.curTokenIs(token.RESCUE) {
 
 		stmt := p.parseStatement()
 		if stmt != nil {

--- a/parser/hash.go
+++ b/parser/hash.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"fmt"
+
 	"github.com/flipez/rocket-lang/ast"
 	"github.com/flipez/rocket-lang/token"
 )
@@ -13,9 +15,26 @@ func (p *Parser) parseHash() ast.Expression {
 		p.nextToken()
 		key := p.parseExpression(LOWEST)
 
-		if !p.expectPeek(token.COLON) {
+		if !p.peekTokenIs(token.COLON) {
+			// `{` only ever opens a hash literal: curly braces stopped being
+			// block delimiters in #89. Someone writing `foreach i in 3 { ... }`
+			// lands here, and "expected next token to be :" tells them nothing,
+			// so say what `{` means when the key is followed by the closing
+			// brace rather than by a value.
+			if p.peekTokenIs(token.RBRACE) {
+				p.errors = append(p.errors, fmt.Sprintf(
+					"%d:%d: expected `:` after a hash key; `{` opens a hash literal, not a block -- a block needs no braces and closes with `end`",
+					p.peekToken.LineNumber, p.peekToken.LinePosition))
+
+				return nil
+			}
+
+			p.peekError(p.curToken, token.COLON)
+
 			return nil
 		}
+
+		p.nextToken()
 
 		p.nextToken()
 		value := p.parseExpression(LOWEST)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -874,7 +874,7 @@ func TestImportWithIntegerExpressionPathIsAParseError(t *testing.T) {
 }
 
 func TestParsingForEachExpressionsFailsWithNegativeNumber(t *testing.T) {
-	l := lexer.New(`foreach i in -5 { puts(i)}`, "test")
+	l := lexer.New("foreach i in -5\n  puts(i)\nend", "test")
 	p := New(l)
 	p.ParseProgram()
 
@@ -1182,5 +1182,96 @@ func TestLineBreakSeparatesStatements(t *testing.T) {
 					tt.expectedStatements, len(program.Statements), tt.input, program.String())
 			}
 		})
+	}
+}
+
+// TestCurlyBraceBlocksAreRejected covers the removal of curly-brace blocks.
+// They were dropped in #89 before v0.16.0, but `}` stayed in parseBlock's
+// terminator list -- so `{` no longer opened a block while `}` still closed
+// one, and a stray `}` quietly stood in for a missing `end`.
+func TestCurlyBraceBlocksAreRejected(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		// The message a reader should get, in part.
+		expectedError string
+	}{
+		{
+			"foreach",
+			"foreach i in 3 { puts(i) }",
+			"`{` opens a hash literal, not a block",
+		},
+		{
+			"if",
+			"if (true) { puts(\"y\") }",
+			"`{` opens a hash literal, not a block",
+		},
+		{
+			"while",
+			"while (false) { puts(1) }",
+			"`{` opens a hash literal, not a block",
+		},
+		{
+			// `}` used to close the block here, and the program ran.
+			"a stray } cannot stand in for end",
+			"if (true)\n  puts(\"in\")\n}\nputs(\"after\")",
+			"expected `end` to close the block opened here",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, p := createProgram(tt.input)
+
+			if len(p.errors) == 0 {
+				t.Fatalf("expected a parser error for %q, got none", tt.input)
+			}
+
+			if !strings.Contains(strings.Join(p.errors, "\n"), tt.expectedError) {
+				t.Errorf("expected an error containing %q for %q, got:\n%s",
+					tt.expectedError, tt.input, strings.Join(p.errors, "\n"))
+			}
+		})
+	}
+}
+
+// TestHashLiteralsStillParse guards the other side of the change: `{` is a hash
+// literal everywhere, including as the only statement of a block, which is how
+// a function returns one.
+func TestHashLiteralsStillParse(t *testing.T) {
+	tests := []string{
+		`x = {"a": 1, "b": 2}`,
+		`x = {}`,
+		`x = {"a": {"b": 1}}`,
+		"def make()\n  {\"a\": 1}\nend",
+		"def empty()\n  {}\nend",
+		`foreach k, v in {"a": 1}` + "\n  puts(k)\nend",
+	}
+
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			_, p := createProgram(input)
+			checkParserErrors(t, p)
+		})
+	}
+}
+
+// TestHashKeyWithoutColonKeepsThePlainMessage checks that the brace-block hint
+// does not leak into a genuine hash typo, where it would be noise.
+func TestHashKeyWithoutColonKeepsThePlainMessage(t *testing.T) {
+	_, p := createProgram(`x = {"a" 1}`)
+
+	if len(p.errors) == 0 {
+		t.Fatal("expected a parser error, got none")
+	}
+
+	joined := strings.Join(p.errors, "\n")
+
+	if strings.Contains(joined, "not a block") {
+		t.Errorf("the brace-block hint should not appear for a hash missing its colon, got:\n%s", joined)
+	}
+
+	if !strings.Contains(joined, "expected next token to be :") {
+		t.Errorf("expected the plain message, got:\n%s", joined)
 	}
 }


### PR DESCRIPTION
Curly braces stopped being block delimiters in #89, before v0.16.0. The removal was unfinished: `}` stayed in `parseBlock`'s terminator list, so `{` no longer opened a block while `}` still closed one.

The consequence was silent. A stray `}` stood in for a missing `end`:

```js
if (true)
  puts("in")
}
puts("after")
```

printed `in` and `after` and exited 0. Now it reports the stray `}` and the unclosed block.

Braces stay dropped: nothing uses them (every `{` in 120 tracked `.rl` files is a hash literal), and `end` already fits on one line — `foreach i in 5 puts(i) end`, which matters because the REPL cannot take a multi-line block.

A brace block now says what is wrong, but only when the key is followed by `}`; a hash merely missing a colon keeps the plain message. `{` at the start of a block body could not just be rejected, since a hash literal is legitimate there (it is how a function returns one).

Two test inputs relied on the hazard: `def(x) { x }` reached the evaluator only because `}` closed the body. Now `def(x) x end`, same resulting error.

The release-0.16 blog post advertised `foreach i in 5 { puts(i) }` — stale on arrival, since braces broke in that release — and claimed `=> 5` where `foreach` answers `nil`. Both fixed.

Bisected: braces worked v0.10.0–v0.15.0, broke in v0.16.0.

Verified: 1 of 120 tracked `.rl` files differs, and it differs from itself run to run (B2, hash order). Three mutations caught — `}` restored as a terminator, the hint removed, the hint firing unconditionally. 10 packages green, `coverage.sh` and the docs build pass.
