### PR TITLE
test(repl): make the REPL testable, and stop a typo ending the session

### DIFF
--- a/repl/repl.go
+++ b/repl/repl.go
@@ -5,13 +5,11 @@ package repl
 import (
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"strings"
 
 	"github.com/chzyer/readline"
 
-	"github.com/flipez/rocket-lang/ast"
 	"github.com/flipez/rocket-lang/evaluator"
 	"github.com/flipez/rocket-lang/lexer"
 	"github.com/flipez/rocket-lang/object"
@@ -21,60 +19,105 @@ import (
 var buildVersion = "v0.10.0"
 var buildDate = "2021-12-27T21:13:44Z"
 
-func Start(in io.Reader, out io.Writer) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		log.Fatal(err)
+const prompt = "🚀 \033[31m»\033[0m "
+
+// Session is what a REPL session accumulates: one environment, shared by every
+// line, so a variable defined on one line is there on the next.
+//
+// It exists so the read-eval-print part can be driven without a terminal.
+// Everything used to sit inside Start, wired to readline and fmt.Println, and
+// the package had no tests at all -- which is how a parse error came to end the
+// session.
+type Session struct {
+	env *object.Environment
+	out io.Writer
+}
+
+// NewSession starts a session that writes to out.
+func NewSession(out io.Writer) *Session {
+	env := object.NewEnvironment()
+
+	// The REPL lets a name be reassigned, which a module may not do.
+	env.AllowRebind()
+
+	return &Session{env: env, out: out}
+}
+
+// Eval runs one line and writes whatever the user should see.
+//
+// A line that does not parse is reported and the session carries on. It used to
+// return from Start instead, so a single typo ended the session and took every
+// variable defined in it -- while a runtime error, the far more common mistake,
+// correctly carried on.
+func (s *Session) Eval(line string) {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return
 	}
 
-	rl, err := readline.NewEx(&readline.Config{
-		Prompt:                 "🚀 \033[31m»\033[0m ",
-		HistoryFile:            homeDir + "/.rocket_history",
+	p := parser.New(lexer.New(line, ""))
+	program := p.ParseProgram()
+
+	if errors := p.Errors(); len(errors) > 0 {
+		s.printParserErrors(errors)
+
+		return
+	}
+
+	if evaluated := evaluator.Eval(program, s.env); evaluated != nil {
+		fmt.Fprintln(s.out, "» "+evaluated.Inspect())
+	}
+}
+
+func (s *Session) printParserErrors(errors []string) {
+	fmt.Fprintln(s.out, "🔥 Great, you broke it!")
+	fmt.Fprintln(s.out, " parser errors:")
+
+	for _, msg := range errors {
+		fmt.Fprintf(s.out, "\t %s\n", msg)
+	}
+}
+
+// Start reads lines from in and writes to out until in is exhausted.
+func Start(in io.Reader, out io.Writer) {
+	config := &readline.Config{
+		Prompt:                 prompt,
 		InterruptPrompt:        "^C",
 		DisableAutoSaveHistory: true,
-	})
+		Stdin:                  io.NopCloser(in),
+		Stdout:                 out,
+	}
 
+	// History is a convenience, not a requirement: without a home directory to
+	// put the file in, the session runs without one rather than refusing to
+	// start.
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		config.HistoryFile = homeDir + "/.rocket_history"
+	}
+
+	rl, err := readline.NewEx(config)
 	if err != nil {
 		panic(err)
 	}
 
 	defer rl.Close()
 
-	env := object.NewEnvironment()
-	env.AllowRebind()
+	session := NewSession(out)
 
-	fmt.Println(SplashScreen())
+	fmt.Fprintln(out, SplashScreen())
 
 	for {
 		line, err := rl.Readline()
-
 		if err != nil {
 			break
 		}
 
-		line = strings.TrimSpace(line)
-		if len(line) == 0 {
+		if strings.TrimSpace(line) == "" {
 			continue
 		}
 
-		rl.SetPrompt("🚀 \033[31m»\033[0m ")
 		rl.SaveHistory(line)
-
-		l := lexer.New(line, "")
-		p := parser.New(l)
-
-		var program *ast.Program
-
-		program = p.ParseProgram()
-		if len(p.Errors()) > 0 {
-			printParserErrors(p.Errors())
-			return
-		}
-
-		evaluated := evaluator.Eval(program, env)
-		if evaluated != nil {
-			fmt.Println("» " + evaluated.Inspect())
-		}
+		session.Eval(line)
 	}
 }
 
@@ -93,12 +136,4 @@ func SplashScreen() string {
 
 func SplashVersion() string {
 	return fmt.Sprintf("rocket-lang version %s (%s)\n", buildVersion, buildDate)
-}
-
-func printParserErrors(errors []string) {
-	fmt.Println("🔥 Great, you broke it!")
-	fmt.Println(" parser errors:")
-	for _, msg := range errors {
-		fmt.Printf("\t %s\n", msg)
-	}
 }

--- a/repl/repl_test.go
+++ b/repl/repl_test.go
@@ -1,0 +1,255 @@
+//go:build !wasm
+
+package repl
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// run feeds lines to one session and returns everything it wrote.
+func run(lines ...string) string {
+	var out bytes.Buffer
+
+	session := NewSession(&out)
+	for _, line := range lines {
+		session.Eval(line)
+	}
+
+	return out.String()
+}
+
+// TestParseErrorDoesNotEndTheSession is the reason this file exists. Start used
+// to return when a line failed to parse, so a single typo ended the session and
+// took every variable defined in it -- while a runtime error carried on.
+func TestParseErrorDoesNotEndTheSession(t *testing.T) {
+	output := run(`a = 21`, `)`, `a * 2`)
+
+	if !strings.Contains(output, "parser errors:") {
+		t.Errorf("expected the parse error to be reported, got:\n%s", output)
+	}
+
+	if !strings.Contains(output, "» 42") {
+		t.Errorf("expected the line after the parse error to still be evaluated, got:\n%s", output)
+	}
+}
+
+func TestRuntimeErrorDoesNotEndTheSession(t *testing.T) {
+	output := run(`nope()`, `1 + 1`)
+
+	if !strings.Contains(output, "identifier not found: nope") {
+		t.Errorf("expected the runtime error to be reported, got:\n%s", output)
+	}
+
+	if !strings.Contains(output, "» 2") {
+		t.Errorf("expected the next line to still be evaluated, got:\n%s", output)
+	}
+}
+
+// TestEnvironmentPersistsAcrossLines covers the whole point of a session: one
+// environment, shared by every line.
+func TestEnvironmentPersistsAcrossLines(t *testing.T) {
+	output := run(`a = 2`, `b = 3`, `a * b`)
+
+	if !strings.Contains(output, "» 6") {
+		t.Errorf("expected a and b to survive to the third line, got:\n%s", output)
+	}
+}
+
+// TestReassignmentWorks is not what AllowRebind governs -- plain reassignment
+// was never restricted -- but it is worth pinning, since it is what a reader
+// does constantly in a REPL.
+func TestReassignmentWorks(t *testing.T) {
+	output := run(`a = 1`, `a = 2`, `a`)
+
+	if strings.Contains(output, "ERROR") {
+		t.Errorf("expected reassignment to work, got:\n%s", output)
+	}
+
+	if !strings.Contains(output, "» 2") {
+		t.Errorf("expected a to be 2 after reassignment, got:\n%s", output)
+	}
+}
+
+// TestReimportingTheSameNameIsAllowed is what NewSession's AllowRebind is for.
+// Outside the REPL, binding a module to a name already in use is an error;
+// re-entering an import line is normal at a prompt.
+//
+// The first version of this test asserted plain reassignment instead, and a
+// mutation that deleted AllowRebind entirely left it passing.
+func TestReimportingTheSameNameIsAllowed(t *testing.T) {
+	output := run(
+		`import "../fixtures/module" as M`,
+		`import "../fixtures/module" as M`,
+		`M.Sum(1, 2)`,
+	)
+
+	if strings.Contains(output, "name already in use") {
+		t.Errorf("expected the second import to be allowed in a session, got:\n%s", output)
+	}
+
+	if !strings.Contains(output, "» 3") {
+		t.Errorf("expected the module to still be usable, got:\n%s", output)
+	}
+}
+
+func TestLinesThatProduceNoOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+	}{
+		{"empty", ""},
+		{"whitespace only", "   \t  "},
+		{"a comment", "// just a comment"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if output := run(tt.line); output != "" {
+				t.Errorf("expected no output for %q, got %q", tt.line, output)
+			}
+		})
+	}
+}
+
+// TestResultsAreInspected pins the shape of a result line, which is what a
+// reader sees for every expression they type.
+func TestResultsAreInspected(t *testing.T) {
+	tests := []struct {
+		line     string
+		expected string
+	}{
+		{`1 + 1`, "» 2\n"},
+		{`"abc"`, "» \"abc\"\n"},
+		{`[1, "a"]`, "» [1, \"a\"]\n"},
+		{`nil`, "» nil\n"},
+		{`puts("hi")`, "» nil\n"},
+		{`1.5`, "» 1.5\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.line, func(t *testing.T) {
+			// puts writes to stdout rather than to the session, so only the
+			// result line is compared.
+			if output := run(tt.line); output != tt.expected {
+				t.Errorf("for %q expected %q, got %q", tt.line, tt.expected, output)
+			}
+		})
+	}
+}
+
+func TestParserErrorsAreAllReported(t *testing.T) {
+	output := run(`[1,`)
+
+	if !strings.Contains(output, "🔥 Great, you broke it!") {
+		t.Errorf("expected the banner, got:\n%s", output)
+	}
+
+	// Each error is on its own indented line.
+	if !strings.Contains(output, "\n\t ") {
+		t.Errorf("expected the errors to be indented, got:\n%s", output)
+	}
+}
+
+func TestSplashScreenCarriesTheBuildInformation(t *testing.T) {
+	splash := SplashScreen()
+
+	for _, want := range []string{buildVersion, buildDate} {
+		if !strings.Contains(splash, want) {
+			t.Errorf("expected the splash screen to mention %q, got:\n%s", want, splash)
+		}
+	}
+
+	// The name is ASCII art, so there is no literal "RocketLang" to look for.
+	// The nose cone is the one part that is a fixed string.
+	if !strings.Contains(splash, `/\`) {
+		t.Errorf("expected the splash screen to draw the rocket, got:\n%s", splash)
+	}
+
+	if lines := strings.Count(splash, "\n"); lines < 6 {
+		t.Errorf("expected the art to span several lines, got %d:\n%s", lines, splash)
+	}
+}
+
+func TestSplashVersion(t *testing.T) {
+	version := SplashVersion()
+
+	if !strings.Contains(version, buildVersion) || !strings.Contains(version, buildDate) {
+		t.Errorf("expected the version line to carry both, got %q", version)
+	}
+
+	if !strings.HasSuffix(version, "\n") {
+		t.Errorf("expected the version line to end in a newline, got %q", version)
+	}
+}
+
+// startOutput drives Start with the given input and returns what it wrote.
+//
+// HOME is redirected to a temporary directory because Start saves history: run
+// against the real one, the tests would append their input to the reader's
+// ~/.rocket_history.
+func startOutput(t *testing.T, input string) string {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+
+	var out bytes.Buffer
+	Start(strings.NewReader(input), &out)
+
+	return out.String()
+}
+
+// TestStartWritesToItsWriter covers Start honouring its arguments. It used to
+// take in and out and ignore both, reading through readline's own stdin and
+// writing with fmt.Println -- which is why nothing here could be tested.
+func TestStartWritesToItsWriter(t *testing.T) {
+	output := startOutput(t, "a = 21\na * 2\n")
+
+	if !strings.Contains(output, buildVersion) {
+		t.Errorf("expected the splash screen on the given writer, got:\n%s", output)
+	}
+
+	if !strings.Contains(output, "» 42") {
+		t.Errorf("expected the result on the given writer, got:\n%s", output)
+	}
+}
+
+func TestStartStopsAtEndOfInput(t *testing.T) {
+	// No trailing newline on the last line, and nothing after it.
+	if output := startOutput(t, "1 + 1"); !strings.Contains(output, "» 2") {
+		t.Errorf("expected the final line to be evaluated, got:\n%s", output)
+	}
+}
+
+func TestStartSurvivesAParseError(t *testing.T) {
+	output := startOutput(t, "a = 1\n)\na + 1\n")
+
+	if !strings.Contains(output, "parser errors:") {
+		t.Errorf("expected the parse error to be reported, got:\n%s", output)
+	}
+
+	if !strings.Contains(output, "» 2") {
+		t.Errorf("expected Start to carry on past the parse error, got:\n%s", output)
+	}
+}
+
+func TestStartSkipsBlankLines(t *testing.T) {
+	output := startOutput(t, "\n   \n1 + 1\n")
+
+	if got := strings.Count(output, "»"); got != 1 {
+		t.Errorf("expected exactly one result line, got %d:\n%s", got, output)
+	}
+}
+
+// TestStartRunsWithoutAHomeDirectory checks the history file is a convenience.
+// A missing home directory used to be log.Fatal, so the REPL refused to start.
+func TestStartRunsWithoutAHomeDirectory(t *testing.T) {
+	t.Setenv("HOME", "")
+
+	var out bytes.Buffer
+	Start(strings.NewReader("1 + 1\n"), &out)
+
+	if !strings.Contains(out.String(), "» 2") {
+		t.Errorf("expected the session to run without a home directory, got:\n%s", out.String())
+	}
+}


### PR DESCRIPTION
`repl/` had no tests, and the reason was structural: `Start` took an `io.Reader` and an `io.Writer` and **ignored both**, reading through readline's own stdin and writing with `fmt.Println`. Nothing could be driven or observed.

Writing the tests found the bug the missing tests were hiding: a line that failed to parse `return`ed from `Start`, which ended the whole session. Typing three lines, the third never ran:

```
🚀 » a = 21
» 21
🚀 » )
🔥 Great, you broke it!
 parser errors:
	 1:1: no prefix parse function for ) found
```

At that point the process had exited and the shell prompt was back — so `a * 2` was never evaluated, and `a` was gone with it. One typo cost you the whole session. The same three lines now end in `» 42`: the parse error is reported and the session carries on, exactly as a runtime error already did.

The read-eval-print part moved into a `Session` owning the environment and writing to an `io.Writer`, and `Start` now honours both arguments — which is what makes it testable in turn. Coverage 0% → 98.4%.

Also: a missing home directory was `log.Fatal`, so the REPL refused to start rather than running without history; the prompt was re-set every line although it never changes.

The tests redirect `HOME` to a temp dir, because `Start` saves history — run against the real one they append their input to the reader's `~/.rocket_history`. I found that by checking the file after a first attempt that had already written to it.

**Five mutations caught, one survived:** deleting `env.AllowRebind()` failed nothing, because the test named after it asserted plain reassignment — never restricted in the first place. `AllowRebind` relaxes *import* shadowing, so the test now re-enters the same import line, and that does fail when the call is removed.

Piped input is byte-identical to before apart from the fixed bug. `stdlib/` is still at 0%, so B6's claim that `repl/` was the only such package was not quite right.
