### PR TITLE
test(stdlib): cover OS.exit and OS.raise

### DIFF
--- a/stdlib/os.go
+++ b/stdlib/os.go
@@ -2,6 +2,7 @@ package stdlib
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/flipez/rocket-lang/object"
@@ -9,6 +10,16 @@ import (
 
 var osFunctions = map[string]*object.BuiltinFunction{}
 var osProperties = map[string]*object.BuiltinProperty{}
+
+// Ending the process is reached through these two rather than called directly,
+// so that the only functions in this package that cannot otherwise be tested
+// can be: a test calling the real os.Exit would take the test binary with it.
+//
+// Same shape as utilities.SetFileSystem and object.AddEvaluator.
+var (
+	exitProcess           = os.Exit
+	exitOutput  io.Writer = os.Stdout
+)
 
 func init() {
 	osFunctions["exit"] = object.NewBuiltinFunction(
@@ -19,7 +30,7 @@ func init() {
 			),
 		},
 		func(_ object.Environment, args ...object.Object) object.Object {
-			os.Exit(int(args[0].(*object.Integer).Value))
+			exitProcess(int(args[0].(*object.Integer).Value))
 
 			return nil
 		})
@@ -33,8 +44,8 @@ func init() {
 			),
 		},
 		func(_ object.Environment, args ...object.Object) object.Object {
-			fmt.Printf("🔥 RocketLang raised an error: %s\n", args[1].Inspect())
-			os.Exit(int(args[0].(*object.Integer).Value))
+			fmt.Fprintf(exitOutput, "🔥 RocketLang raised an error: %s\n", args[1].Inspect())
+			exitProcess(int(args[0].(*object.Integer).Value))
 
 			return nil
 		})

--- a/stdlib/os_test.go
+++ b/stdlib/os_test.go
@@ -1,0 +1,107 @@
+package stdlib
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/flipez/rocket-lang/object"
+)
+
+// captureExit redirects the process-ending path for one test and returns what
+// was recorded: the codes exitProcess was called with, and whatever was written
+// alongside them.
+func captureExit(t *testing.T) (codes *[]int, output *bytes.Buffer) {
+	t.Helper()
+
+	previousExit, previousOutput := exitProcess, exitOutput
+	t.Cleanup(func() {
+		exitProcess, exitOutput = previousExit, previousOutput
+	})
+
+	recorded := []int{}
+	buffer := &bytes.Buffer{}
+
+	// The real os.Exit does not return, so the code after it never runs. This
+	// one does, which is the one way the test differs from production.
+	exitProcess = func(code int) { recorded = append(recorded, code) }
+	exitOutput = buffer
+
+	return &recorded, buffer
+}
+
+func call(name string, args ...object.Object) object.Object {
+	return osFunctions[name].Call(args, *object.NewEnvironment())
+}
+
+func TestOSExitUsesTheGivenCode(t *testing.T) {
+	for _, code := range []int{0, 1, 3, 127} {
+		t.Run(object.NewInteger(code).Inspect(), func(t *testing.T) {
+			codes, output := captureExit(t)
+
+			call("exit", object.NewInteger(code))
+
+			if len(*codes) != 1 || (*codes)[0] != code {
+				t.Errorf("expected exit with %d, got %v", code, *codes)
+			}
+
+			if output.Len() != 0 {
+				t.Errorf("expected exit to print nothing, got %q", output.String())
+			}
+		})
+	}
+}
+
+func TestOSRaisePrintsThenExits(t *testing.T) {
+	codes, output := captureExit(t)
+
+	call("raise", object.NewInteger(2), object.NewString("broken"))
+
+	if len(*codes) != 1 || (*codes)[0] != 2 {
+		t.Errorf("expected exit with 2, got %v", *codes)
+	}
+
+	// Pinned as documented in docs/builtins/os.yml, quotes included: the
+	// message goes through Inspect.
+	expected := "🔥 RocketLang raised an error: \"broken\"\n"
+	if output.String() != expected {
+		t.Errorf("expected %q, got %q", expected, output.String())
+	}
+}
+
+// TestOSFunctionsValidateTheirArguments covers the layout doing the checking, so
+// neither function reaches the process-ending path with the wrong arguments.
+func TestOSFunctionsValidateTheirArguments(t *testing.T) {
+	tests := []struct {
+		name          string
+		function      string
+		args          []object.Object
+		expectedError string
+	}{
+		{"exit without a code", "exit", nil, "too few arguments"},
+		{"exit with a string", "exit", []object.Object{object.NewString("1")}, "wrong argument type"},
+		{"exit with too many", "exit", []object.Object{object.NewInteger(1), object.NewInteger(2)}, "too many arguments"},
+		{"raise without a message", "raise", []object.Object{object.NewInteger(1)}, "too few arguments"},
+		{"raise with a non-string message", "raise", []object.Object{object.NewInteger(1), object.NewInteger(2)}, "wrong argument type"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			codes, _ := captureExit(t)
+
+			result := call(tt.function, tt.args...)
+
+			if !object.IsError(result) {
+				t.Fatalf("expected an error, got %v", result)
+			}
+
+			if !strings.Contains(result.Inspect(), tt.expectedError) {
+				t.Errorf("expected an error containing %q, got %q", tt.expectedError, result.Inspect())
+			}
+
+			if len(*codes) != 0 {
+				t.Errorf("the process should not have been ended, got exits %v", *codes)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**B6's premise was wrong.** `stdlib` was not at 0% — measured across the whole suite it was at **94.6%**, because every module function is reached from `object/`'s tests through `-coverpkg`. The 0% was `coverage.sh` printing a per-package summary for a package with no test files of its own; the real numbers were going into `coverage.txt` all along. Corrected in the backlog.

The genuine gap was `stdlib/os.go` at **16.7%**: `OS.exit` and `OS.raise` call `os.Exit`, so any test reaching them would take the test binary with it. They now go through two package-level indirections — same shape as `utilities.SetFileSystem` and `object.AddEvaluator` — and a test records the code instead of dying.

stdlib 94.6% → 99.5%, `os.go` 16.7% → 100%.

Production behaviour is unchanged, verified against the built binary: `OS.exit(3)` still exits 3, `OS.raise` still prints to stdout and exits with its code, both byte-identical. The one difference is that with a recording exit the statement after it runs, which the real `os.Exit` never reaches.

Four mutations caught: exit ignoring its code, raise not printing, raise printing the unquoted value, raise never exiting.

**Left alone deliberately,** both pinned by `docs/builtins/os.yml`: `OS.raise` writes to stdout rather than stderr — consistent with an uncaught runtime error, inconsistent with a parser error — and prints the message through `Inspect`, so `OS.raise(1, "broken")` reports `"broken"` *with* the quotes. Changing either is a wider decision about where diagnostics go than this PR should make.
